### PR TITLE
Draft-only PR with DirectComposition and Windows Animation Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,3 +258,8 @@ Session.vim
 
 .vscode
 launchSettings.json
+
+.idea/
+
+# CodeRush
+.cr/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,8 +22,12 @@
 
     <!-- Packages versions -->
     <NerdbankGitVersioningVersion>3.1.71</NerdbankGitVersioningVersion>
-    <SharpGenVersion>1.2.1</SharpGenVersion>
+    <SharpGenVersion>2.0.0-local</SharpGenVersion>
     <VorticeMathematicsVersion>1.2.1</VorticeMathematicsVersion>
+
+    <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);D:\Documents\NuGet</RestoreAdditionalProjectSources>
+
+    <SharpGenSdkAssemblyDirectory>D:\dev\SharpGenTools\SharpGenTools.Sdk\bin\Debug\</SharpGenSdkAssemblyDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vortice.DXGI/DXGI.cs
+++ b/src/Vortice.DXGI/DXGI.cs
@@ -20,7 +20,7 @@ namespace Vortice.DXGI
         /// <returns>Return the <see cref="Result"/>.</returns>
         public static Result CreateDXGIFactory<T>(out T factory) where T : IDXGIFactory
         {
-            if (PlatformDetection.IsUAP)
+            if (VorticePlatformDetection.IsUAP)
             {
                 throw new NotSupportedException();
             }

--- a/src/Vortice.DXGI/IDXGIOutput3.cs
+++ b/src/Vortice.DXGI/IDXGIOutput3.cs
@@ -16,7 +16,7 @@ namespace Vortice.DXGI
         /// <returns>Overlay support flags.</returns>
         public OverlaySupportFlags CheckOverlaySupport(Format format, IUnknown concernedDevice)
         {
-            if (PlatformDetection.IsUAP)
+            if (VorticePlatformDetection.IsUAP)
             {
                 throw new NotSupportedException("IDXGIOutput3.CheckOverlaySupport is not supported on UAP platform");
             }

--- a/src/Vortice.DXGI/IDXGIOutput4.cs
+++ b/src/Vortice.DXGI/IDXGIOutput4.cs
@@ -17,7 +17,7 @@ namespace Vortice.DXGI
         /// <returns>Overlay color space support flags.</returns>
         public OverlayColorSpaceSupportFlags CheckOverlayColorSpaceSupport(Format format, ColorSpaceType colorSpace, IUnknown concernedDevice)
         {
-            if (PlatformDetection.IsUAP)
+            if (VorticePlatformDetection.IsUAP)
             {
                 throw new NotSupportedException("IDXGIOutput4.CheckOverlayColorSpaceSupport is not supported on UAP platform");
             }

--- a/src/Vortice.DXGI/IDXGIOutput5.cs
+++ b/src/Vortice.DXGI/IDXGIOutput5.cs
@@ -10,7 +10,7 @@ namespace Vortice.DXGI
     {
         public IDXGIOutputDuplication DuplicateOutput1(IUnknown device, params Format[] supportedFormats)
         {
-            if (PlatformDetection.IsUAP)
+            if (VorticePlatformDetection.IsUAP)
             {
                 throw new NotSupportedException("IDXGIOutput5.DuplicateOutput1 is not supported on UAP platform");
             }

--- a/src/Vortice.Runtime.COM/ComUtilities.cs
+++ b/src/Vortice.Runtime.COM/ComUtilities.cs
@@ -33,7 +33,7 @@ namespace SharpGen.Runtime
     {
         static ComUtilities()
         {
-            if (!PlatformDetection.IsUAP)
+            if (!VorticePlatformDetection.IsUAP)
             {
                 if (CoInitializeEx(IntPtr.Zero, COINIT_APARTMENTTHREADED) == RPC_E_CHANGED_MODE)
                 {
@@ -45,7 +45,7 @@ namespace SharpGen.Runtime
         
         public unsafe static void CreateComInstance(Guid classGuid, ComContext context, Guid interfaceGuid, ComObject comObject)
         {
-            if (!PlatformDetection.IsUAP)
+            if (!VorticePlatformDetection.IsUAP)
             {
                 var result = CoCreateInstance(classGuid, IntPtr.Zero, context, interfaceGuid, out IntPtr pointer);
                 result.CheckError();
@@ -69,7 +69,7 @@ namespace SharpGen.Runtime
 
         public static unsafe bool TryCreateComInstance(Guid classGuid, ComContext context, Guid interfaceGuid, ComObject comObject)
         {
-            if (!PlatformDetection.IsUAP)
+            if (!VorticePlatformDetection.IsUAP)
             {
                 var result = CoCreateInstance(classGuid, IntPtr.Zero, context, interfaceGuid, out IntPtr pointer);
                 comObject.NativePointer = pointer;

--- a/src/Vortice.Runtime.COM/VorticePlatformDetection.cs
+++ b/src/Vortice.Runtime.COM/VorticePlatformDetection.cs
@@ -7,12 +7,12 @@ namespace SharpGen.Runtime
     /// <summary>
 	/// Provides methods to protect against invalid parameters.
 	/// </summary>
-    public static class PlatformDetection
+    public static class VorticePlatformDetection
     {
         private static int s_isInAppContainer = -1;
         public static readonly Version WindowsVersion;
 
-        static PlatformDetection()
+        static VorticePlatformDetection()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -76,19 +76,12 @@ namespace SharpGen.Runtime
                             throw new InvalidOperationException($"Failed to get AppId, result was {result}.");
                     }
                 }
-                catch (Exception e)
+                // We could catch this here, being friendly with older portable surface area should we
+                // desire to use this method elsewhere.
+                catch (Exception e) when (e.GetType().FullName.Equals("System.EntryPointNotFoundException", StringComparison.Ordinal))
                 {
-                    // We could catch this here, being friendly with older portable surface area should we
-                    // desire to use this method elsewhere.
-                    if (e.GetType().FullName.Equals("System.EntryPointNotFoundException", StringComparison.Ordinal))
-                    {
-                        // API doesn't exist, likely pre Win8
-                        s_isInAppContainer = 0;
-                    }
-                    else
-                    {
-                        throw;
-                    }
+                    // API doesn't exist, likely pre-Win8
+                    s_isInAppContainer = 0;
                 }
 
                 return s_isInAppContainer == 1;

--- a/src/Vortice.Visuals/Animation/IUIAnimationManager.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationManager.cs
@@ -1,0 +1,291 @@
+// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Runtime.InteropServices;
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationManager
+    {
+        private static readonly Guid ManagerGuid = new Guid("4C1FC63A-695C-47E8-A339-1A194BE3D0B8");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IUIAnimationManager"/> class.
+        /// </summary>
+        public IUIAnimationManager()
+        {
+            ComUtilities.CreateComInstance(ManagerGuid, ComContext.InprocServer, typeof(IUIAnimationManager).GUID, this);
+        }
+        
+        private IUIAnimationManagerEventHandlerCallback _statusEventHandler;
+
+        /// <summary>
+        /// A delegate to receive status changed events from the manager.
+        /// </summary>
+        /// <param name="newStatus">The new status.</param>
+        /// <param name="previousStatus">The previous status.</param>
+        public delegate void StatusChangedDelegate(AnimationManagerStatus newStatus, AnimationManagerStatus previousStatus);
+
+        /// <summary>
+        /// A delegate used to resolve scheduling conflicts.
+        /// </summary>
+        /// <param name="scheduledStoryboard">The scheduled storyboard.</param>
+        /// <param name="newStoryboard">The new storyboard.</param>
+        /// <param name="priorityEffect">The priority effect.</param>
+        /// <returns><c>true</c> if newStoryboard has priority. <c>false</c> if scheduledStoryboard has priority</returns>
+        public delegate bool PriorityComparisonDelegate(IUIAnimationStoryboard scheduledStoryboard, IUIAnimationStoryboard newStoryboard, AnimationPriorityEffect priorityEffect);
+
+        /// <summary>
+        /// Occurs when [status changed].
+        /// </summary>
+        public event StatusChangedDelegate StatusChanged
+        {
+            add
+            {
+                // Setup the Manager Event Handler delegates
+                if (_statusEventHandler == null)
+                {
+                    _statusEventHandler = new IUIAnimationManagerEventHandlerCallback();
+                    SetManagerEventHandler(_statusEventHandler);
+                }
+                _statusEventHandler.Delegates += value;
+            }
+
+            remove
+            {
+                if (_statusEventHandler == null) return;
+
+                _statusEventHandler.Delegates -= value;
+
+                if (_statusEventHandler.Delegates.GetInvocationList().Length == 0)
+                {
+                    SetManagerEventHandler(null);
+                    _statusEventHandler.Dispose();
+                    _statusEventHandler = null;
+                }
+            }
+        }
+
+        private IUIAnimationPriorityComparisonCallback _cancelPriorityComparisonCallback;
+
+        /// <summary>
+        /// Sets the cancel priority comparison.
+        /// </summary>
+        /// <value>
+        /// The cancel priority comparison.
+        /// </value>
+        public PriorityComparisonDelegate CancelPriorityComparison
+        {
+            set
+            {
+                if (value != null)
+                {
+                    if (_cancelPriorityComparisonCallback == null)
+                    {
+                        _cancelPriorityComparisonCallback = new IUIAnimationPriorityComparisonCallback { Delegate = value };
+                        SetCancelPriorityComparison(_cancelPriorityComparisonCallback);
+                    }
+                    _cancelPriorityComparisonCallback.Delegate = value;
+                }
+                else if (_cancelPriorityComparisonCallback != null)
+                {
+                    SetCancelPriorityComparison(null);
+                    _cancelPriorityComparisonCallback.Dispose();
+                    _cancelPriorityComparisonCallback = null;
+                }
+            }
+        }
+
+        private IUIAnimationPriorityComparisonCallback _trimPriorityComparisonCallback;
+
+        /// <summary>
+        /// Sets the trim priority comparison.
+        /// </summary>
+        /// <value>
+        /// The trim priority comparison.
+        /// </value>
+        public PriorityComparisonDelegate TrimPriorityComparison
+        {
+            set
+            {
+                if (value != null)
+                {
+                    if (_trimPriorityComparisonCallback == null)
+                    {
+                        _trimPriorityComparisonCallback = new IUIAnimationPriorityComparisonCallback { Delegate = value };
+                        SetTrimPriorityComparison(_trimPriorityComparisonCallback);
+                    }
+                    _trimPriorityComparisonCallback.Delegate = value;
+                }
+                else if (_trimPriorityComparisonCallback != null)
+                {
+                    SetTrimPriorityComparison(null);
+                    _trimPriorityComparisonCallback.Dispose();
+                    _trimPriorityComparisonCallback = null;
+                }
+            }
+        }
+
+        private IUIAnimationPriorityComparisonCallback _compressPriorityComparisonCallback;
+
+        /// <summary>
+        /// Sets the compress priority comparison.
+        /// </summary>
+        /// <value>
+        /// The compress priority comparison.
+        /// </value>
+        public PriorityComparisonDelegate CompressPriorityComparison
+        {
+            set
+            {
+                if (value != null)
+                {
+                    if (_compressPriorityComparisonCallback == null)
+                    {
+                        _compressPriorityComparisonCallback = new IUIAnimationPriorityComparisonCallback { Delegate = value };
+                        SetCompressPriorityComparison(_compressPriorityComparisonCallback);
+                    }
+                    _compressPriorityComparisonCallback.Delegate = value;
+                }
+                else if (_compressPriorityComparisonCallback != null)
+                {
+                    SetCompressPriorityComparison(null);
+                    _compressPriorityComparisonCallback.Dispose();
+                    _compressPriorityComparisonCallback = null;
+                }
+            }
+        }
+
+        private IUIAnimationPriorityComparisonCallback _concludePriorityComparisonCallback;
+
+        /// <summary>
+        /// Sets the conclude priority comparison.
+        /// </summary>
+        /// <value>
+        /// The conclude priority comparison.
+        /// </value>
+        public PriorityComparisonDelegate ConcludePriorityComparison
+        {
+            set
+            {
+                if (value != null)
+                {
+                    if (_concludePriorityComparisonCallback == null)
+                    {
+                        _concludePriorityComparisonCallback = new IUIAnimationPriorityComparisonCallback { Delegate = value };
+                        SetConcludePriorityComparison(_concludePriorityComparisonCallback);
+                    }
+                    _concludePriorityComparisonCallback.Delegate = value;
+                }
+                else if (_concludePriorityComparisonCallback != null)
+                {
+                    SetConcludePriorityComparison(null);
+                    _concludePriorityComparisonCallback.Dispose();
+                    _concludePriorityComparisonCallback = null;
+                }
+            }
+        }
+
+
+
+        /// <summary>
+        /// Gets the variable from tag.
+        /// </summary>
+        /// <param name="id">The id.</param>
+        /// <param name="tagObject">The tag object. This parameter can be null.</param>
+        /// <returns>A variable associated with this tag.</returns>
+        /// <unmanaged>HRESULT IUIAnimationManager::GetVariableFromTag([In, Optional] void* object,[In] unsigned int id,[Out] IUIAnimationVariable** variable)</unmanaged>
+        public IUIAnimationVariable GetVariableFromTag(int id, object tagObject = null)
+        {
+            var tagObjectHandle = GCHandle.Alloc(tagObject);
+            try
+            {
+                return GetVariableFromTag(GCHandle.ToIntPtr(tagObjectHandle), id);
+            }
+            finally
+            {
+                tagObjectHandle.Free();
+            }
+        }
+
+        /// <summary>
+        /// Gets the storyboard from tag.
+        /// </summary>
+        /// <param name="id">The id.</param>
+        /// <param name="tagObject">The tag object. This parameter can be null.</param>
+        /// <returns>A storyboard associated with this tag.</returns>
+        /// <unmanaged>HRESULT IUIAnimationManager::GetStoryboardFromTag([In, Optional] void* object,[In] unsigned int id,[Out] IUIAnimationStoryboard** storyboard)</unmanaged>
+        public IUIAnimationStoryboard GetStoryboardFromTag(int id, object tagObject = null)
+        {
+            var tagObjectHandle = GCHandle.Alloc(tagObject);
+            try
+            {
+                return GetStoryboardFromTag(GCHandle.ToIntPtr(tagObjectHandle), id);
+            }
+            finally
+            {
+                tagObjectHandle.Free();
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (_statusEventHandler != null)
+            {
+                SetManagerEventHandler(null);
+                _statusEventHandler.Dispose();
+                _statusEventHandler = null;
+            }
+
+            if (_cancelPriorityComparisonCallback != null)
+            {
+                SetCancelPriorityComparison(null);
+                _cancelPriorityComparisonCallback.Dispose();
+                _cancelPriorityComparisonCallback = null;
+            }
+
+            if (_concludePriorityComparisonCallback != null)
+            {
+                SetConcludePriorityComparison(null);
+                _concludePriorityComparisonCallback.Dispose();
+                _concludePriorityComparisonCallback = null;
+            }
+
+            if (_compressPriorityComparisonCallback != null)
+            {
+                SetCompressPriorityComparison(null);
+                _compressPriorityComparisonCallback.Dispose();
+                _compressPriorityComparisonCallback = null;
+            }
+
+            if (_concludePriorityComparisonCallback != null)
+            {
+                SetConcludePriorityComparison(null);
+                _concludePriorityComparisonCallback.Dispose();
+                _concludePriorityComparisonCallback = null;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationManager2.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationManager2.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Runtime.InteropServices;
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationManager2
+    {
+        private static readonly Guid ManagerGuid = new Guid("D25D8842-8884-4A4A-B321-091314379BDD");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IUIAnimationManager2"/> class.
+        /// </summary>
+        public IUIAnimationManager2()
+        {
+            ComUtilities.CreateComInstance(ManagerGuid, ComContext.InprocServer, typeof(IUIAnimationManager2).GUID,
+                this);
+        }
+        
+        private IUIAnimationManagerEventHandler2Callback _statusEventHandler;
+
+        /// <summary>
+        /// A delegate to receive status changed events from the manager.
+        /// </summary>
+        /// <param name="newStatus">The new status.</param>
+        /// <param name="previousStatus">The previous status.</param>
+        public delegate void StatusChangedDelegate(AnimationManagerStatus newStatus, AnimationManagerStatus previousStatus);
+
+        /// <summary>
+        /// A delegate used to resolve scheduling conflicts.
+        /// </summary>
+        /// <param name="scheduledStoryboard">The scheduled storyboard.</param>
+        /// <param name="newStoryboard">The new storyboard.</param>
+        /// <param name="priorityEffect">The priority effect.</param>
+        /// <returns><c>true</c> if newStoryboard has priority. <c>false</c> if scheduledStoryboard has priority</returns>
+        public delegate bool PriorityComparisonDelegate(IUIAnimationStoryboard2 scheduledStoryboard, IUIAnimationStoryboard2 newStoryboard, AnimationPriorityEffect priorityEffect);
+
+        /// <summary>
+        /// Occurs when [status changed].
+        /// </summary>
+        public event StatusChangedDelegate StatusChanged
+        {
+            add
+            {
+                // Setup the Manager Event Handler delegates
+                if (_statusEventHandler == null)
+                {
+                    _statusEventHandler = new IUIAnimationManagerEventHandler2Callback();
+                    SetManagerEventHandler(_statusEventHandler, true);
+                }
+                _statusEventHandler.Delegates += value;
+            }
+
+            remove
+            {
+                if (_statusEventHandler == null) return;
+
+                _statusEventHandler.Delegates -= value;
+
+                if (_statusEventHandler.Delegates.GetInvocationList().Length == 0)
+                {
+                    SetManagerEventHandler(null, false);
+                    _statusEventHandler.Dispose();
+                    _statusEventHandler = null;
+                }
+            }
+        }
+
+        private IUIAnimationPriorityComparison2Callback _cancelPriorityComparisonCallback;
+
+        /// <summary>
+        /// Sets the cancel priority comparison.
+        /// </summary>
+        /// <value>
+        /// The cancel priority comparison.
+        /// </value>
+        public PriorityComparisonDelegate CancelPriorityComparison
+        {
+            set
+            {
+                if (value != null)
+                {
+                    if (_cancelPriorityComparisonCallback == null)
+                    {
+                        _cancelPriorityComparisonCallback = new IUIAnimationPriorityComparison2Callback { Delegate = value };
+                        SetCancelPriorityComparison(_cancelPriorityComparisonCallback);
+                    }
+                    _cancelPriorityComparisonCallback.Delegate = value;
+                }
+                else if (_cancelPriorityComparisonCallback != null)
+                {
+                    SetCancelPriorityComparison(null);
+                    _cancelPriorityComparisonCallback.Dispose();
+                    _cancelPriorityComparisonCallback = null;
+                }
+            }
+        }
+
+        private IUIAnimationPriorityComparison2Callback _trimPriorityComparisonCallback;
+
+        /// <summary>
+        /// Sets the trim priority comparison.
+        /// </summary>
+        /// <value>
+        /// The trim priority comparison.
+        /// </value>
+        public PriorityComparisonDelegate TrimPriorityComparison
+        {
+            set
+            {
+                if (value != null)
+                {
+                    if (_trimPriorityComparisonCallback == null)
+                    {
+                        _trimPriorityComparisonCallback = new IUIAnimationPriorityComparison2Callback { Delegate = value };
+                        SetTrimPriorityComparison(_trimPriorityComparisonCallback);
+                    }
+                    _trimPriorityComparisonCallback.Delegate = value;
+                }
+                else if (_trimPriorityComparisonCallback != null)
+                {
+                    SetTrimPriorityComparison(null);
+                    _trimPriorityComparisonCallback.Dispose();
+                    _trimPriorityComparisonCallback = null;
+                }
+            }
+        }
+
+        private IUIAnimationPriorityComparison2Callback _compressPriorityComparisonCallback;
+
+        /// <summary>
+        /// Sets the compress priority comparison.
+        /// </summary>
+        /// <value>
+        /// The compress priority comparison.
+        /// </value>
+        public PriorityComparisonDelegate CompressPriorityComparison
+        {
+            set
+            {
+                if (value != null)
+                {
+                    if (_compressPriorityComparisonCallback == null)
+                    {
+                        _compressPriorityComparisonCallback = new IUIAnimationPriorityComparison2Callback { Delegate = value };
+                        SetCompressPriorityComparison(_compressPriorityComparisonCallback);
+                    }
+                    _compressPriorityComparisonCallback.Delegate = value;
+                }
+                else if (_compressPriorityComparisonCallback != null)
+                {
+                    SetCompressPriorityComparison(null);
+                    _compressPriorityComparisonCallback.Dispose();
+                    _compressPriorityComparisonCallback = null;
+                }
+            }
+        }
+
+        private IUIAnimationPriorityComparison2Callback _concludePriorityComparisonCallback;
+
+        /// <summary>
+        /// Sets the conclude priority comparison.
+        /// </summary>
+        /// <value>
+        /// The conclude priority comparison.
+        /// </value>
+        public PriorityComparisonDelegate ConcludePriorityComparison
+        {
+            set
+            {
+                if (value != null)
+                {
+                    if (_concludePriorityComparisonCallback == null)
+                    {
+                        _concludePriorityComparisonCallback = new IUIAnimationPriorityComparison2Callback { Delegate = value };
+                        SetConcludePriorityComparison(_concludePriorityComparisonCallback);
+                    }
+                    _concludePriorityComparisonCallback.Delegate = value;
+                }
+                else if (_concludePriorityComparisonCallback != null)
+                {
+                    SetConcludePriorityComparison(null);
+                    _concludePriorityComparisonCallback.Dispose();
+                    _concludePriorityComparisonCallback = null;
+                }
+            }
+        }
+        
+
+        /// <summary>
+        /// Gets the variable from tag.
+        /// </summary>
+        /// <param name="id">The id.</param>
+        /// <param name="tagObject">The tag object. This parameter can be null.</param>
+        /// <returns>A variable associated with this tag.</returns>
+        /// <unmanaged>HRESULT IUIAnimationManager::GetVariableFromTag([In, Optional] void* object,[In] unsigned int id,[Out] IUIAnimationVariable** variable)</unmanaged>
+        public IUIAnimationVariable2 GetVariableFromTag(int id, object tagObject = null)
+        {
+            var tagObjectHandle = GCHandle.Alloc(tagObject);
+            try
+            {
+                return GetVariableFromTag(GCHandle.ToIntPtr(tagObjectHandle), id);
+            }
+            finally
+            {
+                tagObjectHandle.Free();
+            }
+        }
+
+        /// <summary>
+        /// Gets the storyboard from tag.
+        /// </summary>
+        /// <param name="id">The id.</param>
+        /// <param name="tagObject">The tag object. This parameter can be null.</param>
+        /// <returns>A storyboard associated with this tag.</returns>
+        /// <unmanaged>HRESULT IUIAnimationManager::GetStoryboardFromTag([In, Optional] void* object,[In] unsigned int id,[Out] IUIAnimationStoryboard** storyboard)</unmanaged>
+        public IUIAnimationStoryboard2 GetStoryboardFromTag(int id, object tagObject = null)
+        {
+            var tagObjectHandle = GCHandle.Alloc(tagObject);
+            try
+            {
+                return GetStoryboardFromTag(GCHandle.ToIntPtr(tagObjectHandle), id);
+            }
+            finally
+            {
+                tagObjectHandle.Free();
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (_statusEventHandler != null)
+            {
+                SetManagerEventHandler(null, false);
+                _statusEventHandler.Dispose();
+                _statusEventHandler = null;
+            }
+
+            if (_cancelPriorityComparisonCallback != null)
+            {
+                SetCancelPriorityComparison(null);
+                _cancelPriorityComparisonCallback.Dispose();
+                _cancelPriorityComparisonCallback = null;
+            }
+
+            if (_concludePriorityComparisonCallback != null)
+            {
+                SetConcludePriorityComparison(null);
+                _concludePriorityComparisonCallback.Dispose();
+                _concludePriorityComparisonCallback = null;
+            }
+
+            if (_compressPriorityComparisonCallback != null)
+            {
+                SetCompressPriorityComparison(null);
+                _compressPriorityComparisonCallback.Dispose();
+                _compressPriorityComparisonCallback = null;
+            }
+
+            if (_concludePriorityComparisonCallback != null)
+            {
+                SetConcludePriorityComparison(null);
+                _concludePriorityComparisonCallback.Dispose();
+                _concludePriorityComparisonCallback = null;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationManagerEventHandler2Callback.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationManagerEventHandler2Callback.cs
@@ -1,0 +1,14 @@
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    internal class IUIAnimationManagerEventHandler2Callback : CallbackBase, IUIAnimationManagerEventHandler2
+    {
+        public IUIAnimationManager2.StatusChangedDelegate Delegates;
+
+        public void OnManagerStatusChanged(AnimationManagerStatus newStatus, AnimationManagerStatus previousStatus)
+        {
+            Delegates?.Invoke(newStatus, previousStatus);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationManagerEventHandlerCallback.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationManagerEventHandlerCallback.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    /// <summary>
+    /// Internal ManagerEventHandler Callback
+    /// </summary>
+    internal class IUIAnimationManagerEventHandlerCallback : CallbackBase, IUIAnimationManagerEventHandler
+    {
+        public IUIAnimationManager.StatusChangedDelegate Delegates;
+
+        public void OnManagerStatusChanged(AnimationManagerStatus newStatus, AnimationManagerStatus previousStatus)
+        {
+            Delegates?.Invoke(newStatus, previousStatus);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationPriorityComparison2Callback.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationPriorityComparison2Callback.cs
@@ -1,0 +1,16 @@
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    internal class IUIAnimationPriorityComparison2Callback : CallbackBase, IUIAnimationPriorityComparison2
+    {
+        public IUIAnimationManager2.PriorityComparisonDelegate Delegate;
+
+        public Result HasPriority(IUIAnimationStoryboard2 scheduledStoryboard, IUIAnimationStoryboard2 newStoryboard, AnimationPriorityEffect priorityEffect)
+        {
+            if (Delegate != null)
+                return Delegate.Invoke(scheduledStoryboard, newStoryboard, priorityEffect) ? Result.Ok : Result.False;
+            return Result.False;
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationPriorityComparisonCallback.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationPriorityComparisonCallback.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    /// <summary>
+    /// Internal PriorityComparison Callback
+    /// </summary>
+    internal class IUIAnimationPriorityComparisonCallback : CallbackBase, IUIAnimationPriorityComparison
+    {
+        public IUIAnimationManager.PriorityComparisonDelegate Delegate;
+
+        public Result HasPriority(IUIAnimationStoryboard scheduledStoryboard, IUIAnimationStoryboard newStoryboard, AnimationPriorityEffect priorityEffect)
+        {
+            if (Delegate != null)
+                return Delegate.Invoke(scheduledStoryboard, newStoryboard, priorityEffect) ? Result.Ok : Result.False;
+            return Result.False;
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationStoryboard.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationStoryboard.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationStoryboard
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IUIAnimationStoryboard"/> class.
+        /// </summary>
+        /// <param name="manager">The manager.</param>
+        public IUIAnimationStoryboard(IUIAnimationManager manager)
+        {
+            manager.CreateStoryboard(this);
+        }
+
+        /// <summary>
+        /// Sets the tag.
+        /// </summary>
+        /// <param name="object">The @object.</param>
+        /// <param name="id">The id.</param>
+        /// <returns>A <see cref="Vortice.Result" /> object describing the result of the operation.</returns>
+        /// <unmanaged>HRESULT IUIAnimationStoryboard::SetTag([In, Optional] void* object,[In] unsigned int id)</unmanaged>
+        public void SetTag(object @object, int id)
+        {
+            // Free any previous tag set
+            IntPtr tagObjectPtr = IntPtr.Zero;
+            int previousId;
+            GetTag(out tagObjectPtr, out previousId);
+            if (tagObjectPtr != IntPtr.Zero)
+                GCHandle.FromIntPtr(tagObjectPtr).Free();
+
+            SetTag(GCHandle.ToIntPtr(GCHandle.Alloc(@object)), id);
+        }
+
+        /// <summary>
+        /// Gets the tag.
+        /// </summary>
+        /// <param name="object">The @object.</param>
+        /// <param name="id">The id.</param>
+        /// <returns>
+        /// A <see cref="Vortice.Result"/> object describing the result of the operation.
+        /// </returns>
+        /// <unmanaged>HRESULT IUIAnimationStoryboard::GetTag([Out, Optional] void** object,[Out, Optional] unsigned int* id)</unmanaged>
+        public void GetTag(out object @object, out int id)
+        {
+            IntPtr tagObjectPtr;
+            GetTag(out tagObjectPtr, out id);
+            @object = GCHandle.FromIntPtr(tagObjectPtr).Target;
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationStoryboard2.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationStoryboard2.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Runtime.InteropServices;
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationStoryboard2
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IUIAnimationStoryboard2"/> class.
+        /// </summary>
+        /// <param name="manager">The manager.</param>
+        public IUIAnimationStoryboard2(IUIAnimationManager2 manager)
+        {
+            manager.CreateStoryboard(this);
+        }
+        
+        /// <summary>
+        /// Sets the tag.
+        /// </summary>
+        /// <param name="object">The @object.</param>
+        /// <param name="id">The id.</param>
+        /// <returns>A <see cref="Result" /> object describing the result of the operation.</returns>
+        /// <unmanaged>HRESULT IUIAnimationStoryboard::SetTag([In, Optional] void* object,[In] unsigned int id)</unmanaged>
+        public void SetTag(object @object, int id)
+        {
+            // Free any previous tag set
+            IntPtr tagObjectPtr = IntPtr.Zero;
+            int previousId;
+            GetTag(out tagObjectPtr, out previousId);
+            if (tagObjectPtr != IntPtr.Zero)
+                GCHandle.FromIntPtr(tagObjectPtr).Free();
+
+            SetTag(GCHandle.ToIntPtr(GCHandle.Alloc(@object)), id);
+        }
+
+        /// <summary>
+        /// Gets the tag.
+        /// </summary>
+        /// <param name="object">The @object.</param>
+        /// <param name="id">The id.</param>
+        /// <returns>
+        /// A <see cref="Result"/> object describing the result of the operation.
+        /// </returns>
+        /// <unmanaged>HRESULT IUIAnimationStoryboard::GetTag([Out, Optional] void** object,[Out, Optional] unsigned int* id)</unmanaged>
+        public void GetTag(out object @object, out int id)
+        {
+            IntPtr tagObjectPtr;
+            GetTag(out tagObjectPtr, out id);
+            @object = GCHandle.FromIntPtr(tagObjectPtr).Target;
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationTimer.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationTimer.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationTimer
+    {
+        /// <summary>
+        /// <p> Determines whether the timer is currently enabled.</p>
+        /// </summary>
+        /// <returns>true if the timer is enabled</returns>
+        public bool IsEnabled => IsEnabled_().Success;
+
+        private static readonly Guid TimerGuid = new Guid("BFCD4A0C-06B6-4384-B768-0DAA792C380E");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IUIAnimationTimer"/> class.
+        /// </summary>
+        public IUIAnimationTimer()
+        {
+            ComUtilities.CreateComInstance(TimerGuid, ComContext.InprocServer, typeof(IUIAnimationTimer).GUID, this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationTransition.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationTransition.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationTransition
+    {
+        /// <summary>
+        /// <p>Determines whether a transition's duration is currently known.</p>
+        /// </summary>
+        /// <returns>True if the duration is known</returns>
+        public bool IsDurationKnown => IsDurationKnown_().Success;
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationTransition2.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationTransition2.cs
@@ -1,0 +1,11 @@
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationTransition2
+    {
+        /// <summary>
+        /// <p>Determines whether a transition's duration is currently known.</p>
+        /// </summary>
+        /// <returns>True if the duration is known</returns>
+        public bool IsDurationKnown => IsDurationKnown_().Success;
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationTransitionFactory.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationTransitionFactory.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationTransitionFactory
+    {
+        private static readonly Guid TransitionFactoryGuid = new Guid("8A9B1CDD-FCD7-419c-8B44-42FD17DB1887");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IUIAnimationTransitionFactory"/> class.
+        /// </summary>
+        public IUIAnimationTransitionFactory()
+        {
+            ComUtilities.CreateComInstance(TransitionFactoryGuid, ComContext.InprocServer,
+                typeof(IUIAnimationTransitionFactory).GUID, this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationTransitionFactory2.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationTransitionFactory2.cs
@@ -1,0 +1,19 @@
+using System;
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationTransitionFactory2
+    {
+        private static readonly Guid TransitionFactoryGuid = new Guid("84302F97-7F7B-4040-B190-72AC9D18E420");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IUIAnimationTransitionFactory2"/> class.
+        /// </summary>
+        public IUIAnimationTransitionFactory2()
+        {
+            ComUtilities.CreateComInstance(TransitionFactoryGuid, ComContext.InprocServer,
+                typeof(IUIAnimationTransitionFactory2).GUID, this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationTransitionLibrary.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationTransitionLibrary.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationTransitionLibrary
+    {
+        private static readonly Guid TransitionLibraryGuid = new Guid("1D6322AD-AA85-4EF5-A828-86D71067D145");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IUIAnimationTransitionLibrary"/> class.
+        /// </summary>
+        public IUIAnimationTransitionLibrary()
+        {
+            ComUtilities.CreateComInstance(TransitionLibraryGuid, ComContext.InprocServer,
+                typeof(IUIAnimationTransitionLibrary).GUID, this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationTransitionLibrary2.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationTransitionLibrary2.cs
@@ -1,0 +1,19 @@
+using System;
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationTransitionLibrary2
+    {
+        private static readonly Guid TransitionLibraryGuid = new Guid("812F944A-C5C8-4CD9-B0A6-B3DA802F228D");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IUIAnimationTransitionLibrary2"/> class.
+        /// </summary>
+        public IUIAnimationTransitionLibrary2()
+        {
+            ComUtilities.CreateComInstance(TransitionLibraryGuid, ComContext.InprocServer,
+                typeof(IUIAnimationTransitionLibrary2).GUID, this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationVariable.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationVariable.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Runtime.InteropServices;
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationVariable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IUIAnimationVariable"/> class.
+        /// </summary>
+        /// <param name="manager">The manager.</param>
+        /// <param name="initialValue">The initial value.</param>
+        /// <unmanaged>HRESULT IUIAnimationManager::CreateAnimationVariable([In] double initialValue,[Out] IUIAnimationVariable** variable)</unmanaged>	
+        public IUIAnimationVariable(IUIAnimationManager manager, double initialValue = 0.0)
+        {
+            manager.CreateAnimationVariable(initialValue, this);
+        }
+
+        /// <summary>
+        /// Sets the tag.
+        /// </summary>
+        /// <param name="object">The @object.</param>
+        /// <param name="id">The id.</param>
+        /// <returns>A <see cref="Result" /> object describing the result of the operation.</returns>
+        public void SetTag(object @object, int id)
+        {
+            // Free any previous tag set
+            IntPtr tagObjectPtr = IntPtr.Zero;
+            int previousId;
+            GetTag(out tagObjectPtr, out previousId);
+            if (tagObjectPtr != IntPtr.Zero)
+                GCHandle.FromIntPtr(tagObjectPtr).Free();
+
+            SetTag(GCHandle.ToIntPtr(GCHandle.Alloc(@object)), id);
+        }
+
+        /// <summary>
+        /// Gets the tag.
+        /// </summary>
+        /// <param name="object">The @object.</param>
+        /// <param name="id">The id.</param>
+        /// <returns>
+        /// A <see cref="Result"/> object describing the result of the operation.
+        /// </returns>
+        public void GetTag(out object @object, out int id)
+        {
+            IntPtr tagObjectPtr;
+            GetTag(out tagObjectPtr, out id);
+            @object = GCHandle.FromIntPtr(tagObjectPtr).Target;
+        }
+    }
+}

--- a/src/Vortice.Visuals/Animation/IUIAnimationVariable2.cs
+++ b/src/Vortice.Visuals/Animation/IUIAnimationVariable2.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Runtime.InteropServices;
+using SharpGen.Runtime;
+
+namespace Vortice.Animation
+{
+    public partial class IUIAnimationVariable2
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IUIAnimationVariable2"/> class.
+        /// </summary>
+        /// <param name="manager">The manager.</param>
+        /// <param name="initialValue">The initial value.</param>
+        public IUIAnimationVariable2(IUIAnimationManager2 manager, double initialValue = 0.0)
+        {
+            manager.CreateAnimationVariable(initialValue, this);
+        }
+
+        /// <summary>
+        /// Sets the tag.
+        /// </summary>
+        /// <param name="object">The @object.</param>
+        /// <param name="id">The id.</param>
+        /// <returns>A <see cref="Result" /> object describing the result of the operation.</returns>
+        public void SetTag(object @object, int id)
+        {
+            // Free any previous tag set
+            IntPtr tagObjectPtr = IntPtr.Zero;
+            int previousId;
+            GetTag(out tagObjectPtr, out previousId);
+            if (tagObjectPtr != IntPtr.Zero)
+                GCHandle.FromIntPtr(tagObjectPtr).Free();
+
+            SetTag(GCHandle.ToIntPtr(GCHandle.Alloc(@object)), id);
+        }
+
+        /// <summary>
+        /// Gets the tag.
+        /// </summary>
+        /// <param name="object">The @object.</param>
+        /// <param name="id">The id.</param>
+        /// <returns>
+        /// A <see cref="Result"/> object describing the result of the operation.
+        /// </returns>
+        public void GetTag(out object @object, out int id)
+        {
+            IntPtr tagObjectPtr;
+            GetTag(out tagObjectPtr, out id);
+            @object = GCHandle.FromIntPtr(tagObjectPtr).Target;
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionAffineTransform2DEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionAffineTransform2DEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionAffineTransform2DEffect
+    {
+        public IDCompositionAffineTransform2DEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateAffineTransform2DEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionAnimation.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionAnimation.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+	partial class IDCompositionAnimation
+    {
+		public IDCompositionAnimation(IDCompositionDevice device) : base(IntPtr.Zero)
+		{
+			device.CreateAnimation(this);
+		}
+
+		public IDCompositionAnimation(IDCompositionDevice2 device) : base(IntPtr.Zero)
+		{
+			device.CreateAnimation(this);
+		}
+	}
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionArithmeticCompositeEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionArithmeticCompositeEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionArithmeticCompositeEffect
+    {
+        public IDCompositionArithmeticCompositeEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateArithmeticCompositeEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionBlendEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionBlendEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionBlendEffect
+    {
+        public IDCompositionBlendEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateBlendEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionBrightnessEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionBrightnessEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionBrightnessEffect
+    {
+        public IDCompositionBrightnessEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateBrightnessEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionColorMatrixEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionColorMatrixEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionColorMatrixEffect
+    {
+        public IDCompositionColorMatrixEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateColorMatrixEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionCompositeEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionCompositeEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionCompositeEffect
+    {
+        public IDCompositionCompositeEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateCompositeEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionDesktopDevice.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionDesktopDevice.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using SharpGen.Runtime;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionDesktopDevice
+    {
+        /// <summary>
+        /// Creates a new device object that can be used to create other Microsoft DirectComposition objects.
+        /// </summary>
+        /// <param name="renderingDevice">An optional reference to a DirectX device to be used to create DirectComposition surface objects. Must be a reference to an object implementing the <strong><see cref="Vortice.DXGI.Device"/></strong> or <strong><see cref="Vortice.Direct2D1.Device"/></strong> interfaces.</param>
+        public IDCompositionDesktopDevice(ComObject renderingDevice)
+            : base(IntPtr.Zero)
+        {
+            DComp.CreateDevice2(renderingDevice, typeof(IDCompositionDesktopDevice).GUID, out var temp);
+            NativePointer = temp;
+        }
+
+        private static class NativeMethods
+        {
+            [DllImport("user32.dll")]
+            public static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+            [DllImport("user32.dll")]
+            public static extern IntPtr GetWindowLongPtr(IntPtr hwnd, int index);
+
+            [DllImport("user32.dll")]
+            public static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
+            [DllImport("user32.dll")]
+            public static extern int GetWindowLong(IntPtr hwnd, int index);
+
+            [DllImport("user32.dll")]
+            public static extern int SetLayeredWindowAttributes(IntPtr hwnd, int color, byte alpha, int flags);
+
+            [DllImport("dwmapi.dll")]
+            public static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int pvAttr, int attrSize);
+
+            [DllImport("dwmapi.dll")]
+            public static extern int DwmGetWindowAttribute(IntPtr hwnd, int attr, ref int pvAttr, int attrSize);
+
+            public const int GWL_EXSTYLE = -20;
+            public const int WS_EX_LAYERED = 0x00080000;
+            public const int LWA_ALPHA = 2;
+            public const int DWMWA_CLOAK = 13;
+        }
+
+        /// <summary>
+        /// Sets the DWM cloaking state for the given window.
+        /// </summary>
+        /// <param name="hwnd">A window handle.</param>
+        /// <param name="cloaked">True to cloak the window, false to make the window visible again.</param>
+        /// <remarks>
+        /// When a window is used as a source in a DirectComposition tree, by default it will still be rendered in its original position and 
+        /// layout. Cloaking the window causes it to disappear from its original position and render only through the DirectComposition tree.
+        /// </remarks>
+        public static void SetWindowIsCloaked(IntPtr hwnd, bool cloaked)
+        {
+            int value = 1;
+            int result = NativeMethods.DwmSetWindowAttribute(hwnd, NativeMethods.DWMWA_CLOAK, ref value, sizeof(int));
+            if (result != 0)
+                throw new Win32Exception(result);
+        }
+
+        /// <summary>
+        /// Gets the cloaking state for a given window.
+        /// </summary>
+        /// <param name="hwnd">A window handle.</param>
+        /// <returns>True if the window is currently being cloaked, false if it is visible in its regular position.</returns>
+        public static bool GetWindowIsCloaked(IntPtr hwnd)
+        {
+            int value = 1;
+            int result = NativeMethods.DwmGetWindowAttribute(hwnd, NativeMethods.DWMWA_CLOAK, ref value, sizeof(int));
+            if (result != 0)
+                throw new Win32Exception(result);
+            return value != 0;
+        }
+
+        /// <summary>
+        /// Sets or clears the WS_EX_LAYERED extended style for a window.
+        /// </summary>
+        /// <param name="hwnd">A window handle.</param>
+        /// <param name="isLayered">True to apply the layered style to the window, false to clear the style.</param>
+        /// <remarks>
+        /// Only windows with the WS_EX_LAYERED style can be used as Visual content. Starting in Windows 8, child windows can also be layered windows.
+        /// </remarks>
+        public static void SetWindowIsLayered(IntPtr hwnd, bool isLayered)
+        {
+#if NET45
+            if (Environment.Is64BitProcess)
+#else
+            if (IntPtr.Size == 8)
+#endif
+            {
+                IntPtr exStyle = NativeMethods.GetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE);
+                if (exStyle == IntPtr.Zero)
+                    throw new Win32Exception();
+                exStyle = NativeMethods.SetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE,
+                    (IntPtr)(exStyle.ToInt64() | NativeMethods.WS_EX_LAYERED));
+                if (exStyle == IntPtr.Zero)
+                    throw new Win32Exception();
+            }
+            else
+            {
+                int exStyle = NativeMethods.GetWindowLong(hwnd, NativeMethods.GWL_EXSTYLE);
+                if (exStyle == 0)
+                    throw new Win32Exception();
+                exStyle = NativeMethods.SetWindowLong(hwnd, NativeMethods.GWL_EXSTYLE,
+                    exStyle | NativeMethods.WS_EX_LAYERED);
+                if (exStyle == 0)
+                    throw new Win32Exception();
+            }
+        }
+
+        /// <summary>
+        /// Gets whether a given window has the WS_EX_LAYERED extended style applied.
+        /// </summary>
+        /// <param name="hwnd">A window handle.</param>
+        /// <returns>True if the window has the layered style applied, false otherwise.</returns>
+        public static bool GetWindowIsLayered(IntPtr hwnd)
+        {
+#if NET45
+            if (Environment.Is64BitProcess)
+#else
+            if (IntPtr.Size == 8)
+#endif
+            {
+                IntPtr exStyle = NativeMethods.GetWindowLongPtr(hwnd, NativeMethods.GWL_EXSTYLE);
+                if (exStyle == IntPtr.Zero)
+                    throw new Win32Exception();
+                return (int)(exStyle.ToInt64() & NativeMethods.WS_EX_LAYERED) == NativeMethods.WS_EX_LAYERED;
+            }
+            else
+            {
+                int exStyle = NativeMethods.GetWindowLong(hwnd, NativeMethods.GWL_EXSTYLE);
+                if (exStyle == 0)
+                    throw new Win32Exception();
+                return (exStyle & NativeMethods.WS_EX_LAYERED) == NativeMethods.WS_EX_LAYERED;
+            }
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionDevice.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionDevice.cs
@@ -1,0 +1,15 @@
+﻿namespace Vortice.DirectComposition
+{
+	public partial class IDCompositionDevice
+    {
+		/// <summary>
+		/// Creates a new device object that can be used to create other Microsoft DirectComposition objects.
+		/// </summary>
+		/// <param name="device">The DXGI device to use to create DirectComposition surface objects.</param>
+		public IDCompositionDevice(DXGI.IDXGIDevice device)
+		{
+            DComp.CreateDevice(device, typeof(IDCompositionDevice).GUID, out var temp);
+			NativePointer = temp;
+		}
+	}
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionDevice2.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionDevice2.cs
@@ -1,0 +1,24 @@
+﻿using SharpGen.Runtime;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionDevice2
+    {
+        /// <summary>
+        /// Used for inherited constructors
+        /// </summary>
+        protected IDCompositionDevice2() { }
+
+		/// <summary>
+		/// Creates a new device object that can be used to create other Microsoft DirectComposition objects.
+		/// </summary>
+		/// <param name="renderingDevice">An optional reference to a DirectX device to be used to create DirectComposition surface 
+		/// objects. Must be a reference to an object implementing the <strong><see cref="DXGI.IDXGIDevice"/></strong> or
+		/// <strong><see cref="Direct2D1.ID2D1Device"/></strong> interfaces.</param>
+		public IDCompositionDevice2(ComObject renderingDevice)
+		{
+            DComp.CreateDevice2(renderingDevice, typeof(IDCompositionDevice2).GUID, out var temp);
+			NativePointer = temp;
+		}
+	}
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionDevice3.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionDevice3.cs
@@ -1,0 +1,19 @@
+﻿using SharpGen.Runtime;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionDevice3
+    {
+        /// <summary>
+        /// Creates a new device object that can be used to create other Microsoft DirectComposition objects.
+        /// </summary>
+        /// <param name="renderingDevice">An optional reference to a DirectX device to be used to create DirectComposition surface
+        /// objects. Must be a reference to an object implementing the <strong><see cref="DXGI.IDXGIDevice"/></strong> or
+        /// <strong><see cref="Direct2D1.ID2D1Device"/></strong> interfaces.</param>
+        public IDCompositionDevice3(ComObject renderingDevice)
+		{
+            DComp.CreateDevice3(renderingDevice, typeof(IDCompositionDevice3).GUID, out var temp);
+			NativePointer = temp;
+		}
+	}
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionEffectGroup.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionEffectGroup.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionEffectGroup
+    {
+        public IDCompositionEffectGroup(IDCompositionDevice device)
+            : base(IntPtr.Zero)
+        {
+            device.CreateEffectGroup(this);
+        }
+
+        public IDCompositionEffectGroup(IDCompositionDevice2 device) : base(IntPtr.Zero)
+        {
+            device.CreateEffectGroup(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionGaussianBlurEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionGaussianBlurEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionGaussianBlurEffect
+    {
+        public IDCompositionGaussianBlurEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateGaussianBlurEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionHueRotationEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionHueRotationEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionHueRotationEffect
+    {
+        public IDCompositionHueRotationEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateHueRotationEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionLinearTransferEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionLinearTransferEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionLinearTransferEffect
+    {
+        public IDCompositionLinearTransferEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateLinearTransferEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionMatrixTransform.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionMatrixTransform.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionMatrixTransform
+    {
+        public IDCompositionMatrixTransform(IDCompositionDevice device) : base(IntPtr.Zero)
+        {
+            device.CreateMatrixTransform(this);
+        }
+
+        public IDCompositionMatrixTransform(IDCompositionDevice2 device)
+            : base(IntPtr.Zero)
+        {
+            device.CreateMatrixTransform(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionMatrixTransform3D.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionMatrixTransform3D.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionMatrixTransform3D
+    {
+        public IDCompositionMatrixTransform3D(IDCompositionDevice device) : base(IntPtr.Zero)
+        {
+            device.CreateMatrixTransform3D(this);
+        }
+
+        public IDCompositionMatrixTransform3D(IDCompositionDevice2 device)
+            : base(IntPtr.Zero)
+        {
+            device.CreateMatrixTransform3D(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionRectangleClip.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionRectangleClip.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionRectangleClip
+    {
+        public IDCompositionRectangleClip(IDCompositionDevice device) : base(IntPtr.Zero)
+        {
+            device.CreateRectangleClip(this);
+        }
+
+        public IDCompositionRectangleClip(IDCompositionDevice2 device)
+            : base(IntPtr.Zero)
+        {
+            device.CreateRectangleClip(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionRotateTransform.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionRotateTransform.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionRotateTransform
+    {
+        public IDCompositionRotateTransform(IDCompositionDevice device) : base(IntPtr.Zero)
+        {
+            device.CreateRotateTransform(this);
+        }
+
+        public IDCompositionRotateTransform(IDCompositionDevice2 device)
+            : base(IntPtr.Zero)
+        {
+            device.CreateRotateTransform(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionRotateTransform3D.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionRotateTransform3D.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionRotateTransform3D
+    {
+        public IDCompositionRotateTransform3D(IDCompositionDevice device) : base(IntPtr.Zero)
+        {
+            device.CreateRotateTransform3D(this);
+        }
+
+        public IDCompositionRotateTransform3D(IDCompositionDevice2 device)
+            : base(IntPtr.Zero)
+        {
+            device.CreateRotateTransform3D(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionSaturationEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionSaturationEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionSaturationEffect
+    {
+        public IDCompositionSaturationEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateSaturationEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionScaleTransform.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionScaleTransform.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionScaleTransform
+    {
+        public IDCompositionScaleTransform(IDCompositionDevice device) : base(IntPtr.Zero)
+        {
+            device.CreateScaleTransform(this);
+        }
+
+        public IDCompositionScaleTransform(IDCompositionDevice2 device)
+            : base(IntPtr.Zero)
+        {
+            device.CreateScaleTransform(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionScaleTransform3D.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionScaleTransform3D.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionScaleTransform3D
+    {
+        public IDCompositionScaleTransform3D(IDCompositionDevice device) : base(IntPtr.Zero)
+        {
+            device.CreateScaleTransform3D(this);
+        }
+
+        public IDCompositionScaleTransform3D(IDCompositionDevice2 device)
+            : base(IntPtr.Zero)
+        {
+            device.CreateScaleTransform3D(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionShadowEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionShadowEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionShadowEffect
+    {
+        public IDCompositionShadowEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateShadowEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionSkewTransform.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionSkewTransform.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionSkewTransform
+    {
+        public IDCompositionSkewTransform(IDCompositionDevice device) : base(IntPtr.Zero)
+        {
+            device.CreateSkewTransform(this);
+        }
+
+        public IDCompositionSkewTransform(IDCompositionDevice2 device)
+            : base(IntPtr.Zero)
+        {
+            device.CreateSkewTransform(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionSurface.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionSurface.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using SharpGen.Runtime;
+using Vortice.DXGI;
+using Vortice.Mathematics;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionSurface
+    {
+        public IDCompositionSurface(IDCompositionDevice device, int width, int height, Format format,
+            AlphaMode alphaMode) : base(IntPtr.Zero)
+        {
+            device.CreateSurface(width, height, format, alphaMode, this);
+        }
+
+        public IDCompositionSurface(IDCompositionDevice2 device, int width, int height, Format format,
+            AlphaMode alphaMode)
+            : base(IntPtr.Zero)
+        {
+            device.CreateSurface(width, height, format, alphaMode, this);
+        }
+
+        public IDCompositionSurface(IDCompositionSurfaceFactory factory, int initialWidth, int initialHeight,
+            Format format, AlphaMode alphaMode)
+            : base(IntPtr.Zero)
+        {
+            factory.CreateSurface(initialWidth, initialHeight, format, alphaMode, this);
+        }
+
+        public T BeginDraw<T>(RawRect? updateRect, out Point updateOffset) where T : ComObject
+        {
+            BeginDraw(updateRect, typeof(T).GUID, out var temp, out updateOffset);
+            return FromPointer<T>(temp);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionSurfaceFactory.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionSurfaceFactory.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using SharpGen.Runtime;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionSurfaceFactory
+    {
+        public IDCompositionSurfaceFactory(IDCompositionDevice2 device, ComObject renderingDevice) : base(IntPtr.Zero)
+        {
+            device.CreateSurfaceFactory(renderingDevice, this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionTableTransferEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionTableTransferEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionTableTransferEffect
+    {
+        public IDCompositionTableTransferEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateTableTransferEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionTarget.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionTarget.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionTarget
+    {
+        /// <summary>
+        /// Creates a composition target object that is bound to the window that is represented by the specified window handle.
+        /// </summary>
+        /// <param name="desktopDevice">A device the target is to be associated with.</param>
+        /// <param name="hwnd">The window to which the composition object will be bound. This cannot be null.</param>
+        /// <param name="topmost">TRUE if the visual tree should be displayed on top of the children of the window specified by the hwnd parameter; otherwise, the visual tree is displayed behind the children.</param>
+        /// <returns></returns>
+        public static IDCompositionTarget FromHwnd(IDCompositionDesktopDevice desktopDevice, IntPtr hwnd, bool topmost)
+        {
+            return desktopDevice.CreateTargetForHwnd(hwnd, topmost);
+        }
+
+        /// <summary>
+        /// Creates a composition target object that is bound to the window that is represented by the specified window handle.
+        /// </summary>
+        /// <param name="device">A device the target is to be associated with.</param>
+        /// <param name="hwnd">The window to which the composition object will be bound. This cannot be null.</param>
+        /// <param name="topmost">TRUE if the visual tree should be displayed on top of the children of the window specified by the hwnd parameter; otherwise, the visual tree is displayed behind the children.</param>
+        /// <returns></returns>
+        public static IDCompositionTarget FromHwnd(IDCompositionDevice device, IntPtr hwnd, bool topmost)
+        {
+            device.CreateTargetForHwnd(hwnd, topmost, out var target);
+            return target;
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionTransform.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionTransform.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using SharpGen.Runtime;
+
+namespace Vortice.DirectComposition
+{
+    partial class IDCompositionTransform
+    {
+        public IDCompositionTransform(IDCompositionDevice dev, params IDCompositionTransform[] effects)
+            : this(IntPtr.Zero)
+        {
+            dev.CreateTransformGroup(effects, effects.Length, this);
+        }
+
+        public IDCompositionTransform(IDCompositionDevice2 dev, params IDCompositionTransform[] effects)
+            : this(IntPtr.Zero)
+        {
+            dev.CreateTransformGroup(effects, effects.Length, this);
+        }
+
+        public IDCompositionTransform(IDCompositionDevice dev, InterfaceArray<IDCompositionTransform> effects)
+            : this(IntPtr.Zero)
+        {
+            dev.CreateTransformGroup(effects, effects.Length, this);
+        }
+
+        public IDCompositionTransform(IDCompositionDevice2 dev, InterfaceArray<IDCompositionTransform> effects)
+            : this(IntPtr.Zero)
+        {
+            dev.CreateTransformGroup(effects, effects.Length, this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionTransform3D.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionTransform3D.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using SharpGen.Runtime;
+
+namespace Vortice.DirectComposition
+{
+	partial class IDCompositionTransform3D
+    {
+		public IDCompositionTransform3D(IDCompositionDevice dev, params IDCompositionTransform3D[] effects)
+			: this(IntPtr.Zero)
+		{
+			dev.CreateTransform3DGroup(effects, effects.Length, this);
+		}
+
+		public IDCompositionTransform3D(IDCompositionDevice2 dev, params IDCompositionTransform3D[] effects)
+			: this(IntPtr.Zero)
+		{
+			dev.CreateTransform3DGroup(effects, effects.Length, this);
+		}
+
+		public IDCompositionTransform3D(IDCompositionDevice dev, InterfaceArray<IDCompositionTransform3D> effects)
+			: this(IntPtr.Zero)
+		{
+			dev.CreateTransform3DGroup(effects, effects.Length, this);
+		}
+
+		public IDCompositionTransform3D(IDCompositionDevice2 dev, InterfaceArray<IDCompositionTransform3D> effects)
+			: this(IntPtr.Zero)
+		{
+			dev.CreateTransform3DGroup(effects, effects.Length, this);
+		}
+	}
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionTranslateTransform.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionTranslateTransform.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+	partial class IDCompositionTranslateTransform
+    {
+		public IDCompositionTranslateTransform(IDCompositionDevice device) : base(IntPtr.Zero)
+		{
+			device.CreateTranslateTransform(this);
+		}
+
+		public IDCompositionTranslateTransform(IDCompositionDevice2 device)
+			: base(IntPtr.Zero)
+		{
+			device.CreateTranslateTransform(this);
+		}
+	}
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionTranslateTransform3D.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionTranslateTransform3D.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+	partial class IDCompositionTranslateTransform3D
+    {
+		public IDCompositionTranslateTransform3D(IDCompositionDevice device) : base(IntPtr.Zero)
+		{
+			device.CreateTranslateTransform3D(this);
+		}
+
+		public IDCompositionTranslateTransform3D(IDCompositionDevice2 device)
+			: base(IntPtr.Zero)
+		{
+			device.CreateTranslateTransform3D(this);
+		}
+	}
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionTurbulenceEffect.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionTurbulenceEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+    public partial class IDCompositionTurbulenceEffect
+    {
+        public IDCompositionTurbulenceEffect(IDCompositionDevice3 device) : base(IntPtr.Zero)
+        {
+            device.CreateTurbulenceEffect(this);
+        }
+    }
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionVirtualSurface.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionVirtualSurface.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+	partial class IDCompositionVirtualSurface
+    {
+		public IDCompositionVirtualSurface(IDCompositionDevice device, int initialWidth, int initialHeight, DXGI.Format format, DXGI.AlphaMode alphaMode) : base(IntPtr.Zero)
+		{
+			device.CreateVirtualSurface(initialWidth, initialHeight, format, alphaMode, this);
+		}
+
+		public IDCompositionVirtualSurface(IDCompositionDevice2 device, int initialWidth, int initialHeight, DXGI.Format format, DXGI.AlphaMode alphaMode)
+			: base(IntPtr.Zero)
+		{
+			device.CreateVirtualSurface(initialWidth, initialHeight, format, alphaMode, this);
+		}
+
+		public IDCompositionVirtualSurface(IDCompositionSurfaceFactory factory, int initialWidth, int initialHeight, DXGI.Format format, DXGI.AlphaMode alphaMode)
+			: base(IntPtr.Zero)
+		{
+			factory.CreateVirtualSurface(initialWidth, initialHeight, format, alphaMode, this);
+		}
+	}
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionVisual.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionVisual.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+	partial class IDCompositionVisual
+    {
+		public IDCompositionVisual(IDCompositionDevice device)
+			: base(IntPtr.Zero)
+		{
+			device.CreateVisual(this);
+		}
+	}
+}

--- a/src/Vortice.Visuals/Composition/IDCompositionVisual2.cs
+++ b/src/Vortice.Visuals/Composition/IDCompositionVisual2.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Vortice.DirectComposition
+{
+	partial class IDCompositionVisual2
+    {
+		public IDCompositionVisual2(IDCompositionDevice2 device)
+			: base(IntPtr.Zero)
+		{
+			device.CreateVisual(this);
+		}
+	}
+}

--- a/src/Vortice.Visuals/Mappings.xml
+++ b/src/Vortice.Visuals/Mappings.xml
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config id="vortice-visuals" xmlns="urn:SharpGen.Config">
+  <assembly>Vortice.Visuals</assembly>
+  <namespace>Vortice.Visuals</namespace>
+  <depends>Vortice.Direct2D1</depends>
+
+  <sdk name="WindowsSdk" version="10.0.18362.0" />
+  <sdk name="StdLib" />
+
+  <include file="uianimation.h" namespace="Vortice.Animation" attach="true" output="AnimationManager" />
+  <include file="dcomp.h" namespace="Vortice.DirectComposition" attach="true" output="DComp" />
+  <include file="dcompanimation.h" namespace="Vortice.DirectComposition" attach="true" output="DComp" />
+  <include file="dcomptypes.h" namespace="Vortice.DirectComposition" attach="true" output="DComp" />
+
+  <extension>
+    <create class="Vortice.Animation.AnimationManager" visibility="public static" />
+    <create class="Vortice.DirectComposition.DComp" visibility="public static" />
+
+    <create class="Vortice.DirectComposition.ResultCode" visibility="public"/>
+    <const from-macro="DCOMPOSITION_ERROR_(.*)" type="SharpGen.Runtime.ResultDescriptor" cpp-type="int" name="$1" class="Vortice.DirectComposition.ResultCode" visibility="public static readonly">new SharpGen.Runtime.ResultDescriptor($1, "$3", "$0", "$2")</const>
+
+    <create class="Vortice.Animation.AnimationRepeat" visibility="public static" />
+    <const from-macro="UI_ANIMATION_REPEAT_(.*)" type="int" cpp-type="int" name="$1" class="Vortice.Animation.AnimationRepeat" visibility="public static readonly" />
+  </extension>
+
+  <bindings>
+    <bind from="D3DMATRIX" to="System.Numerics.Matrix4x4" />
+    <bind from="D2D1_2DAFFINETRANSFORM_INTERPOLATION_MODE" to="Vortice.Direct2D1.AffineTransform2DInterpolationMode" />
+    <bind from="__MIDL___MIDL_itf_UIAnimation_0000_0002_0003" to="System.IntPtr" />
+  </bindings>
+
+  <naming>
+    <short name="DESCRIPTOR">Descriptor</short>
+    <short name="DESCRIPTION">Description</short>
+    <short name="DESC">Description</short>
+    <short name="TOPLEFT">TopLeft</short>
+    <short name="UINT32">UInt32</short>
+    <short name="UINT64">UInt64</short>
+    <short name="IUNKNOWN">IUnknown</short>
+    <short name="RECTANGLE">Rectangle</short>
+    <short name="RECTS">Rectangles</short>
+    <short name="RECT">Rectangle</short>
+    <short name="POINT">Point</short>
+    <short name="POINTS">Points</short>
+    <short name="TRIANGLE">Triangle</short>
+    <short name="LIST">List</short>
+    <short name="ADJACENCY">Adjacency</short>
+    <short name="ADJ">Adjacency</short>
+    <short name="STRIP">Strip</short>
+    <short name="SRV">ShaderResourceView</short>
+    <short name="DSV">DepthStencilView</short>
+    <short name="RTV">RenderTargetView</short>
+    <short name="UAVS">UnorderedAccessViews</short>
+    <short name="UAV">UnorderedAccessView</short>
+    <short name="TEXTURE">Texture</short>
+    <short name="TEXT">Text</short>
+    <short name="CUBE">Cube</short>
+    <short name="TEX">Texture</short>
+    <short name="1D">1D</short>
+    <short name="2D">2D</short>
+    <short name="3D">3D</short>
+    <short name="MS">Multisampled</short>
+    <short name="RW">RW</short>
+    <short name="ARRAYSIZE">ArraySize</short>
+    <short name="ARRAYSLICE">ArraySlice</short>
+    <short name="ARRAYS">Arrays</short>
+    <short name="ARRAY">Array</short>
+    <short name="BUFFERS">Buffers</short>
+    <short name="BUFFER">Buffer</short>
+    <short name="BUFFEREX">BufferExtended</short>
+    <short name="CBV">ConstantBufferView</short>
+    <short name="CBUFFER">ConstantBuffer</short>
+    <short name="TBUFFER">TextureBuffer</short>
+    <short name="VDOV">VideoDecoderOutputView</short>
+    <short name="VPIV">VideoProcessorInputView</short>
+    <short name="VPOV">VideoProcessorOutputView</short>
+    <short name="INVALIDPARAMETER">InvalidParameter</short>
+    <short name="OUTOFMEMORY">OutOfMemory</short>
+    <short name="NOTIMPLEMENTED">NotImplemented</short>
+    <short name="ACCESSDENIED">AccessDenied</short>
+    <short name="VALUEOVERFLOW">ValueOverflow</short>
+    <short name="WRONGSTATE">WrongState</short>
+    <short name="VALUEOUTOFRANGE">ValueOutOfRange</short>
+    <short name="UNKNOWNIMAGEFORMAT">UnknownImageFormat</short>
+    <short name="UNSUPPORTEDVERSION">UnsupportedVersion</short>
+    <short name="POINTER">Pointer</short>
+    <short name="POINTERS">Pointers</short>
+    <short name="NOPERSPECTIVE">NoPerspective</short>
+    <short name="POINTLIST">PointList</short>
+    <short name="LINELIST">LineList</short>
+    <short name="LINESTRIP">LineStrip</short>
+    <short name="TRIANGLELIST">TriangleList</short>
+    <short name="COMPUTESHADER">ComputeShader</short>
+    <short name="DEPTHSTENCIL">DepthStencil</short>
+    <short name="DEPTHSTENCILVIEW">DepthStencilView</short>
+    <short name="DOMAINSHADER">DomainShader</short>
+    <short name="GEOMETRYSHADER">GeometryShader</short>
+    <short name="HULLSHADER">HullShader</short>
+    <short name="MIN8FLOAT">Min8Float</short>
+    <short name="MIN10FLOAT">Min10Float</short>
+    <short name="MIN16FLOAT">Min16Float</short>
+    <short name="MIN12INT">Min12Int</short>
+    <short name="MIN16INT">Min16Int</short>
+    <short name="MIN16UINT">Min16UInt</short>
+    <short name="PIXELFRAGMENT">PixelFragment</short>
+    <short name="PIXELSHADER">PixelShader</short>
+    <short name="RENDERTARGETVIEW">RenderTargetView</short>
+    <short name="SAMPLER1D">Sampler1D</short>
+    <short name="SAMPLER2D">Sampler2D</short>
+    <short name="SAMPLER3D">Sampler3D</short>
+    <short name="SAMPLERCUBE">SamplerCube</short>
+    <short name="VERTEXFRAGMENT">VertexFragment</short>
+    <short name="VERTEXSHADER">VertexShader</short>
+    <short name="SRC">Source</short>
+    <short name="DST">Destination</short>
+    <short name="DEST">Destination</short>
+    <short name="INV">Inverse</short>
+  </naming>
+
+  <mapping>
+    <!-- DComp Enumerations -->
+    <map enum="DCOMPOSITION_(.*)" name-tmp="$1" />
+    <map enum="DCOMPOSITION_BACKFACE_VISIBILITY" name-tmp="BackFaceVisibility" />
+    <map enum-item="DCOMPOSITION_TRANSFORM_MODE_3D_TRANSFORM" name-tmp="Transform3D"/>
+    <map enum-item="DCOMPOSITION_TRANSFORM_MODE_3D_TRANSFORM_AND_VISIBILITY" name-tmp="Transform3DAndVisibility"/>
+    
+    <remove enum-item=".*_FORCE_DWORD" />
+    <remove enum-item=".*_FORCE_UINT" />
+
+    <!-- DComp Structures -->
+    <map struct="DCOMPOSITION(.*)" name-tmp="$1" />
+
+    <!-- DComp Interfaces -->
+    <map method="IDCompositionDevice2?::Create.*" visibility="internal" />
+    <map param="IDCompositionDevice2?::CreateAnimation::animation" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateEffectGroup::effectGroup" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateMatrixTransform::matrixTransform" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateMatrixTransform3D::matrixTransform3D" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateRectangleClip::clip" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateRotateTransform::rotateTransform" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateRotateTransform3D::rotateTransform3D" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateScaleTransform::scaleTransform" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateScaleTransform3D::scaleTransform3D" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateSkewTransform::skewTransform" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateSurface::surface" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateSurfaceFactory::surfaceFactory" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateTransform3DGroup::transform3DGroup" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateTransformGroup::transformGroup" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateTranslateTransform::translateTransform" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateTranslateTransform3D::translateTransform3D" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateVirtualSurface::(virtualS|s)urface" attribute="out fast" />
+    <map param="IDCompositionDevice2?::CreateVisual::visual" attribute="out fast" />
+
+    <map method="IDCompositionDevice3?::Create.*" visibility="internal" />
+    <map param="IDCompositionDevice3::CreateGaussianBlurEffect::gaussianBlurEffect" attribute="out fast" />
+    <map param="IDCompositionDevice3::CreateBrightnessEffect::brightnessEffect" attribute="out fast" />
+    <map param="IDCompositionDevice3::CreateColorMatrixEffect::colorMatrixEffect" attribute="out fast" />
+    <map param="IDCompositionDevice3::CreateShadowEffect::shadowEffect" attribute="out fast" />
+    <map param="IDCompositionDevice3::CreateHueRotationEffect::hueRotationEffect" attribute="out fast" />
+    <map param="IDCompositionDevice3::CreateSaturationEffect::saturationEffect" attribute="out fast" />
+    <map param="IDCompositionDevice3::CreateTurbulenceEffect::turbulenceEffect" attribute="out fast" />
+    <map param="IDCompositionDevice3::CreateLinearTransferEffect::linearTransferEffect" attribute="out fast" />
+    <map param="IDCompositionDevice3::CreateTableTransferEffect::tableTransferEffect" attribute="out fast" />
+    <map param="IDCompositionDevice3::CreateCompositeEffect::compositeEffect" attribute="out fast" />
+    <map param="IDCompositionDevice3::CreateBlendEffect::blendEffect" attribute="out fast" />
+    <map param="IDCompositionDevice3::CreateArithmeticCompositeEffect::arithmeticCompositeEffect" attribute="out fast" />
+    <map param="IDCompositionDevice3::CreateAffineTransform2DEffect::affineTransform2dEffect" attribute="out fast" />
+
+    <map method="IDCompositionDesktopDevice::CreateTargetForHwnd" visibility="internal" />
+    <map param="IDCompositionDesktopDevice::CreateTargetForHwnd::target" return="true" />
+    <map param="IDCompositionDesktopDevice::CreateSurfaceFromHandle::surface" return="true" />
+    <map param="IDCompositionDesktopDevice::CreateSurfaceFromHwnd::surface" return="true" />
+
+    <map method="IDCompositionRectangleClip::.*" property="false" />
+    <map method="IDCompositionEffectGroup::SetOpacity.*" property="false" />
+    <map method="IDCompositionVisual::Set(Clip|Offset|Transform).*" property="false" />
+
+    <map method="IDCompositionSurfaceFactory::Create(Virtual)?Surface" visibility="internal" />
+    <map param="IDCompositionSurfaceFactory::Create(Virtual)?Surface::(virtualS|s)urface" attribute="out fast" />
+
+    <map method="IDComposition(Rotate|Translate|Scale|Skew|Matrix)Transform(3D)?::Set.*" property="false" />
+
+    <!-- DComp Functions -->
+    <map function="DComposition(.+)" name-tmp="$1" visibility="internal" />
+    <map function="DComposition.*" dll='"dcomp.dll"' group="Vortice.DirectComposition.DComp" />
+    <map function="DCompositionCreateSurfaceHandle" visibility="public" />
+
+
+    <!-- Animation Enumerations -->
+    <map enum="UI_(.*)" name-tmp="$1"/>
+    <map enum-item="UI_ANIMATION_(.*)" name-tmp="$1"/>
+
+    <map enum="UI_ANIMATION_DEPENDENCIES" flags="true"/>
+    <map enum-item="UI_ANIMATION_DEPENDENCY_(.*)" name-tmp="$1"/>
+
+    <map enum-item="UI_ANIMATION_IDLE_BEHAVIOR_(.*)" name-tmp="$1"/>
+    <map enum-item="UI_ANIMATION_MANAGER_(.*)" name-tmp="$1"/>
+
+    <map enum-item="UI_ANIMATION_MODE_(.*)" name-tmp="$1"/>
+    <map enum-item="UI_ANIMATION_PRIORITY_EFFECT_(.*)" name-tmp="$1"/>
+    <map enum-item="UI_ANIMATION_SCHEDULING_(.*)" name-tmp="$1"/>
+    <map enum-item="UI_ANIMATION_SLOPE_(.*)" name-tmp="$1"/>
+    <map enum-item="UI_ANIMATION_STORYBOARD_(.*)" name-tmp="$1"/>
+    <map enum-item="UI_ANIMATION_TIMER_CLIENT_(.*)" name-tmp="$1"/>
+    <map enum-item="UI_ANIMATION_UPDATE_(.*)" name-tmp="$1"/>
+
+    <!-- Animation Interfaces -->
+    <map interface="IUIAnimationInterpolator2?" callback="true" callback-dual="true" callback-visibility="internal" autogen-shadow="true" />
+    <map method="IUIAnimationInterpolator2?::.+" hresult="true" check="false" />
+    <map method="IUIAnimationInterpolator2?::GetDimension" property="false" />
+    <map method="IUIAnimationInterpolator2?::GetDuration" property="false" />
+    <map method="IUIAnimationInterpolator2?::GetFinalValue" property="false" />
+    <map method="IUIAnimationInterpolator2?::SetDuration" property="false" />
+    <map param="IUIAnimationInterpolator2::SetInitialValueAndVelocity::cDimension" relation="length(initialValue),length(initialVelocity)" />
+    <map param="IUIAnimationInterpolator2::GetFinalValue::cDimension" relation="length(value)" />
+    <map param="IUIAnimationInterpolator2::InterpolateValue::cDimension" relation="length(value)" />
+    <map param="IUIAnimationInterpolator2::InterpolateVelocity::cDimension" relation="length(velocity)" />
+    <map param="IUIAnimationInterpolator2::SetInitialValueAndVelocity::initialValue" attribute="out buffer fast" />
+    <map param="IUIAnimationInterpolator2::SetInitialValueAndVelocity::initialVelocity" attribute="out buffer fast" />
+    <map param="IUIAnimationInterpolator2::GetFinalValue::value" attribute="out buffer fast" />
+    <map param="IUIAnimationInterpolator2::InterpolateValue::value" attribute="out buffer fast" />
+    <map param="IUIAnimationInterpolator2::InterpolateVelocity::velocity" attribute="out buffer fast" />
+
+    <!-- IUIAnimationManager2? -->
+    <map method="IUIAnimationManager2?::CreateAnimationVariable" visibility="internal"/>
+    <map param="IUIAnimationManager2?::CreateAnimationVariable::variable" attribute="fast out"/>
+
+    <map method="IUIAnimationManager2?::CreateStoryboard" visibility="internal"/>
+    <map param="IUIAnimationManager2?::CreateStoryboard::storyboard" attribute="fast out"/>
+
+    <map param="IUIAnimationManager2?::Update::updateResult" return="true"/>
+
+    <map method="IUIAnimationManager2?::GetVariableFromTag" visibility="internal"/>
+    <map param="IUIAnimationManager2?::GetVariableFromTag::object" type="void"/>
+    <map param="IUIAnimationManager2?::GetVariableFromTag::variable" return="true"/>
+
+    <map method="IUIAnimationManager2?::GetStoryboardFromTag" visibility="internal"/>
+    <map param="IUIAnimationManager2?::GetStoryboardFromTag::object" type="void"/>
+    <map param="IUIAnimationManager2?::GetStoryboardFromTag::storyboard" return="true"/>
+
+    <!-- Don't generate properties for event handler setter -->
+    <map interface=".*Handler2?" callback="true" callback-dual="true" callback-visibility="internal" autogen-shadow="true" />
+    <map method=".*::Set.*Handler" property="false" />
+
+    <!-- Callback for Priority Comparison -->
+    <map interface="IUIAnimationPriorityComparison2?" callback="true" callback-dual="true" callback-visibility="internal" autogen-shadow="true" />
+    <map method="IUIAnimationPriorityComparison2?::HasPriority" type="HRESULT" check="false" />
+    <map method="IUIAnimationManager2?::Set.*Comparison" property="false" visibility="internal" />
+
+    <!-- IUIAnimationStoryboard -->
+    <map param="IUIAnimationStoryboard2?::AddKeyframeAtOffset::keyframe" return="true" />
+    <map param="IUIAnimationStoryboard2?::AddKeyframeAfterTransition::keyframe" return="true" />
+    <map param="IUIAnimationStoryboard2?::Schedule::schedulingResult" return="true" />
+
+    <map method="IUIAnimationStoryboard2?::SetTag" visibility="internal"/>
+    <map method="IUIAnimationStoryboard2?::GetTag" visibility="internal"/>
+    <map param="IUIAnimationStoryboard2?::SetTag::object" type="void"/>
+    <map param="IUIAnimationStoryboard2?::GetTag::object" type="void"/>
+
+    <map method="IUIAnimationStoryboard2::RepeatBetweenKeyframes" visibility="internal" />
+
+    <!-- IUIAnimationTransitionLibrary -->
+    <map method="IUIAnimationTransitionLibrary2?::Create(.*)Transition" name="$1"/>
+    <map method="IUIAnimationTransitionLibrary2?::Create(.*)Transition(.+)" name="$1$2"/>
+    <map param="IUIAnimationTransitionLibrary2?::.*::transition" return="true"/>
+
+    <!-- IUIAnimationTransitionFactory -->
+    <map param="IUIAnimationTransitionFactory2?::CreateTransition::transition" return="true" />
+
+    <!-- IUIAnimationVariable -->
+    <map method="IUIAnimationVariable2?::SetTag" visibility="internal"/>
+    <map method="IUIAnimationVariable2?::GetTag" visibility="internal"/>
+    <map param="IUIAnimationVariable2?::SetTag::object" type="void"/>
+    <map param="IUIAnimationVariable2?::GetTag::object" type="void"/>
+    
+    <map param="IUIAnimationVariable.*ChangeHandler2::On.*ValueChanged::cDimension" relation="length(newValue),length(previousValue)" />
+    
+    <map method="IUIAnimationTimer::IsEnabled" return="true" check="false" property="false" name="IsEnabled_" visibility="internal"/>
+    <map method="IUIAnimationTransition2?::IsDurationKnown" return="true" check="false" property="false" name="IsDurationKnown_" visibility="internal"/>
+
+  </mapping>
+</config>

--- a/src/Vortice.Visuals/Vortice.Visuals.csproj
+++ b/src/Vortice.Visuals/Vortice.Visuals.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Description>DirectComposition and Windows Animation Manager bindings.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SharpGenMapping Include="Mappings.xml" />
+    <PackageReference Include="SharpGenTools.Sdk" Version="$(SharpGenVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Vortice.Direct2D1\Vortice.Direct2D1.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Vortice.Windows.sln
+++ b/src/Vortice.Windows.sln
@@ -34,6 +34,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vortice.Multimedia", "Vorti
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vortice.Direct3D9", "Vortice.Direct3D9\Vortice.Direct3D9.csproj", "{B51C4D23-F3EC-4E69-9CEA-76D340BD6749}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HelloComposition", "samples\HelloComposition\HelloComposition.csproj", "{98A4BFCA-2DDE-4960-8B17-E28F660B7CBF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vortice.Visuals", "Vortice.Visuals\Vortice.Visuals.csproj", "{3CDB1662-C415-4A5A-BFF3-17A3CC96BC65}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -100,6 +104,14 @@ Global
 		{B51C4D23-F3EC-4E69-9CEA-76D340BD6749}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B51C4D23-F3EC-4E69-9CEA-76D340BD6749}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B51C4D23-F3EC-4E69-9CEA-76D340BD6749}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98A4BFCA-2DDE-4960-8B17-E28F660B7CBF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98A4BFCA-2DDE-4960-8B17-E28F660B7CBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98A4BFCA-2DDE-4960-8B17-E28F660B7CBF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98A4BFCA-2DDE-4960-8B17-E28F660B7CBF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CDB1662-C415-4A5A-BFF3-17A3CC96BC65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CDB1662-C415-4A5A-BFF3-17A3CC96BC65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CDB1662-C415-4A5A-BFF3-17A3CC96BC65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CDB1662-C415-4A5A-BFF3-17A3CC96BC65}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -108,6 +120,7 @@ Global
 		{58C451C2-994B-41E6-80C5-975C23D6ECF9} = {5676F50D-CC54-4DC6-980D-6B68FFF64065}
 		{5368F2D1-D113-4C92-ABBC-A6FC3DE781B2} = {5676F50D-CC54-4DC6-980D-6B68FFF64065}
 		{2246B81E-ED94-4DAD-8336-782CEDCD1795} = {5676F50D-CC54-4DC6-980D-6B68FFF64065}
+		{98A4BFCA-2DDE-4960-8B17-E28F660B7CBF} = {5676F50D-CC54-4DC6-980D-6B68FFF64065}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0734700-42E1-4F87-8DD2-0084849DA44A}

--- a/src/Vortice.XAudio2/XAudio2Native.cs
+++ b/src/Vortice.XAudio2/XAudio2Native.cs
@@ -15,7 +15,7 @@ namespace Vortice.XAudio2
 
         private static IntPtr LoadXAudio2()
         {
-            if (PlatformDetection.IsUAP)
+            if (VorticePlatformDetection.IsUAP)
             {
                 s_XAudio2CreateCallback = XAudio29.XAudio2Create;
                 s_CreateAudioReverb = XAudio29.CreateAudioReverb;

--- a/src/samples/HelloComposition/AnimationImpulseInterpolator.cs
+++ b/src/samples/HelloComposition/AnimationImpulseInterpolator.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Diagnostics;
+using SharpGen.Runtime;
+using Vortice.Animation;
+
+namespace HelloComposition
+{
+    public sealed class AnimationImpulseInterpolator : CallbackBase, IUIAnimationInterpolator, IUIAnimationInterpolator2
+    {
+        private double _mDuration; // Duration of the transition
+        private double _mInitialValue; // Initial value of the transition
+        private double _mFinalValue; // Final value of the transition
+        private double _mInitialVelocity; // Initial velocity of the transition
+        private double _mAbsoluteAcceleration; // The original acceleration passed to the interpolator
+        private double _mAcceleration; // Acceleration of the transition
+
+        public Result SetInitialValueAndVelocity(double initialValue, double initialVelocity)
+        {
+            _mInitialValue = initialValue;
+            _mInitialVelocity = initialVelocity;
+
+            _mAcceleration = _mFinalValue > _mInitialValue ? _mAbsoluteAcceleration : -_mAbsoluteAcceleration;
+
+            _mDuration =
+                (-_mInitialVelocity + (_mAcceleration < 0.0 ? -1.0 : 1.0) *
+                    Math.Sqrt(_mInitialVelocity * _mInitialVelocity +
+                              2.0 * _mAcceleration * (_mFinalValue - _mInitialValue)))
+                / _mAcceleration;
+
+            return Result.Ok;
+        }
+
+        public Result GetDimension(out int dimension)
+        {
+            dimension = 1;
+            
+            return Result.Ok;
+        }
+
+        public Result SetInitialValueAndVelocity(double[] initialValue, double[] initialVelocity)
+        {
+            Debug.Assert(initialValue.Length == 1);
+            Debug.Assert(initialVelocity.Length == 1);
+
+            return SetInitialValueAndVelocity(initialValue[0], initialVelocity[0]);
+        }
+
+        public Result SetDuration(double duration)
+        {
+            return Result.Fail;
+        }
+
+        public Result GetDuration(out double duration)
+        {
+            duration = _mDuration;
+
+            return Result.Ok;
+        }
+
+        public Result GetFinalValue(double[] value)
+        {
+            var result = GetFinalValue(out var value0);
+            value[0] = value0;
+            return result;
+        }
+
+        public Result InterpolateValue(double offset, double[] value)
+        {
+            var result = InterpolateValue(offset, out var value0);
+            value[0] = value0;
+            return result;
+        }
+
+        public Result InterpolateVelocity(double offset, double[] velocity)
+        {
+            var result = InterpolateVelocity(offset, out var velocity0);
+            velocity[0] = velocity0;
+            return result;
+        }
+
+        public Result GetPrimitiveInterpolation(IUIAnimationPrimitiveInterpolation interpolation, int cDimension)
+        {
+            return Result.Fail;
+        }
+
+        public Result GetFinalValue(out double value)
+        {
+            value = _mFinalValue;
+
+            return Result.Ok;
+        }
+
+        public Result InterpolateValue(double offset, out double value)
+        {
+            value = 0.5 * _mAcceleration * (offset * offset) + _mInitialVelocity * offset + _mInitialValue;
+
+            return Result.Ok;
+        }
+
+        public Result InterpolateVelocity(double offset, out double velocity)
+        {
+            velocity = _mAcceleration * offset + _mInitialVelocity;
+
+            return Result.Ok;
+        }
+
+        public Result GetDependencies(out AnimationDependencies initialValueDependencies,
+            out AnimationDependencies initialVelocityDependencies, out AnimationDependencies durationDependencies)
+        {
+            // The final value of the interpolator is not affected by the initial value or velocity, but
+            // the intermediate values, final velocity and duration all are affected
+
+            initialValueDependencies =
+                AnimationDependencies.IntermediateValues |
+                AnimationDependencies.FinalVelocity |
+                AnimationDependencies.Duration;
+
+            initialVelocityDependencies =
+                AnimationDependencies.IntermediateValues |
+                AnimationDependencies.FinalVelocity |
+                AnimationDependencies.Duration;
+
+            // This interpolator does not have a duration parameter, so SetDuration should not be called on it
+
+            durationDependencies = AnimationDependencies.None;
+
+            return Result.Ok;
+        }
+
+        private static AnimationImpulseInterpolator CreateInterpolator(double finalValue, double acceleration)
+        {
+            if (Math.Abs(acceleration) < 10 * double.Epsilon)
+                throw new ArgumentOutOfRangeException(nameof(acceleration), "Acceleration is too small");
+
+            return new AnimationImpulseInterpolator
+            {
+                _mAcceleration = acceleration,
+                _mFinalValue = finalValue
+            };
+        }
+
+        /// <summary>
+        /// Creates an impulse transition
+        /// </summary>
+        /// <param name="factory">The transition factory to use to wrap the interpolator</param>
+        /// <param name="finalValue">The final value this transition leads to when applied to an animation variable</param>
+        /// <param name="acceleration">The rate of change of the velocity</param>
+        /// <returns>The new impulse transition</returns>
+        /// <exception cref="ArgumentOutOfRangeException">When acceleration is too small by absolute value</exception>
+        public static IUIAnimationTransition CreateTransition(IUIAnimationTransitionFactory factory, double finalValue,
+            double acceleration)
+        {
+            return factory.CreateTransition(CreateInterpolator(finalValue, acceleration));
+        }
+
+        /// <summary>
+        /// Creates an impulse transition
+        /// </summary>
+        /// <param name="factory">The transition factory to use to wrap the interpolator</param>
+        /// <param name="finalValue">The final value this transition leads to when applied to an animation variable</param>
+        /// <param name="acceleration">The rate of change of the velocity</param>
+        /// <returns>The new impulse transition</returns>
+        /// <exception cref="ArgumentOutOfRangeException">When acceleration is too small by absolute value</exception>
+        public static IUIAnimationTransition2 CreateTransition(IUIAnimationTransitionFactory2 factory, double finalValue,
+            double acceleration)
+        {
+            return factory.CreateTransition(CreateInterpolator(finalValue, acceleration));
+        }
+    }
+}

--- a/src/samples/HelloComposition/CompositionDemoVisual.cs
+++ b/src/samples/HelloComposition/CompositionDemoVisual.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using SharpGen.Runtime;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Serilog;
+using Vortice.Direct2D1;
+using Vortice.Mathematics;
+
+namespace HelloComposition
+{
+    public sealed class CompositionDemoVisual : CompositionVisual
+    {
+        private const string RectangleBrushName = "RectangleBrush";
+        private const int _windowMargin = 20;
+
+        public CompositionDemoVisual([DisallowNull] CompositionGraphicsDevice device) : base(device, 40, 40)
+        {
+            Position.ConstraintAgents += PositionConstraintAgent;
+            
+            // Enable this when https://github.com/SharpGenTools/SharpGenTools/pull/161 yields some input
+            // Position.AnimationFactories += PositionAnimationFactory;
+            
+            Device.Schedule(ApplyImpulse);
+        }
+
+        private void PositionAnimationFactory(ref CompositionVisualPosition.AnimationFactoryArgs args)
+        {
+            args.Transition = AnimationImpulseInterpolator.CreateTransition(
+                Device.AnimationTransitionFactory,
+                args.TargetValue,
+                1.0
+            );
+        }
+
+        private void PositionConstraintAgent(ref CompositionVisualPosition.VariableConstraintAgentArgs args)
+        {
+            var size = Device.MainWindow.ClientSize;
+
+            ref var point = ref args.Value;
+            if (point.X < 0)
+                point.X = 0;
+            if (point.Y < 0)
+                point.Y = 0;
+            var windowWidth = size.Width - Width;
+            var windowHeight = size.Height - Height;
+            if (point.X >= windowWidth)
+                point.X = windowWidth;
+            if (point.Y >= windowHeight)
+                point.Y = windowHeight;
+        }
+
+        private void ApplyImpulse()
+        {
+            const double pi = Math.PI;
+            var (width, height) = Device.MainWindow.ClientSize;
+
+            if (width >= 10 && height >= 10)
+            {
+                var r = NextDouble(20, 200);
+
+                var phiExclusionRanges = new List<(double, double)>();
+
+                var (currentX, currentY) = Position.TargetPoint;
+                if (currentY < _windowMargin)
+                    phiExclusionRanges.Add((pi / 6, 5 * pi / 6));
+                if (currentX < _windowMargin)
+                    phiExclusionRanges.Add((2 * pi / 3, 4 * pi / 3));
+                if (currentY >= height - Height - _windowMargin)
+                    phiExclusionRanges.Add((7 * pi / 6, 11 * pi / 6));
+                if (currentX >= width - Width - _windowMargin)
+                {
+                    phiExclusionRanges.Add((0, pi / 3));
+                    phiExclusionRanges.Add((5 * pi / 3, 2 * pi));
+                }
+
+                if (phiExclusionRanges.Count != 0)
+                    Log.Verbose(
+                        "[Demo] Impulse restricted angles: {Angles} for [{X};{Y}]",
+                        phiExclusionRanges,
+                        currentX, currentY
+                    );
+
+                uint attempts = 0;
+                bool retryRandom;
+                double phi;
+                do
+                {
+                    ++attempts;
+                    phi = NextDouble(0, 2 * pi);
+                    retryRandom = false;
+
+                    foreach (var (from, to) in phiExclusionRanges)
+                    {
+                        if (phi >= from && phi <= to)
+                            retryRandom = true;
+                    }
+                } while (retryRandom && attempts <= 5);
+
+                if (!retryRandom)
+                {
+                    var (x, y) = (r * Math.Cos(phi), r * Math.Sin(phi));
+                    Position.AnimateToRelativeOffset(new PointF((float)x, (float)y));
+                }
+            }
+
+            Device.Schedule(TimeSpan.FromMilliseconds(NextDouble(500, 1500)), ApplyImpulse);
+        }
+
+        public double NextDouble(double minValue, double maxValue)
+        {
+            return Device.Random.NextDouble() * (maxValue - minValue) + minValue;
+        }
+
+        protected override void DrawImpl(ID2D1DeviceContext context, IReadOnlyDictionary<string, ComObject> resources,
+            Point offset)
+        {
+            if (!resources.TryGetValue(RectangleBrushName, out var brushObject))
+            {
+                ResourcesMissing = true;
+                return;
+            }
+
+            if (!(brushObject is ID2D1Brush brush))
+            {
+                return;
+            }
+
+            context.DrawRectangle(new RectangleF(offset.X, offset.Y, 40, 40), brush);
+        }
+
+        public override void CreateResources(IDictionary<string, ComObject> resources, ID2D1DeviceContext context)
+        {
+            Log.Verbose("[Demo] CreateResources [{Id}]", RuntimeHelpers.GetHashCode(this));
+            var clearColor = new Color4(0.8f, 0.8f, 1f, 1.0f);
+            resources[RectangleBrushName] = context.CreateSolidColorBrush(clearColor);
+        }
+    }
+}

--- a/src/samples/HelloComposition/CompositionGraphicsDevice.Window.cs
+++ b/src/samples/HelloComposition/CompositionGraphicsDevice.Window.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Vortice;
+using Vortice.Win32;
+
+namespace HelloComposition
+{
+    public sealed partial class CompositionGraphicsDevice
+    {
+        private const string _wndClassName = "Vortice.DirectComposition.Window";
+        public readonly IntPtr HInstance = Kernel32.GetModuleHandle(null);
+
+        private void PlatformConstruct()
+        {
+            _wndProc = ProcessWindowMessage;
+            var wndClassEx = new WNDCLASSEX
+            {
+                Size = Unsafe.SizeOf<WNDCLASSEX>(),
+                Styles = WindowClassStyles.CS_HREDRAW | WindowClassStyles.CS_VREDRAW | WindowClassStyles.CS_OWNDC,
+                WindowProc = _wndProc,
+                InstanceHandle = HInstance,
+                CursorHandle = User32.LoadCursor(IntPtr.Zero, SystemCursor.IDC_ARROW),
+                BackgroundBrushHandle = IntPtr.Zero,
+                IconHandle = IntPtr.Zero,
+                ClassName = _wndClassName
+            };
+
+            var atom = User32.RegisterClassEx(ref wndClassEx);
+
+            if (atom == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to register window class. Error: {Marshal.GetLastWin32Error()}"
+                );
+            }
+
+            // Create main window.
+            MainWindow = new Window("Vortice", 800, 600, _wndClassName);
+        }
+
+        public void Run()
+        {
+            while (!_exitRequested)
+            {
+                if (!_paused)
+                {
+                    const uint PM_REMOVE = 1;
+                    if (User32.PeekMessage(out var msg, IntPtr.Zero, 0, 0, PM_REMOVE))
+                    {
+                        User32.TranslateMessage(ref msg);
+                        User32.DispatchMessage(ref msg);
+
+                        if (msg.Value == (uint)WindowMessage.Quit)
+                        {
+                            _exitRequested = true;
+                            break;
+                        }
+                    }
+                    
+                    ProcessDispatcherQueue();
+
+                    DrawFrame();
+                }
+                else
+                {
+                    var ret = User32.GetMessage(out var msg, IntPtr.Zero, 0, 0);
+                    if (ret == 0)
+                    {
+                        _exitRequested = true;
+                        break;
+                    }
+
+                    if (ret == -1)
+                    {
+                        //Log.Error("[Win32] - Failed to get message");
+                        _exitRequested = true;
+                        break;
+                    }
+
+                    User32.TranslateMessage(ref msg);
+                    User32.DispatchMessage(ref msg);
+                    
+                    ProcessDispatcherQueue();
+                }
+            }
+        }
+
+        private IntPtr ProcessWindowMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+        {
+            if (msg == (uint)WindowMessage.ActivateApp)
+            {
+                _paused = IntPtrToInt32(wParam) == 0;
+
+                return User32.DefWindowProc(hWnd, msg, wParam, lParam);
+            }
+
+            switch ((WindowMessage)msg)
+            {
+                case WindowMessage.Destroy:
+                    User32.PostQuitMessage(0);
+                    break;
+            }
+
+            return User32.DefWindowProc(hWnd, msg, wParam, lParam);
+        }
+
+        private static int IntPtrToInt32(IntPtr intPtr)
+        {
+            return (int)intPtr.ToInt64();
+        }
+    }
+}

--- a/src/samples/HelloComposition/CompositionGraphicsDevice.cs
+++ b/src/samples/HelloComposition/CompositionGraphicsDevice.cs
@@ -1,0 +1,328 @@
+﻿using SharpGen.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using C5;
+using Vortice;
+using Vortice.Animation;
+using Vortice.Direct2D1;
+using Vortice.Direct3D;
+using Vortice.Direct3D11;
+using Vortice.DirectComposition;
+using Vortice.DXGI;
+using Vortice.Win32;
+
+namespace HelloComposition
+{
+    public sealed partial class CompositionGraphicsDevice : IDisposable
+    {
+        private static readonly Vortice.Direct3D.FeatureLevel[] s_featureLevels =
+        {
+            Vortice.Direct3D.FeatureLevel.Level_11_1, Vortice.Direct3D.FeatureLevel.Level_11_0
+        };
+
+        private const int FrameCount = 2;
+
+        private readonly IDXGIFactory2 _factory;
+        private readonly ID2D1Factory1 _factory2D;
+        private readonly IDXGIDevice1 _device;
+        private readonly ID3D11Device _device3D;
+        private readonly ID2D1Device _device2D;
+        
+        
+        private readonly ID3D11DeviceContext _deviceContext3D;
+        private readonly ID2D1DeviceContext _deviceContext2D;
+        private readonly IDXGISwapChain _swapChain;
+        private readonly IDXGISurface _surface;
+        private readonly ID2D1Bitmap _bitmap2D;
+        private readonly IDCompositionTarget _compositionTarget;
+        private readonly IDCompositionVisual _rootVisual;
+        
+        private double _lastNextEstimatedFrameTime;
+
+        [NotNull] public Stopwatch DispatcherTimer { get; } = new Stopwatch();
+        [NotNull] public IDCompositionDesktopDevice CompositionDevice { get; }
+        [NotNull] public IDCompositionSurfaceFactory CompositionSurfaceFactory { get; }
+        [NotNull] public IUIAnimationManager2 AnimationManager { get; }
+        [NotNull] public IUIAnimationTransitionLibrary2 AnimationTransitionLibrary { get; }
+        [NotNull] public IUIAnimationTransitionFactory2 AnimationTransitionFactory { get; }
+        [NotNull] public Random Random { get; } = new Random();
+        
+        [NotNull] private readonly System.Collections.Generic.IList<CompositionVisual> _visuals = new List<CompositionVisual>();
+        [NotNull] private readonly Dictionary<string, ComObject> _resources = new Dictionary<string, ComObject>();
+        
+        [NotNull] private readonly System.Collections.Generic.IList<CompositionVisual> _graphicsInvalidatedVisuals = new List<CompositionVisual>();
+        [NotNull] private readonly System.Collections.Generic.IList<CompositionVisual> _compositionInvalidatedVisuals = new List<CompositionVisual>();
+        [NotNull] private readonly System.Collections.Generic.IList<CompositionVisual> _positionAnimationInvalidatedVisuals = new List<CompositionVisual>();
+        [NotNull] private readonly TreeDictionary<long, Queue<Action>> _scheduleWithTime = new TreeDictionary<long, Queue<Action>>();
+        [NotNull] private readonly Queue<Action> _scheduleQueue = new Queue<Action>();
+        
+        private WNDPROC _wndProc;
+        private bool _paused;
+        private bool _exitRequested;
+        public Window MainWindow { get; private set; }
+
+        private void OnDraw()
+        {
+            var requiresCommit = false;
+
+            if (_graphicsInvalidatedVisuals.Count != 0)
+            {
+                requiresCommit = true;
+
+                foreach (var visual in _graphicsInvalidatedVisuals)
+                {
+                    visual._hasGraphicsInvalidated = false;
+                    
+                    visual.Draw(_resources);
+                }
+
+                _graphicsInvalidatedVisuals.Clear();
+            }
+
+            if (_compositionInvalidatedVisuals.Count != 0)
+            {
+                requiresCommit = true;
+
+                foreach (var visual in _compositionInvalidatedVisuals)
+                {
+                    visual._hasCompositionInvalidated = false;
+                    
+                    visual.Composite();
+                }
+
+                _compositionInvalidatedVisuals.Clear();
+            }
+            
+            var frameStats = CompositionDevice.FrameStatistics;
+ 
+            var nextEstimatedFrameTime = (double)frameStats.NextEstimatedFrameTime / frameStats.TimeFrequency;
+
+            if (nextEstimatedFrameTime <= _lastNextEstimatedFrameTime)
+                nextEstimatedFrameTime = _lastNextEstimatedFrameTime + 2 * double.Epsilon;
+
+            _lastNextEstimatedFrameTime = nextEstimatedFrameTime;
+                    
+            AnimationManager.Update(nextEstimatedFrameTime);
+
+            if (_positionAnimationInvalidatedVisuals.Count != 0)
+            {
+                requiresCommit = true;
+                
+                foreach (var visual in _positionAnimationInvalidatedVisuals)
+                {
+                    visual._hasPositionAnimationInvalidated = false;
+                    
+                    visual.Position.AnimationCommit.Commit(nextEstimatedFrameTime);
+                    visual.Position.AnimationCommit.Dispose();
+                    visual.Position.AnimationCommit = null;
+                }
+
+                _positionAnimationInvalidatedVisuals.Clear();
+            }
+
+            if (requiresCommit)
+            {
+                CompositionDevice.Commit();
+            }
+        }
+
+        public CompositionGraphicsDevice(bool validation)
+        {
+            DXGI.CreateDXGIFactory2(validation, out _factory).CheckError();
+            var factory2DOptions = new FactoryOptions
+            {
+                DebugLevel = validation ? DebugLevel.Information : DebugLevel.None
+            };
+            D2D1.D2D1CreateFactory(FactoryType.SingleThreaded, factory2DOptions, out _factory2D).CheckError();
+            AnimationManager = new IUIAnimationManager2();
+            AnimationTransitionLibrary = new IUIAnimationTransitionLibrary2();
+            AnimationTransitionFactory = new IUIAnimationTransitionFactory2();
+
+            var creationFlags = DeviceCreationFlags.BgraSupport;
+            if (validation)
+                creationFlags |= DeviceCreationFlags.Debug;
+
+            if (D3D11.D3D11CreateDevice(
+                null,
+                DriverType.Hardware,
+                creationFlags,
+                s_featureLevels,
+                out _device3D, out _, out _deviceContext3D).Failure)
+            {
+                // Remove debug flag not being supported.
+                creationFlags &= ~DeviceCreationFlags.Debug;
+
+                D3D11.D3D11CreateDevice(null, DriverType.Hardware,
+                    creationFlags, s_featureLevels,
+                    out _device3D, out _, out _deviceContext3D).CheckError();
+            }
+
+            _device = _device3D.QueryInterface<IDXGIDevice1>();
+            _device2D = _factory2D.CreateDevice(_device);
+            _deviceContext2D = _device2D.CreateDeviceContext(DeviceContextOptions.None);
+            _device.MaximumFrameLatency = 1;
+
+            PlatformConstruct();
+
+            var (width, height) = MainWindow.ClientSize;
+
+            var swapChainDescription = new SwapChainDescription1
+            {
+                BufferCount = FrameCount,
+                SampleDescription = new SampleDescription(1, 0),
+                SwapEffect = SwapEffect.FlipSequential,
+                Usage = Vortice.DXGI.Usage.RenderTargetOutput,
+                Format = Format.B8G8R8A8_UNorm,
+                AlphaMode = Vortice.DXGI.AlphaMode.Premultiplied,
+                Width = width,
+                Height = height
+            };
+
+            _swapChain = _factory.CreateSwapChainForComposition(_device3D, swapChainDescription);
+            _factory.MakeWindowAssociation(MainWindow.Handle, WindowAssociationFlags.IgnoreAltEnter);
+
+            var dpi = User32.GetDpiForWindow(MainWindow.Handle);
+            var bitmapProperties = new BitmapProperties1
+            {
+                BitmapOptions = BitmapOptions.CannotDraw | BitmapOptions.Target,
+                PixelFormat = new PixelFormat(Format.B8G8R8A8_UNorm, Vortice.Direct2D1.AlphaMode.Premultiplied),
+                DpiX = dpi,
+                DpiY = dpi
+            };
+
+            _surface = _swapChain.GetBuffer<IDXGISurface>(0);
+            _bitmap2D = _deviceContext2D.CreateBitmapFromDxgiSurface(_surface, bitmapProperties);
+            _deviceContext2D.SetTarget(_bitmap2D);
+
+            CompositionDevice = new IDCompositionDesktopDevice(_device);
+            _compositionTarget = IDCompositionTarget.FromHwnd(CompositionDevice, MainWindow.Handle, true);
+            CompositionSurfaceFactory = new IDCompositionSurfaceFactory(CompositionDevice, _device2D);
+
+            _rootVisual = new IDCompositionVisual2(CompositionDevice);
+            _compositionTarget.Root = _rootVisual;
+            CompositionDevice.Commit();
+            
+            _scheduleWithTime.ItemsRemoved += ScheduleWithTimeOnItemsRemoved;
+            DispatcherTimer.Start();
+        }
+
+        public void Dispose()
+        {
+            // Stop the Dispatcher
+            DispatcherTimer.Stop();
+            _scheduleQueue.Clear();
+            _scheduleWithTime.ItemsRemoved -= ScheduleWithTimeOnItemsRemoved; 
+            _scheduleWithTime.Clear();
+            
+            
+            // Drop the visual tree
+            _graphicsInvalidatedVisuals.Clear();
+            _compositionInvalidatedVisuals.Clear();
+            foreach (var resource in _resources.Values)
+                resource.Dispose();
+            foreach (var visual in _visuals)
+                visual.Dispose();
+            _resources.Clear();
+            _compositionTarget.Root = null;
+            _rootVisual.Dispose();
+            
+            // Drop the rest of the graphics stack
+            CompositionSurfaceFactory.Dispose();
+            _compositionTarget.Dispose();
+            CompositionDevice.Dispose();
+            _bitmap2D.Dispose();
+            _surface.Dispose();
+            _deviceContext2D.Dispose();
+            _device2D.Dispose();
+            _deviceContext3D.ClearState();
+            _deviceContext3D.Flush();
+            _deviceContext3D.Dispose();
+            _device3D.Dispose();
+            _device.Dispose();
+            _swapChain.Dispose();
+            AnimationTransitionLibrary.Dispose();
+            AnimationManager.Dispose();
+            _factory2D.Dispose();
+            _factory.Dispose();
+        }
+
+        private void ScheduleWithTimeOnItemsRemoved(object sender, ItemCountEventArgs<C5.KeyValuePair<long, Queue<Action>>> eventargs)
+        {
+            while (eventargs.Item.Value.TryDequeue(out var action)) action();
+        }
+
+        public bool DrawFrame()
+        {
+            _deviceContext2D.BeginDraw();
+
+            OnDraw();
+
+            _deviceContext2D.EndDraw().CheckError();
+
+            var result = _swapChain.Present(1, PresentFlags.None);
+            return !result.Failure || result.Code != Vortice.DXGI.ResultCode.DeviceRemoved.Code;
+        }
+
+        public void AddVisual(CompositionVisual visual)
+        {
+            _visuals.Add(visual);
+            _rootVisual.AddVisual(visual.Visual, true, null);
+            visual.CompositionInvalidated += VisualOnCompositionInvalidated;
+            visual.GraphicsInvalidated += VisualOnGraphicsInvalidated;
+            visual.PositionAnimationInvalidated += VisualOnPositionAnimationInvalidated;
+            visual._hasCompositionInvalidated = false;
+            visual._hasGraphicsInvalidated = false;
+            visual._hasPositionAnimationInvalidated = false;
+            visual.OnCompositionInvalidated();
+            visual.OnGraphicsInvalidated();
+            visual.OnPositionAnimationInvalidated();
+        }
+
+        private void VisualOnPositionAnimationInvalidated(CompositionVisual sender)
+        {
+            _positionAnimationInvalidatedVisuals.Add(sender);
+        }
+
+        private void VisualOnGraphicsInvalidated(CompositionVisual sender)
+        {
+            _graphicsInvalidatedVisuals.Add(sender);
+        }
+
+        private void VisualOnCompositionInvalidated(CompositionVisual sender)
+        {
+            _compositionInvalidatedVisuals.Add(sender);
+        }
+
+        public void Schedule(TimeSpan delay, Action action)
+        {
+            if (_exitRequested)
+                return;
+
+            var key = (long) Math.Ceiling(DispatcherTimer.ElapsedMilliseconds + delay.TotalMilliseconds);
+            var queue = new Queue<Action>();
+            _scheduleWithTime.FindOrAdd(key, ref queue);
+            queue.Enqueue(action);
+        }
+
+        public void Schedule(Action action)
+        {
+            if (_exitRequested)
+                return;
+
+            _scheduleQueue.Enqueue(action);
+        }
+
+        public void ProcessDispatcherQueue()
+        {
+            if (_exitRequested)
+                return;
+            
+            while (_scheduleQueue.TryDequeue(out var action))
+                action();
+
+            _scheduleWithTime.RemoveRangeTo(DispatcherTimer.ElapsedMilliseconds);
+        }
+    }
+}

--- a/src/samples/HelloComposition/CompositionVisual.cs
+++ b/src/samples/HelloComposition/CompositionVisual.cs
@@ -1,0 +1,192 @@
+﻿using SharpGen.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Vortice.Direct2D1;
+using Vortice.DirectComposition;
+using Vortice.DXGI;
+using Vortice.Mathematics;
+using Color = System.Drawing.Color;
+using AlphaMode = Vortice.DXGI.AlphaMode;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using Serilog;
+
+namespace HelloComposition
+{
+    public abstract class CompositionVisual : IDisposable
+    {
+        public int Width { get; }
+        public int Height { get; }
+        [MaybeNull] public IDCompositionVisual2 Visual { get; private set; }
+        [MaybeNull] public CompositionVisualPosition Position { get; private set; }
+        [MaybeNull] public IDCompositionSurface SurfaceComposition { get; private set; }
+        protected bool ResourcesMissing { get; set; }
+        [MaybeNull] protected CompositionGraphicsDevice Device { get; private set; }
+
+        private Color4 _background = new Color4(Color.Transparent);
+
+        private const int SurfaceMargin = 2;
+
+        public Color4 Background
+        {
+            get
+            {
+                return _background;
+            }
+
+            set
+            {
+                if (_background == value)
+                {
+                    return;
+                }
+
+                _background = value;
+                OnGraphicsInvalidated();
+            }
+        }
+
+        protected CompositionVisual([DisallowNull] CompositionGraphicsDevice device, int width, int height)
+        {
+            Device = device ?? throw new ArgumentNullException(nameof(device));
+            Width = width;
+            Height = height;
+            Visual = new IDCompositionVisual2(device.CompositionDevice);
+            Position = new CompositionVisualPosition(device, this);
+            SurfaceComposition = new IDCompositionSurface(device.CompositionSurfaceFactory, width + 2 * SurfaceMargin,
+                height + 2 * SurfaceMargin,
+                Format.B8G8R8A8_UNorm, AlphaMode.Premultiplied);
+            Visual.Content = SurfaceComposition;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Position?.Dispose();
+                SurfaceComposition?.Dispose();
+                Visual?.Dispose();
+                Position = null;
+                SurfaceComposition = null;
+                Visual = null;
+                Device = null;
+            }
+        }
+
+        protected abstract void DrawImpl(ID2D1DeviceContext context, IReadOnlyDictionary<string, ComObject> resources,
+            Point offset);
+
+        public virtual void Draw(Dictionary<string, ComObject> resources)
+        {
+            if (SurfaceComposition is null || Visual is null)
+                return;
+
+            using var context = SurfaceComposition.BeginDraw<ID2D1DeviceContext>(null, out var offset);
+            var transform = context.Transform;
+            transform.Translation = new Vector2(2, 2);
+            context.Transform = transform;
+
+            if (ResourcesMissing)
+            {
+                ResourcesMissing = false;
+                CreateResources(resources, context);
+            }
+
+            if (!ResourcesMissing)
+            {
+                // We've successfully created resources (if it was needed)
+
+                context.Clear(Background);
+                DrawImpl(context, resources, offset);
+
+                if (ResourcesMissing)
+                {
+                    // Create resources...
+
+                    ResourcesMissing = false;
+                    CreateResources(resources, context);
+
+                    if (!ResourcesMissing)
+                    {
+                        // ... and retry
+
+                        context.Clear(Background);
+                        DrawImpl(context, resources, offset);
+                    }
+                }
+            }
+
+            SurfaceComposition.EndDraw();
+        }
+
+        public virtual void Composite()
+        {
+        }
+
+        public virtual void CreateResources(IDictionary<string, ComObject> resources, ID2D1DeviceContext context)
+        {
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public delegate void VisualInvalidatedEventHandler(CompositionVisual sender);
+
+        public event VisualInvalidatedEventHandler CompositionInvalidated;
+        public event VisualInvalidatedEventHandler GraphicsInvalidated;
+        public event VisualInvalidatedEventHandler PositionAnimationInvalidated;
+
+        internal bool _hasCompositionInvalidated;
+        internal bool _hasGraphicsInvalidated;
+        internal bool _hasPositionAnimationInvalidated;
+
+        protected internal void OnCompositionInvalidated([CallerMemberName] string propertyName = null)
+        {
+            Log.Verbose(
+                "[Visual] OnCompositionInvalidated [{Id}][{Source}][{PreviousState}]",
+                RuntimeHelpers.GetHashCode(this),
+                propertyName,
+                _hasCompositionInvalidated
+            );
+            
+            if (_hasCompositionInvalidated) return;
+
+            _hasCompositionInvalidated = true;
+            CompositionInvalidated?.Invoke(this);
+        }
+
+        protected internal void OnGraphicsInvalidated([CallerMemberName] string propertyName = null)
+        {
+            Log.Verbose(
+                "[Visual] OnGraphicsInvalidated [{Id}][{Source}][{PreviousState}]",
+                RuntimeHelpers.GetHashCode(this),
+                propertyName,
+                _hasGraphicsInvalidated
+            );
+
+            if (_hasGraphicsInvalidated) return;
+
+            _hasGraphicsInvalidated = true;
+            GraphicsInvalidated?.Invoke(this);
+        }
+
+        protected internal void OnPositionAnimationInvalidated([CallerMemberName] string propertyName = null)
+        {
+            Log.Verbose(
+                "[Visual] OnPositionAnimationInvalidated [{Id}][{Source}][{PreviousState}]",
+                RuntimeHelpers.GetHashCode(this),
+                propertyName,
+                _hasPositionAnimationInvalidated
+            );
+
+            if (_hasPositionAnimationInvalidated) return;
+
+            _hasPositionAnimationInvalidated = true;
+            PositionAnimationInvalidated?.Invoke(this);
+        }
+    }
+}

--- a/src/samples/HelloComposition/CompositionVisualPosition.AnimationFactory.cs
+++ b/src/samples/HelloComposition/CompositionVisualPosition.AnimationFactory.cs
@@ -1,0 +1,47 @@
+using Vortice.Animation;
+
+namespace HelloComposition
+{
+    public sealed partial class CompositionVisualPosition
+    {
+        public delegate void AnimationFactory(ref AnimationFactoryArgs args);
+
+        public ref struct AnimationFactoryArgs
+        {
+            public readonly float PreviousTargetValue;
+            public readonly float TargetValue;
+            public IUIAnimationTransition2 Transition;
+
+            internal AnimationFactoryArgs(float previousTargetValue, float targetValue)
+            {
+                PreviousTargetValue = previousTargetValue;
+                TargetValue = targetValue;
+                Transition = null;
+            }
+        }
+
+        public event AnimationFactory AnimationFactories;
+
+        private IUIAnimationTransition2 CreateAnimation(float previousTargetValue, float targetValue)
+        {
+            var args = new AnimationFactoryArgs(previousTargetValue, targetValue);
+
+            AnimationFactories?.Invoke(ref args);
+
+            if (args.Transition is null)
+                DefaultAnimationFactory(ref args);
+
+            return args.Transition;
+        }
+
+        private void DefaultAnimationFactory(ref AnimationFactoryArgs args)
+        {
+            args.Transition = _graphicsDevice.AnimationTransitionLibrary.AccelerateDecelerate(
+                1,
+                args.TargetValue,
+                0.5,
+                0.5
+            );
+        }
+    }
+}

--- a/src/samples/HelloComposition/CompositionVisualPosition.Constraints.cs
+++ b/src/samples/HelloComposition/CompositionVisualPosition.Constraints.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Runtime.InteropServices;
+using Serilog;
+using Vortice.Animation;
+using Vortice.DirectComposition;
+using Vortice.Mathematics;
+
+namespace HelloComposition
+{
+    public sealed partial class CompositionVisualPosition
+    {
+        /// <summary>
+        /// Delegate which verifies the proposed variable value and modifies it as necessary. If the constraint still can't be satisfied - aborts the operation.
+        /// </summary>
+        /// <param name="args">Event args with variable value</param>
+        /// <returns>true if the point now satisfies the constraint, false means operation abort</returns>
+        public delegate void VariableConstraintAgent(ref VariableConstraintAgentArgs args);
+
+        public ref struct VariableConstraintAgentArgs
+        {
+            private readonly Span<PointF> _value;
+
+            internal VariableConstraintAgentArgs(ref PointF value)
+            {
+                _value = MemoryMarshal.CreateSpan(ref value, 1);
+                Cancel = false;
+            }
+
+            public ref PointF Value => ref _value[0];
+            public bool Cancel;
+        }
+
+        public event VariableConstraintAgent ConstraintAgents;
+
+        private void InvokeConstraintAgents(ref VariableConstraintAgentArgs args)
+        {
+            var agents = ConstraintAgents?.GetInvocationList();
+            if (agents is null || agents.Length == 0) return;
+
+            foreach (var agentDelegate in agents)
+            {
+                if (agentDelegate is VariableConstraintAgent agent)
+                    agent(ref args);
+
+                if (args.Cancel)
+                    break;
+            }
+        }
+
+        private bool TryApplyValue(PointF value)
+        {
+            if (_visual is null || _graphicsDevice is null || _x is null || _y is null)
+                return false;
+            
+            var args = new VariableConstraintAgentArgs(ref value);
+            InvokeConstraintAgents(ref args);
+
+            var (newX, newY) = args.Value;
+            
+            if (args.Cancel)
+            {
+                Log.Verbose("[Visual] ConstraintAgents [{X};{Y}] -> Cancel", newX, newY);
+                return false;
+            }
+
+            if (!(AnimationCommit is null))
+            {
+                Log.Warning("[Visual] AnimationCommit was not committed when creating next commit request");
+                AnimationCommit.Dispose();
+                AnimationCommit = null;
+            }
+
+            AnimationCommit = new CompositionVisualPositionAnimationCommit(this)
+            {
+                XComposition = new IDCompositionAnimation(_graphicsDevice.CompositionDevice),
+                YComposition = new IDCompositionAnimation(_graphicsDevice.CompositionDevice),
+                Storyboard = new IUIAnimationStoryboard2(_graphicsDevice.AnimationManager)
+            };
+
+            using var xTransition = CreateAnimation(_targetPoint.X, newX);
+            AnimationCommit.Storyboard.AddTransition(_x, xTransition);
+            _targetPoint.X = newX;
+
+            using var yTransition = CreateAnimation(_targetPoint.Y, newY);
+            AnimationCommit.Storyboard.AddTransition(_y, yTransition);
+            _targetPoint.Y = newY;
+
+            _visual.OnPositionAnimationInvalidated();
+            
+            return true;
+        }
+    }
+}

--- a/src/samples/HelloComposition/CompositionVisualPosition.cs
+++ b/src/samples/HelloComposition/CompositionVisualPosition.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Vortice.Animation;
+using Vortice.DirectComposition;
+using Vortice.Mathematics;
+
+namespace HelloComposition
+{
+    public sealed partial class CompositionVisualPosition : IDisposable
+    {
+        internal CompositionVisualPosition([DisallowNull] CompositionGraphicsDevice graphicsDevice,
+            [DisallowNull] CompositionVisual visual)
+        {
+            _graphicsDevice = graphicsDevice ?? throw new ArgumentNullException(nameof(graphicsDevice));
+            _visual = visual ?? throw new ArgumentNullException(nameof(visual));
+            var animationManager = _graphicsDevice.AnimationManager;
+            var point = new PointF(20, 20);
+            _x = new IUIAnimationVariable2(animationManager, point.X);
+            _y = new IUIAnimationVariable2(animationManager, point.Y);
+            AnimateToPoint(point);
+        }
+        [MaybeNull] internal CompositionVisualPositionAnimationCommit AnimationCommit;
+        [MaybeNull] private CompositionVisual _visual;
+        [MaybeNull] private CompositionGraphicsDevice _graphicsDevice;
+        [MaybeNull] private IUIAnimationVariable2 _x;
+        [MaybeNull] private IUIAnimationVariable2 _y;
+        private PointF _targetPoint;
+
+        public PointF TargetPoint => _targetPoint;
+        
+        internal sealed class CompositionVisualPositionAnimationCommit : IDisposable
+        {
+            public IDCompositionAnimation XComposition;
+            public IDCompositionAnimation YComposition;
+            public IUIAnimationStoryboard2 Storyboard;
+            private CompositionVisualPosition _position;
+
+            public CompositionVisualPositionAnimationCommit([DisallowNull] CompositionVisualPosition position)
+            {
+                _position = position ?? throw new ArgumentNullException(nameof(position));
+            }
+
+            public void Commit(double nextEstimatedFrameTime)
+            {
+                Storyboard.Schedule(nextEstimatedFrameTime);
+                
+                _position._x.GetCurve(XComposition);
+                _position._y.GetCurve(YComposition);
+                _position._visual.Visual.SetOffsetX(XComposition);
+                _position._visual.Visual.SetOffsetY(YComposition);
+            }
+
+            public void Dispose()
+            {
+                XComposition?.Dispose();
+                YComposition?.Dispose();
+                Storyboard?.Dispose();
+                XComposition = null;
+                YComposition = null;
+                Storyboard = null;
+                _position = null;
+            }
+        }
+
+        public bool AnimateToPoint(PointF point)
+        {
+            return TryApplyValue(point);
+        }
+
+        public bool AnimateToRelativeOffset(PointF point)
+        {
+            return TryApplyValue(_targetPoint + point);
+        }
+
+        public void Dispose()
+        {
+            AnimationCommit?.Dispose();
+            _x?.Dispose();
+            _y?.Dispose();
+            AnimationCommit = null;
+            _x = null;
+            _y = null;
+            _visual = null;
+            _graphicsDevice = null;
+        }
+    }
+}

--- a/src/samples/HelloComposition/HelloComposition.csproj
+++ b/src/samples/HelloComposition/HelloComposition.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Vortice.Direct2D1\Vortice.Direct2D1.csproj" />
+    <ProjectReference Include="..\..\Vortice.Direct3D11\Vortice.Direct3D11.csproj" />
+    <ProjectReference Include="..\..\Vortice.Visuals\Vortice.Visuals.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="C5" Version="3.0.0-beta" />
+    <PackageReference Include="Serilog" Version="2.9.1-dev-01154" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.2-dev-00020" />
+  </ItemGroup>
+
+</Project>

--- a/src/samples/HelloComposition/Program.cs
+++ b/src/samples/HelloComposition/Program.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Serilog;
+using SharpGen.Runtime;
+using SharpGen.Runtime.Diagnostics;
+
+namespace HelloComposition
+{
+    internal class Program
+    {
+        static void Main()
+        {
+            var validation = false;
+#if DEBUG
+            Configuration.EnableObjectTracking = true;
+            validation = true;
+#endif
+            
+            Log.Logger = new LoggerConfiguration().MinimumLevel.Verbose().WriteTo.Debug().CreateLogger();
+
+            using (var app = new CompositionGraphicsDevice(validation))
+            {
+                for (var i = 0; i < 50; i++)
+                {
+                    app.AddVisual(new CompositionDemoVisual(app));                    
+                }
+                
+                app.Run();
+            }
+
+#if DEBUG
+            Console.WriteLine(ObjectTracker.ReportActiveObjects());
+#endif
+        }
+    }
+}

--- a/src/samples/HelloComposition/Win32/Kernel32.cs
+++ b/src/samples/HelloComposition/Win32/Kernel32.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Amer Koleci and contributors.
+// Distributed under the MIT license. See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Vortice.Win32
+{
+    internal static class Kernel32
+    {
+        public const string Name = "kernel32";
+
+        [DllImport(Name)]
+        public static extern IntPtr LoadLibrary(string fileName);
+
+        [DllImport(Name, CharSet = CharSet.Ansi, BestFitMapping = false)]
+        public static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
+
+        [DllImport(Name, ExactSpelling = true, SetLastError = true)]
+        public static extern bool FreeLibrary([In] IntPtr hModule);
+
+        [DllImport(Name)]
+        public static extern IntPtr GetModuleHandle(string lpModuleName);
+
+        [DllImport(Name)]
+        public static extern IntPtr GetCurrentProcess();
+
+        [DllImport(Name)]
+        public static extern IntPtr GetCurrentThread();
+
+        [return: MarshalAs(UnmanagedType.U1)]
+        [DllImport(Name, SetLastError = true)]
+        public static extern bool GetProcessAffinityMask(IntPtr hProcess, out UIntPtr lpProcessAffinityMask, out UIntPtr lpSystemAffinityMask);
+
+        [DllImport(Name)]
+        public static extern UIntPtr SetThreadAffinityMask(IntPtr hThread, UIntPtr dwThreadAffinityMask);
+    }
+}

--- a/src/samples/HelloComposition/Win32/User32.cs
+++ b/src/samples/HelloComposition/Win32/User32.cs
@@ -1,0 +1,524 @@
+﻿// Copyright (c) Amer Koleci and contributors.
+// Distributed under the MIT license. See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Vortice.Mathematics;
+
+namespace Vortice.Win32
+{
+    #region Enums
+    [Flags]
+    public enum WindowStyles
+    {
+        WS_BORDER = 0x00800000,
+        WS_CAPTION = 0x00C00000,
+        WS_CHILD = 0x40000000,
+        WS_CHILDWINDOW = 0x40000000,
+        WS_CLIPCHILDREN = 0x02000000,
+        WS_CLIPSIBLINGS = 0x04000000,
+        WS_DISABLED = 0x08000000,
+        WS_DLGFRAME = 0x00400000,
+        WS_GROUP = 0x00020000,
+        WS_HSCROLL = 0x00100000,
+        WS_ICONIC = 0x20000000,
+        WS_MAXIMIZE = 0x01000000,
+        WS_MAXIMIZEBOX = 0x00010000,
+        WS_MINIMIZE = 0x20000000,
+        WS_MINIMIZEBOX = 0x00020000,
+        WS_OVERLAPPED = 0x00000000,
+        WS_OVERLAPPEDWINDOW =
+            WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX,
+        WS_POPUP = unchecked((int)0x80000000),
+        WS_POPUPWINDOW = WS_POPUP | WS_BORDER | WS_SYSMENU,
+        WS_SIZEBOX = 0x00040000,
+        WS_SYSMENU = 0x00080000,
+        WS_TABSTOP = 0x00010000,
+        WS_THICKFRAME = 0x00040000,
+        WS_TILED = 0x00000000,
+        WS_TILEDWINDOW = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX,
+        WS_VISIBLE = 0x10000000,
+        WS_VSCROLL = 0x00200000
+    }
+
+    [Flags]
+    public enum WindowExStyles : uint
+    {
+        WS_EX_LEFT = 0x00000000,
+        WS_EX_LTRREADING = 0x00000000,
+        WS_EX_RIGHTSCROLLBAR = 0x00000000,
+        WS_EX_DLGMODALFRAME = 0x00000001,
+        WS_EX_NOPARENTNOTIFY = 0x00000004,
+        WS_EX_TOPMOST = 0x00000008,
+        WS_EX_ACCEPTFILES = 0x00000010,
+        WS_EX_TRANSPARENT = 0x00000020,
+        WS_EX_MDICHILD = 0x00000040,
+        /// <summary>
+        ///     The window is intended to be used as a floating toolbar. A tool window has a title bar that is shorter than a
+        ///     normal title bar, and the window title is drawn using a smaller font. A tool window does not appear in the taskbar
+        ///     or in the dialog that appears when the user presses ALT+TAB. If a tool window has a system menu, its icon is not
+        ///     displayed on the title bar. However, you can display the system menu by right-clicking or by typing ALT+SPACE.
+        /// </summary>
+        WS_EX_TOOLWINDOW = 0x00000080,
+        WS_EX_WINDOWEDGE = 0x00000100,
+        WS_EX_PALETTEWINDOW = WS_EX_WINDOWEDGE | WS_EX_TOOLWINDOW | WS_EX_TOPMOST,
+        WS_EX_CLIENTEDGE = 0x00000200,
+        WS_EX_OVERLAPPEDWINDOW = WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE,
+        WS_EX_CONTEXTHELP = 0x00000400,
+        WS_EX_RIGHT = 0x00001000,
+        WS_EX_RTLREADING = 0x00002000,
+        WS_EX_LEFTSCROLLBAR = 0x00004000,
+        WS_EX_CONTROLPARENT = 0x00010000,
+        WS_EX_STATICEDGE = 0x00020000,
+        WS_EX_APPWINDOW = 0x00040000,
+        WS_EX_LAYERED = 0x00080000,
+        WS_EX_NOINHERITLAYOUT = 0x00100000,
+        WS_EX_NOREDIRECTIONBITMAP = 0x00200000,
+        WS_EX_LAYOUTRTL = 0x00400000,
+        WS_EX_COMPOSITED = 0x02000000,
+        WS_EX_NOACTIVATE = 0x08000000
+    }
+
+    [Flags]
+    public enum WindowClassStyles
+    {
+        CS_BYTEALIGNCLIENT = 0x1000,
+        CS_BYTEALIGNWINDOW = 0x2000,
+        CS_CLASSDC = 0x0040,
+        CS_DBLCLKS = 0x0008,
+        CS_DROPSHADOW = 0x00020000,
+        CS_GLOBALCLASS = 0x4000,
+        CS_HREDRAW = 0x0002,
+        CS_NOCLOSE = 0x0200,
+        CS_OWNDC = 0x0020,
+        CS_PARENTDC = 0x0080,
+        CS_SAVEBITS = 0x0800,
+        CS_VREDRAW = 0x0001
+    }
+
+    public enum WindowMessage : uint
+    {
+        Null = 0x0000,
+        Create = 0x0001,
+        Destroy = 0x0002,
+        Move = 0x0003,
+        Size = 0x0005,
+        Activate = 0x0006,
+        SetFocus = 0x0007,
+        KillFocus = 0x0008,
+        Enable = 0x000A,
+        SetRedraw = 0x000B,
+        SetText = 0x000C,
+        GetText = 0x000D,
+        GetTextLength = 0x000E,
+        Paint = 0x000F,
+        Close = 0x0010,
+        QueryEndSession = 0x0011,
+        QueryOpen = 0x0013,
+        EndSession = 0x0016,
+        Quit = 0x0012,
+        EraseBackground = 0x0014,
+        SystemColorChange = 0x0015,
+        ShowWindow = 0x0018,
+        WindowsIniChange = 0x001A,
+        SettingChange = WindowsIniChange,
+        DevModeChange = 0x001B,
+        ActivateApp = 0x001C,
+        FontChange = 0x001D,
+        TimeChange = 0x001E,
+        CancelMode = 0x001F,
+        SetCursor = 0x0020,
+        MouseActivate = 0x0021,
+        ChildActivate = 0x0022,
+        KeyDown = 0x0100,
+        KeyUp = 0x0101,
+        Char = 0x0102,
+        SysKeyDown = 0x0104,
+        SysKeyUp = 0x0105,
+        MouseMove = 0x0200,
+        LButtonDown = 0x0201,
+        LButtonUp = 0x0202,
+        MButtonDown = 0x0207,
+        MButtonUp = 0x0208,
+        RButtonDown = 0x0204,
+        RButtonUp = 0x0205,
+        MouseWheel = 0x020A,
+        XButtonDown = 0x020B,
+        XButtonUp = 0x020C,
+        MouseLeave = 0x02A3,
+        NcMouseMove = 0x00A0,
+        WindowPositionChanging = 0x0046,
+        WindowPositionChanged = 0x0047,
+    }
+
+    public enum ShowWindowCommand
+    {
+        /// <summary>
+        /// Hides the window and activates another window.
+        /// </summary>
+        Hide = 0,
+
+        /// <summary>
+        /// Activates and displays a window. If the window is minimized or
+        /// maximized, the system restores it to its original size and position.
+        /// An application should specify this flag when displaying the window
+        /// for the first time.
+        /// </summary>
+        Normal = 1,
+
+        /// <summary>
+        /// Activates the window and displays it as a minimized window.
+        /// </summary>
+        ShowMinimized = 2,
+
+        /// <summary>
+        /// Maximizes the specified window.
+        /// </summary>
+        Maximize = 3,
+
+        /// <summary>
+        /// Activates the window and displays it as a maximized window.
+        /// </summary>
+        ShowMaximized = 3,
+
+        /// <summary>
+        /// Displays a window in its most recent size and position. This value
+        /// is similar to <see cref="ShowWindowCommand.Normal"/>, except
+        /// the window is not activated.
+        /// </summary>
+        ShowNoActivate = 4,
+
+        /// <summary>
+        /// Activates the window and displays it in its current size and position.
+        /// </summary>
+        Show = 5,
+
+        /// <summary>
+        /// Minimizes the specified window and activates the next top-level
+        /// window in the Z order.
+        /// </summary>
+        Minimize = 6,
+
+        /// <summary>
+        /// Displays the window as a minimized window. This value is similar to
+        /// <see cref="ShowMinimized"/>, except the
+        /// window is not activated.
+        /// </summary>
+        ShowMinNoActive = 7,
+
+        /// <summary>
+        /// Displays the window in its current size and position. This value is
+        /// similar to <see cref="Show"/>, except the
+        /// window is not activated.
+        /// </summary>
+        ShowNA = 8,
+
+        /// <summary>
+        /// Activates and displays the window. If the window is minimized or
+        /// maximized, the system restores it to its original size and position.
+        /// An application should specify this flag when restoring a minimized window.
+        /// </summary>
+        Restore = 9,
+
+        /// <summary>
+        /// Sets the show state based on the SW_* value specified in the
+        /// STARTUPINFO structure passed to the CreateProcess function by the
+        /// program that started the application.
+        /// </summary>
+        ShowDefault = 10,
+
+        /// <summary>
+        ///  <b>Windows 2000/XP:</b> Minimizes a window, even if the thread
+        /// that owns the window is not responding. This flag should only be
+        /// used when minimizing windows from a different thread.
+        /// </summary>
+        ForceMinimize = 11
+    }
+
+    public enum SystemCursor
+    {
+        IDC_ARROW = 32512,
+        IDC_IBEAM = 32513,
+        IDC_WAIT = 32514,
+        IDC_CROSS = 32515,
+        IDC_UPARROW = 32516,
+        IDC_SIZE = 32640,
+        IDC_ICON = 32641,
+        IDC_SIZENWSE = 32642,
+        IDC_SIZENESW = 32643,
+        IDC_SIZEWE = 32644,
+        IDC_SIZENS = 32645,
+        IDC_SIZEALL = 32646,
+        IDC_NO = 32648,
+        IDC_HAND = 32649,
+        IDC_APPSTARTING = 32650,
+        IDC_HELP = 32651
+    }
+
+    public enum SystemMetrics
+    {
+        SM_CXSCREEN = 0,  // 0x00
+        SM_CYSCREEN = 1,  // 0x01
+        SM_CXVSCROLL = 2,  // 0x02
+        SM_CYHSCROLL = 3,  // 0x03
+        SM_CYCAPTION = 4,  // 0x04
+        SM_CXBORDER = 5,  // 0x05
+        SM_CYBORDER = 6,  // 0x06
+        SM_CXDLGFRAME = 7,  // 0x07
+        SM_CXFIXEDFRAME = 7,  // 0x07
+        SM_CYDLGFRAME = 8,  // 0x08
+        SM_CYFIXEDFRAME = 8,  // 0x08
+        SM_CYVTHUMB = 9,  // 0x09
+        SM_CXHTHUMB = 10, // 0x0A
+        SM_CXICON = 11, // 0x0B
+        SM_CYICON = 12, // 0x0C
+        SM_CXCURSOR = 13, // 0x0D
+        SM_CYCURSOR = 14, // 0x0E
+        SM_CYMENU = 15, // 0x0F
+        SM_CXFULLSCREEN = 16, // 0x10
+        SM_CYFULLSCREEN = 17, // 0x11
+        SM_CYKANJIWINDOW = 18, // 0x12
+        SM_MOUSEPRESENT = 19, // 0x13
+        SM_CYVSCROLL = 20, // 0x14
+        SM_CXHSCROLL = 21, // 0x15
+        SM_DEBUG = 22, // 0x16
+        SM_SWAPBUTTON = 23, // 0x17
+        SM_CXMIN = 28, // 0x1C
+        SM_CYMIN = 29, // 0x1D
+        SM_CXSIZE = 30, // 0x1E
+        SM_CYSIZE = 31, // 0x1F
+        SM_CXSIZEFRAME = 32, // 0x20
+        SM_CXFRAME = 32, // 0x20
+        SM_CYSIZEFRAME = 33, // 0x21
+        SM_CYFRAME = 33, // 0x21
+        SM_CXMINTRACK = 34, // 0x22
+        SM_CYMINTRACK = 35, // 0x23
+        SM_CXDOUBLECLK = 36, // 0x24
+        SM_CYDOUBLECLK = 37, // 0x25
+        SM_CXICONSPACING = 38, // 0x26
+        SM_CYICONSPACING = 39, // 0x27
+        SM_MENUDROPALIGNMENT = 40, // 0x28
+        SM_PENWINDOWS = 41, // 0x29
+        SM_DBCSENABLED = 42, // 0x2A
+        SM_CMOUSEBUTTONS = 43, // 0x2B
+        SM_SECURE = 44, // 0x2C
+        SM_CXEDGE = 45, // 0x2D
+        SM_CYEDGE = 46, // 0x2E
+        SM_CXMINSPACING = 47, // 0x2F
+        SM_CYMINSPACING = 48, // 0x30
+        SM_CXSMICON = 49, // 0x31
+        SM_CYSMICON = 50, // 0x32
+        SM_CYSMCAPTION = 51, // 0x33
+        SM_CXSMSIZE = 52, // 0x34
+        SM_CYSMSIZE = 53, // 0x35
+        SM_CXMENUSIZE = 54, // 0x36
+        SM_CYMENUSIZE = 55, // 0x37
+        SM_ARRANGE = 56, // 0x38
+        SM_CXMINIMIZED = 57, // 0x39
+        SM_CYMINIMIZED = 58, // 0x3A
+        SM_CXMAXTRACK = 59, // 0x3B
+        SM_CYMAXTRACK = 60, // 0x3C
+        SM_CXMAXIMIZED = 61, // 0x3D
+        SM_CYMAXIMIZED = 62, // 0x3E
+        SM_NETWORK = 63, // 0x3F
+        SM_CLEANBOOT = 67, // 0x43
+        SM_CXDRAG = 68, // 0x44
+        SM_CYDRAG = 69, // 0x45
+        SM_SHOWSOUNDS = 70, // 0x46
+        SM_CXMENUCHECK = 71, // 0x47
+        SM_CYMENUCHECK = 72, // 0x48
+        SM_SLOWMACHINE = 73, // 0x49
+        SM_MIDEASTENABLED = 74, // 0x4A
+        SM_MOUSEWHEELPRESENT = 75, // 0x4B
+        SM_XVIRTUALSCREEN = 76,
+        SM_YVIRTUALSCREEN = 77,
+        SM_CXVIRTUALSCREEN = 78, // 0x4E
+        SM_CYVIRTUALSCREEN = 79, // 0x4F
+        SM_CMONITORS = 80, // 0x50
+        SM_SAMEDISPLAYFORMAT = 81, // 0x51
+        SM_IMMENABLED = 82, // 0x52
+        SM_CXFOCUSBORDER = 83, // 0x53
+        SM_CYFOCUSBORDER = 84, // 0x54
+        SM_TABLETPC = 86,
+        SM_MEDIACENTER = 87,
+        SM_STARTER = 88,
+        SM_SERVERR2 = 89,
+        SM_MOUSEHORIZONTALWHEELPRESENT = 91,
+        SM_CXPADDEDBORDER = 92,
+        SM_DIGITIZER = 94,
+        SM_MAXIMUMTOUCHES = 95,
+
+        SM_REMOTESESSION = 0x1000,
+        SM_SHUTTINGDOWN = 0x2000,
+        SM_REMOTECONTROL = 0x2001,
+
+        SM_CONVERTABLESLATEMODE = 0x2003,
+        SM_SYSTEMDOCKED = 0x2004,
+    }
+    #endregion
+
+    #region Structures
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Message
+    {
+        public IntPtr Hwnd;
+        public uint Value;
+        public IntPtr WParam;
+        public IntPtr LParam;
+        public uint Time;
+        public Point Point;
+    }
+
+    public delegate IntPtr WNDPROC(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct WNDCLASSEX
+    {
+        public int Size;
+        public WindowClassStyles Styles;
+
+        [MarshalAs(UnmanagedType.FunctionPtr)] public WNDPROC WindowProc;
+        public int ClassExtraBytes;
+        public int WindowExtraBytes;
+        public IntPtr InstanceHandle;
+        public IntPtr IconHandle;
+        public IntPtr CursorHandle;
+        public IntPtr BackgroundBrushHandle;
+        public string MenuName;
+        public string ClassName;
+        public IntPtr SmallIconHandle;
+    }
+    #endregion Structures
+
+    internal static class User32
+    {
+        public const string LibraryName = "user32.dll";
+
+        [DllImport(LibraryName, CharSet = CharSet.Unicode)]
+        public static extern ushort RegisterClassEx([In] ref WNDCLASSEX lpwcx);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport(LibraryName)]
+        public static extern bool UnregisterClass(string lpClassName, IntPtr hInstance);
+
+        [DllImport(LibraryName, CharSet = CharSet.Unicode)]
+        public static extern IntPtr DefWindowProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport(LibraryName, CharSet = CharSet.Unicode)]
+        public static extern IntPtr CallWindowProc(WNDPROC lpPrevWndFunc, IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport(LibraryName, CharSet = CharSet.Unicode)]
+        public static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport(LibraryName, CharSet = CharSet.Unicode)]
+        public static extern IntPtr LoadCursor(IntPtr hInstance, string lpCursorName);
+
+        [DllImport(LibraryName, CharSet = CharSet.Unicode)]
+        public static extern IntPtr LoadCursor(IntPtr hInstance, IntPtr lpCursorResource);
+
+        public static IntPtr LoadCursor(IntPtr hInstance, SystemCursor cursor)
+        {
+            return LoadCursor(hInstance, new IntPtr((int)cursor));
+        }
+
+        [DllImport(LibraryName, CharSet = CharSet.Unicode)]
+        public static extern int GetMessage(out Message lpMsg, IntPtr hWnd, uint wMsgFilterMin, uint wMsgFilterMax);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport(LibraryName, CharSet = CharSet.Unicode, EntryPoint = "PeekMessageW")]
+        public static extern bool PeekMessage(
+            out Message lpMsg,
+            IntPtr hWnd,
+            uint wMsgFilterMin,
+            uint wMsgFilterMax,
+            uint wRemoveMsg);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport(LibraryName, SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "PostMessageW")]
+        public static extern bool PostMessage(IntPtr hWnd, WindowMessage msg, IntPtr wParam, IntPtr lParam);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern bool TranslateMessage([In] ref Message lpMsg);
+
+        [DllImport(LibraryName, CharSet = CharSet.Unicode)]
+        public static extern IntPtr DispatchMessage([In] ref Message lpmsg);
+
+        [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern int GetSystemMetrics(SystemMetrics smIndex);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint GetWindowLongPtr(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll", SetLastError = true, EntryPoint = "GetWindowLong")]
+        private static extern uint GetWindowLong32b(IntPtr hWnd, int nIndex);
+
+        public static uint GetWindowLong(IntPtr hWnd, int nIndex)
+        {
+            if (IntPtr.Size == 4)
+            {
+                return GetWindowLong32b(hWnd, nIndex);
+            }
+
+            return GetWindowLongPtr(hWnd, nIndex);
+        }
+
+        [DllImport("user32.dll", SetLastError = true, EntryPoint = "SetWindowLong")]
+        private static extern uint SetWindowLong32b(IntPtr hWnd, int nIndex, uint value);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint SetWindowLongPtr(IntPtr hWnd, int nIndex, uint value);
+
+        public static uint SetWindowLong(IntPtr hWnd, int nIndex, uint value)
+        {
+            if (IntPtr.Size == 4)
+            {
+                return SetWindowLong32b(hWnd, nIndex, value);
+            }
+
+            return SetWindowLongPtr(hWnd, nIndex, value);
+        }
+
+        [return: MarshalAs(UnmanagedType.U1)]
+        [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern bool AdjustWindowRect([In] [Out] ref RawRect lpRect, WindowStyles dwStyle, bool hasMenu);
+
+        [return: MarshalAs(UnmanagedType.U1)]
+        [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern bool AdjustWindowRectEx([In] [Out] ref RawRect lpRect, WindowStyles dwStyle, bool bMenu, WindowExStyles exStyle);
+
+        [DllImport(LibraryName, CharSet = CharSet.Unicode)]
+        public static extern IntPtr CreateWindowEx(
+            int exStyle,
+            string className,
+            string windowName,
+            int style,
+            int x, int y,
+            int width, int height,
+            IntPtr hwndParent,
+            IntPtr Menu,
+            IntPtr Instance,
+            IntPtr pvParam);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern bool DestroyWindow(IntPtr windowHandle);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport(LibraryName, ExactSpelling = true)]
+        public static extern bool ShowWindow(IntPtr hWnd, ShowWindowCommand nCmdShow);
+
+
+        [DllImport(LibraryName)]
+        public static extern void PostQuitMessage(int nExitCode);
+
+        // This method is not available until Windows 8.1
+        [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+        [ResourceExposure(ResourceScope.None)]
+        public static extern uint GetDpiForWindow(IntPtr hWnd);
+        
+        [DllImport(LibraryName, EntryPoint = nameof(GetClientRect), ExactSpelling = true, CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern bool GetClientRect(IntPtr hWnd, [In, Out] ref RawRect rect);
+    }
+}

--- a/src/samples/HelloComposition/Window.cs
+++ b/src/samples/HelloComposition/Window.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Amer Koleci and contributors.
+// Distributed under the MIT license. See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using Vortice.Mathematics;
+using Vortice.Win32;
+using static Vortice.Win32.User32;
+
+namespace Vortice
+{
+    public sealed class Window
+    {
+        private const int CW_USEDEFAULT = unchecked((int)0x80000000);
+        private const WindowStyles _windowStyles = WindowStyles.WS_POPUP | WindowStyles.WS_VISIBLE | WindowStyles.WS_BORDER | WindowStyles.WS_OVERLAPPEDWINDOW | WindowStyles.WS_CLIPSIBLINGS | WindowStyles.WS_DLGFRAME;
+        private const WindowExStyles _windowExStyles = WindowExStyles.WS_EX_NOREDIRECTIONBITMAP | WindowExStyles.WS_EX_WINDOWEDGE;
+
+        public IntPtr Handle { get; private set; }
+
+        public void GetClientRect(ref RawRect rect)
+        {
+            User32.GetClientRect(Handle, ref rect);
+        }
+
+        public Size ClientSize
+        {
+            get
+            {
+                RawRect rect = default;
+                GetClientRect(ref rect);
+                return new Size(rect.Right - rect.Left, rect.Bottom - rect.Top);
+            }
+        }
+
+        public Window(string title, int width, int height, string className)
+        {
+            var x = 0;
+            var y = 0;
+
+            if (width > 0 && height > 0)
+            {
+                var screenWidth = GetSystemMetrics(SystemMetrics.SM_CXSCREEN);
+                var screenHeight = GetSystemMetrics(SystemMetrics.SM_CYSCREEN);
+
+                // Place the window in the middle of the screen.
+                x = (screenWidth - width) / 2;
+                y = (screenHeight - height) / 2;
+            }
+
+            int windowWidth;
+            int windowHeight;
+
+            if (width > 0 && height > 0)
+            {
+                var rect = new RawRect(0, 0, width, height);
+
+                // Adjust according to window styles
+                AdjustWindowRectEx(
+                    ref rect,
+                    _windowStyles,
+                    false,
+                    _windowExStyles);
+
+                windowWidth = rect.Right - rect.Left;
+                windowHeight = rect.Bottom - rect.Top;
+            }
+            else
+            {
+                x = y = windowWidth = windowHeight = CW_USEDEFAULT;
+            }
+
+            Handle = CreateWindowEx(
+                (int)_windowExStyles,
+                className,
+                title,
+                (int)_windowStyles,
+                x,
+                y,
+                windowWidth,
+                windowHeight,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                IntPtr.Zero);
+
+            if (Handle == IntPtr.Zero)
+            {
+                return;
+            }
+
+            ShowWindow(Handle, ShowWindowCommand.Normal);
+        }
+
+        public void Destroy()
+        {
+            if (Handle == IntPtr.Zero) return;
+
+            var destroyHandle = Handle;
+            Handle = IntPtr.Zero;
+
+            Debug.WriteLine($"[WIN32] - Destroying window: {destroyHandle}");
+            DestroyWindow(destroyHandle);
+        }
+    }
+}


### PR DESCRIPTION
Note: requires [my SharpGen branch](https://github.com/SharpGenTools/SharpGenTools/pull/161).

* Move DirectComposition and Windows Animation Manager from SharpDX into a new `Vortice.Visuals` assembly, simplify and greatly extend bindings (WAM bindings in SharpDX are a joke). These 2 technologies are intertwined, so a single assembly makes sense.
* Create a solid HelloComposition sample: good practices, clear separation of generic visual tree code (like some UI framework) and simple demo app. Requires Windows 8.1, but tested only on Windows 10. Windows 8 path can also be implemented if needed, but it would be less efficient. This sample is one of a few available samples on these technologies, so some personal investigation was required to get everything right. [Video](https://drive.google.com/file/d/1z1bFJmusP0xc9W4E4ZpSEGnSYfL1smtE/view?usp=sharing). Note that video preview is reencoded by YouTube, downloaded video plays more smoothly in 60 FPS. Still, video capture is done using GDI, that induces additional jaggedness, not present on real display. Real rendering has perfectly smooth animations (thanks DWM!).
* Updating SharpGen to 2.0.0-dev (locally built), fixed name clash with `PlatformDetection`.

This PR is not meant to be merged for now. I'd like to have a feedback on these changes, if they are in line with Vortice project goals, if they are worthy of upstreaming, if there is a better way to accomplish their aims.