### PR TITLE
Unnecessary dispose and related memory leak problem.

### DIFF
--- a/src/Vortice.Direct3D11/D3D11.cs
+++ b/src/Vortice.Direct3D11/D3D11.cs
@@ -53,8 +53,8 @@ namespace Vortice.Direct3D11
 
             if (immediateContext != null)
             {
-                device.AddRef();
                 device.ImmediateContext__ = immediateContext;
+                immediateContext.shouldNotDisposeDevice = true;
                 immediateContext.Device__ = device;
             }
 
@@ -85,8 +85,8 @@ namespace Vortice.Direct3D11
 
             if (immediateContext != null)
             {
-                device.AddRef();
                 device.ImmediateContext__ = immediateContext;
+                immediateContext.shouldNotDisposeDevice = true;
                 immediateContext.Device__ = device;
             }
 

--- a/src/Vortice.Direct3D11/D3D11.cs
+++ b/src/Vortice.Direct3D11/D3D11.cs
@@ -16,15 +16,7 @@ namespace Vortice.Direct3D11
             FeatureLevel[] featureLevels,
             out ID3D11Device device)
         {
-            ID3D11DeviceContext context = null;
-            try
-            {
-                return D3D11CreateDevice(adapter, driverType, flags, featureLevels, out device, out var featureLevel, out context);
-            }
-            finally
-            {
-                context?.Dispose();
-            }
+            return D3D11CreateDevice(adapter, driverType, flags, featureLevels, out device, out var featureLevel, out var context);
         }
 
         public static Result D3D11CreateDevice(IDXGIAdapter adapter,

--- a/src/Vortice.Direct3D11/ID3D11Device1.cs
+++ b/src/Vortice.Direct3D11/ID3D11Device1.cs
@@ -9,6 +9,20 @@ namespace Vortice.Direct3D11
 {
     public partial class ID3D11Device1
     {
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (ImmediateContext1__ != null)
+                {
+                    ImmediateContext1__.Dispose();
+                    ImmediateContext1__ = null;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
         public ID3D11DeviceContext1 CreateDeferredContext1()
         {
             return CreateDeferredContext1(0);

--- a/src/Vortice.Direct3D11/ID3D11Device2.cs
+++ b/src/Vortice.Direct3D11/ID3D11Device2.cs
@@ -7,6 +7,20 @@ namespace Vortice.Direct3D11
 {
     public partial class ID3D11Device2
     {
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (ImmediateContext2__ != null)
+                {
+                    ImmediateContext2__.Dispose();
+                    ImmediateContext2__ = null;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
         public unsafe ID3D11DeviceContext2 CreateDeferredContext2()
         {
             return CreateDeferredContext2(0);

--- a/src/Vortice.Direct3D11/ID3D11Device3.cs
+++ b/src/Vortice.Direct3D11/ID3D11Device3.cs
@@ -9,6 +9,20 @@ namespace Vortice.Direct3D11
 {
     public partial class ID3D11Device3
     {
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (ImmediateContext3__ != null)
+                {
+                    ImmediateContext3__.Dispose();
+                    ImmediateContext3__ = null;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
         public unsafe ID3D11DeviceContext3 CreateDeferredContext3()
         {
             return CreateDeferredContext3(0);

--- a/src/Vortice.Direct3D11/ID3D11DeviceChild.cs
+++ b/src/Vortice.Direct3D11/ID3D11DeviceChild.cs
@@ -9,6 +9,8 @@ namespace Vortice.Direct3D11
 {
     public partial class ID3D11DeviceChild
     {
+        internal bool shouldNotDisposeDevice = false;
+
         /// <summary>
         /// Gets or sets the debug-name for this object.
         /// </summary>
@@ -64,9 +66,12 @@ namespace Vortice.Direct3D11
         {
             if (Device__ != null)
             {
-                // Don't use Dispose() in order to avoid circular references with DeviceContext
-                ((IUnknown)Device__).Release();
-                Device__ = null;
+                // Only call Dispose() when it is created by accessing ID3D11DeviceChild.Device.
+                if (!shouldNotDisposeDevice)
+                {
+                    Device__.Dispose();
+                    Device__ = null;
+                }
             }
         }
     }

--- a/src/Vortice.Direct3D11/ID3D11DeviceChild.cs
+++ b/src/Vortice.Direct3D11/ID3D11DeviceChild.cs
@@ -11,6 +11,27 @@ namespace Vortice.Direct3D11
     {
         internal bool shouldNotDisposeDevice = false;
 
+        protected internal ID3D11Device Device__;
+        public ID3D11Device Device
+        {
+            get
+            {
+                if (Device__ == null)
+                {
+                    GetDeviceInternal(out Device__);
+
+                    // Manually set ImmediateContext.Device__ to avoid circular loop.
+                    var immediateContext = Device__.ImmediateContext;
+                    if (immediateContext != null)
+                    {
+                        immediateContext.shouldNotDisposeDevice = true;
+                        immediateContext.Device__ = Device__;
+                    }
+                }
+                return Device__;
+            }
+        }
+
         /// <summary>
         /// Gets or sets the debug-name for this object.
         /// </summary>

--- a/src/Vortice.Direct3D11/Mappings.xml
+++ b/src/Vortice.Direct3D11/Mappings.xml
@@ -486,7 +486,7 @@
     <map field="D3D11_COUNTER_DESC::Counter" name="CounterKind" />
     
     <!-- ID3D11DeviceChild methods -->
-    <map method="ID3D11DeviceChild::GetDevice" persist="true"/>
+    <map method="ID3D11DeviceChild::GetDevice" visibility="private" name="GetDeviceInternal"/>
     <map method="ID3D11DeviceChild::GetPrivateData" visibility="public" hresult="true" check="false"/>
     <map method="ID3D11DeviceChild::SetPrivateData" visibility="public" hresult="true" check="false"/>
 


### PR DESCRIPTION
#60.

Current situation:
1. First commit fixes the null device context problem.
2. Second commit solves an object tracking problem. Adding a flag makes the code a little bit dirty, but the device object gets properly disposed. This also eliminates the ```AddRef``` when creating device. The problem is that, originally, the following code reports memory leak:
```C#
Configuration.EnableObjectTracking = true;
{
    using var device = D3D11.D3D11CreateDevice(...);
    using var buffer = device.CreateBuffer(...);
    var dd = buffer.Device; //Simply reading from the property can cause the problem.
}
Console.WriteLine(ObjectTracker.ReportActiveObjects()); //Report one device reference.
```


3. One remaining issue related to generated code that I am afraid I can't do.
I realized we have to set ```Device__``` manually for immediate context to avoid the immediate context to create another device object (with same unmanaged pointer). Keeping this scheme should give better performance. However, this optimization only exists for device objects created by ```D3D11CreateDevice```. For devices obtained from a device child (through ```ID3D11DeviceChild::GetDevice```), there is still infinite loops. This can be solved by modifying the implementation of ```ID3D11DeviceChild.Device``` property or ```ID3D11Device.ImmediateContext``` property, manually setting the immediate context or device. The following code shows the problem:
```C#
var buffer = device.CreateBuffer(...); //Buffer is a device child.
var dd = buffer.Device; //This property get creates a new ComObject for the device.
while (true)
{
    //dd.ImmediateContext is null now.
    var dc = dd.ImmediateContext; //This allocates a new ComObject
    dd = dc.Device; //This allocates a new ComObject
}
```
