### PR TITLE
Fix a number of memory safety issues

### DIFF
--- a/src/Vortice.DXGI/IDXGIFactory5.cs
+++ b/src/Vortice.DXGI/IDXGIFactory5.cs
@@ -24,7 +24,10 @@ namespace Vortice.DXGI
 
         public unsafe bool CheckFeatureSupport<T>(Feature feature, ref T featureSupport) where T : unmanaged
         {
-            return CheckFeatureSupport(feature, (IntPtr)Unsafe.AsPointer(ref featureSupport), sizeof(T)).Success;
+            fixed (void* featureSupportPtr = &featureSupport)
+            {
+                return CheckFeatureSupport(feature, (IntPtr)featureSupportPtr, sizeof(T)).Success;
+            }
         }
     }
 }

--- a/src/Vortice.DXGI/IDXGISwapChain4.cs
+++ b/src/Vortice.DXGI/IDXGISwapChain4.cs
@@ -8,19 +8,25 @@ namespace Vortice.DXGI
 {
     public partial class IDXGISwapChain4
     {
-        public unsafe void SetHDRMetaData<T>(HdrMetadataType type, T data) where T : struct
+        public unsafe void SetHDRMetaData<T>(HdrMetadataType type, T data) where T : unmanaged
         {
-            SetHDRMetaData(type, Unsafe.SizeOf<T>(), new IntPtr(Unsafe.AsPointer(ref data)));
+            SetHDRMetaData(type, sizeof(T), new IntPtr(&data));
         }
 
-        public unsafe void SetHDRMetaData<T>(HdrMetadataType type, ref T data) where T : struct
+        public unsafe void SetHDRMetaData<T>(HdrMetadataType type, ref T data) where T : unmanaged
         {
-            SetHDRMetaData(type, Unsafe.SizeOf<T>(), new IntPtr(Unsafe.AsPointer(ref data)));
+            fixed (void* dataPtr = &data)
+            {
+                SetHDRMetaData(type, sizeof(T), (IntPtr)dataPtr);
+            }
         }
 
         public unsafe void SetHDRMetaData(HdrMetadataType type, HdrMetadataHdr10 data)
         {
-            SetHDRMetaData(type, Unsafe.SizeOf<HdrMetadataHdr10>(), new IntPtr(Unsafe.AsPointer(ref data)));
+            var native = new HdrMetadataHdr10.__Native();
+            data.__MarshalTo(ref native);
+            SetHDRMetaData(type, sizeof(HdrMetadataHdr10.__Native), new IntPtr(&native));
+            data.__MarshalFree(ref native);
         }
     }
 }

--- a/src/Vortice.Direct2D1/DirectWrite/GlyphRun.cs
+++ b/src/Vortice.Direct2D1/DirectWrite/GlyphRun.cs
@@ -67,30 +67,39 @@ namespace Vortice.DirectWrite
             {
                 GlyphIndices = new short[@ref.GlyphCount];
                 if (@ref.GlyphCount > 0)
-                    Unsafe.CopyBlock(
-                        Unsafe.AsPointer(ref GlyphIndices[0]),
-                        @ref.GlyphIndices.ToPointer(),
-                        (uint)(sizeof(short) * @ref.GlyphCount));
+                    fixed (void* indicesPtr = &GlyphIndices[0])
+                    {
+                        Unsafe.CopyBlock(
+                            indicesPtr,
+                            @ref.GlyphIndices.ToPointer(),
+                            (uint)(sizeof(short) * @ref.GlyphCount));
+                    }
             }
 
             if (@ref.GlyphAdvances != IntPtr.Zero)
             {
                 GlyphAdvances = new float[@ref.GlyphCount];
                 if (@ref.GlyphCount > 0)
-                    Unsafe.CopyBlock(
-                        Unsafe.AsPointer(ref GlyphAdvances[0]),
-                        @ref.GlyphAdvances.ToPointer(),
-                        (uint)(sizeof(float) * @ref.GlyphCount));
+                    fixed (void* advancesPtr = &GlyphAdvances[0])
+                    {
+                        Unsafe.CopyBlock(
+                            advancesPtr,
+                            @ref.GlyphAdvances.ToPointer(),
+                            (uint)(sizeof(float) * @ref.GlyphCount));
+                    }
             }
 
             if (@ref.GlyphOffsets != IntPtr.Zero)
             {
                 GlyphOffsets = new GlyphOffset[@ref.GlyphCount];
                 if (@ref.GlyphCount > 0)
-                    Unsafe.CopyBlock(
-                        Unsafe.AsPointer(ref GlyphOffsets[0]),
-                        @ref.GlyphOffsets.ToPointer(),
-                        (uint)(sizeof(GlyphOffset) * @ref.GlyphCount));
+                    fixed (void* offsetsPtr = &GlyphOffsets[0])
+                    {
+                        Unsafe.CopyBlock(
+                            offsetsPtr,
+                            @ref.GlyphOffsets.ToPointer(),
+                            (uint)(sizeof(GlyphOffset) * @ref.GlyphCount));
+                    }
             }
         }
 
@@ -110,9 +119,12 @@ namespace Vortice.DirectWrite
                 @ref.GlyphIndices = Marshal.AllocHGlobal(GlyphIndices.Length * sizeof(short));
                 if (GlyphCount > 0)
                 {
-                    Unsafe.CopyBlock(@ref.GlyphIndices.ToPointer(),
-                        Unsafe.AsPointer(ref GlyphIndices[0]),
-                        (uint)(sizeof(short) * GlyphCount));
+                    fixed (void* glyphIndicesPtr = &GlyphIndices[0])
+                    {
+                        Unsafe.CopyBlock(@ref.GlyphIndices.ToPointer(),
+                            glyphIndicesPtr,
+                            (uint)(sizeof(short) * GlyphCount));
+                    }
                 }
 
             }
@@ -122,9 +134,12 @@ namespace Vortice.DirectWrite
                 @ref.GlyphAdvances = Marshal.AllocHGlobal(GlyphAdvances.Length * sizeof(float));
                 if (GlyphCount > 0)
                 {
-                    Unsafe.CopyBlock(@ref.GlyphAdvances.ToPointer(),
-                        Unsafe.AsPointer(ref GlyphAdvances[0]),
-                        (uint)(sizeof(float) * GlyphCount));
+                    fixed (void* glyphAdvancesPtr = &GlyphAdvances[0])
+                    {
+                        Unsafe.CopyBlock(@ref.GlyphAdvances.ToPointer(),
+                            glyphAdvancesPtr,
+                            (uint)(sizeof(float) * GlyphCount));
+                    }
                 }
             }
 
@@ -133,9 +148,12 @@ namespace Vortice.DirectWrite
                 @ref.GlyphOffsets = Marshal.AllocHGlobal(GlyphOffsets.Length * sizeof(GlyphOffset));
                 if (GlyphCount > 0)
                 {
-                    Unsafe.CopyBlock(@ref.GlyphOffsets.ToPointer(), 
-                        Unsafe.AsPointer(ref GlyphOffsets[0]),
-                        (uint)(sizeof(GlyphOffset) * GlyphCount));
+                    fixed (void* offsetsPtr = &GlyphOffsets[0])
+                    {
+                        Unsafe.CopyBlock(@ref.GlyphOffsets.ToPointer(), 
+                            offsetsPtr,
+                            (uint)(sizeof(GlyphOffset) * GlyphCount));
+                    }
                 }
             }
         }

--- a/src/Vortice.Direct2D1/Effects/ConvolveMatrix.cs
+++ b/src/Vortice.Direct2D1/Effects/ConvolveMatrix.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 
 namespace Vortice.Direct2D1.Effects
 {
@@ -49,7 +48,10 @@ namespace Vortice.Direct2D1.Effects
             {
                 var size = KernelSizeX * KernelSizeY;
                 var value = new float[size];
-                GetValue((int)ConvolveMatrixProperties.KernelMatrix, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref value[0])), sizeof(float) * size);
+                fixed (void* valuePtr = &value[0])
+                {
+                    GetValue((int)ConvolveMatrixProperties.KernelMatrix, PropertyType.Blob, (IntPtr)valuePtr, sizeof(float) * size);
+                }
                 return value;
             }
             set
@@ -60,7 +62,10 @@ namespace Vortice.Direct2D1.Effects
                     throw new ArgumentException();
                 }
 
-                SetValue((int)ConvolveMatrixProperties.KernelMatrix, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref value[0])), sizeof(float) * size);
+                fixed (void* valuePtr = &value[0])
+                {
+                    SetValue((int)ConvolveMatrixProperties.KernelMatrix, PropertyType.Blob, (IntPtr)valuePtr, sizeof(float) * size);
+                }
             }
         }
 

--- a/src/Vortice.Direct2D1/Effects/DiscreteTransfer.cs
+++ b/src/Vortice.Direct2D1/Effects/DiscreteTransfer.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
 
 namespace Vortice.Direct2D1.Effects
 {
@@ -29,7 +28,10 @@ namespace Vortice.Direct2D1.Effects
             get
             {
                 var table = new float[_redTableSize];
-                GetValue((int)DiscreteTransferProperties.RedTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref table[0])), sizeof(float) * _redTableSize);
+                fixed (void* tablePtr = &table[0])
+                {
+                    GetValue((int)DiscreteTransferProperties.RedTable, PropertyType.Blob, (IntPtr)tablePtr, sizeof(float) * _redTableSize);
+                }
                 return table;
             }
             set
@@ -40,7 +42,10 @@ namespace Vortice.Direct2D1.Effects
                 }
 
                 _redTableSize = value.Length;
-                SetValue((int)DiscreteTransferProperties.RedTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref value[0])), sizeof(float) * _redTableSize);
+                fixed (void* valuePtr = &value[0])
+                {
+                    SetValue((int)DiscreteTransferProperties.RedTable, PropertyType.Blob, (IntPtr)valuePtr, sizeof(float) * _redTableSize);
+                }
             }
         }
 
@@ -49,7 +54,10 @@ namespace Vortice.Direct2D1.Effects
             get
             {
                 var table = new float[_greenTableSize];
-                GetValue((int)DiscreteTransferProperties.GreenTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref table[0])), sizeof(float) * _greenTableSize);
+                fixed (void* tablePtr = &table[0])
+                {
+                    GetValue((int)DiscreteTransferProperties.GreenTable, PropertyType.Blob, (IntPtr)tablePtr, sizeof(float) * _greenTableSize);
+                }
                 return table;
             }
             set
@@ -60,7 +68,10 @@ namespace Vortice.Direct2D1.Effects
                 }
 
                 _greenTableSize = value.Length;
-                SetValue((int)DiscreteTransferProperties.GreenTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref value[0])), sizeof(float) * _greenTableSize);
+                fixed (void* valuePtr = &value[0])
+                {
+                    SetValue((int)DiscreteTransferProperties.GreenTable, PropertyType.Blob, (IntPtr)valuePtr, sizeof(float) * _greenTableSize);
+                }
             }
         }
 
@@ -69,7 +80,10 @@ namespace Vortice.Direct2D1.Effects
             get
             {
                 var table = new float[_blueTableSize];
-                GetValue((int)DiscreteTransferProperties.BlueTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref table[0])), sizeof(float) * _blueTableSize);
+                fixed (void* tablePtr = &table[0])
+                {
+                    GetValue((int)DiscreteTransferProperties.BlueTable, PropertyType.Blob, (IntPtr)tablePtr, sizeof(float) * _blueTableSize);
+                }
                 return table;
             }
             set
@@ -80,7 +94,10 @@ namespace Vortice.Direct2D1.Effects
                 }
 
                 _blueTableSize = value.Length;
-                SetValue((int)DiscreteTransferProperties.BlueTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref value[0])), sizeof(float) * _blueTableSize);
+                fixed (void* valuePtr = &value[0])
+                {
+                    SetValue((int)DiscreteTransferProperties.BlueTable, PropertyType.Blob, (IntPtr)valuePtr, sizeof(float) * _blueTableSize);
+                }
             }
         }
 
@@ -89,7 +106,10 @@ namespace Vortice.Direct2D1.Effects
             get
             {
                 var table = new float[_alphaTableSize];
-                GetValue((int)DiscreteTransferProperties.AlphaTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref table[0])), sizeof(float) * _alphaTableSize);
+                fixed (void* tablePtr = &table[0])
+                {
+                    GetValue((int)DiscreteTransferProperties.AlphaTable, PropertyType.Blob, (IntPtr)tablePtr, sizeof(float) * _alphaTableSize);
+                }
                 return table;
             }
             set
@@ -100,7 +120,10 @@ namespace Vortice.Direct2D1.Effects
                 }
 
                 _alphaTableSize = value.Length;
-                SetValue((int)DiscreteTransferProperties.AlphaTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref value[0])), sizeof(float) * _alphaTableSize);
+                fixed (void* valuePtr = &value[0])
+                {
+                    SetValue((int)DiscreteTransferProperties.AlphaTable, PropertyType.Blob, (IntPtr)valuePtr, sizeof(float) * _alphaTableSize);
+                }
             }
         }
 

--- a/src/Vortice.Direct2D1/Effects/Histogram.cs
+++ b/src/Vortice.Direct2D1/Effects/Histogram.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
 
 namespace Vortice.Direct2D1.Effects
 {
@@ -38,7 +37,10 @@ namespace Vortice.Direct2D1.Effects
                 throw new ArgumentException();
             }
 
-            GetValue((int)HistogramProperties.HistogramOutput, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref output[0])), sizeof(float) * numBins);
+            fixed (void* outputPtr = &output[0])
+            {
+                GetValue((int)HistogramProperties.HistogramOutput, PropertyType.Blob, (IntPtr)outputPtr, sizeof(float) * numBins);
+            }
         }
     }
 }

--- a/src/Vortice.Direct2D1/Effects/TableTransfer.cs
+++ b/src/Vortice.Direct2D1/Effects/TableTransfer.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
 
 namespace Vortice.Direct2D1.Effects
 {
@@ -29,7 +28,10 @@ namespace Vortice.Direct2D1.Effects
             get
             {
                 var table = new float[_redTableSize];
-                GetValue((int)TableTransferProperties.RedTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref table[0])), sizeof(float) * _redTableSize);
+                fixed (void* tablePtr = &table[0])
+                {
+                    GetValue((int)TableTransferProperties.RedTable, PropertyType.Blob, (IntPtr)tablePtr, sizeof(float) * _redTableSize);
+                }
                 return table;
             }
             set
@@ -37,7 +39,10 @@ namespace Vortice.Direct2D1.Effects
                 if (value.Length == 0)
                     throw new ArgumentException($"{nameof(RedTable)} length must be greather than 0");
                 _redTableSize = value.Length;
-                SetValue((int)TableTransferProperties.RedTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref value[0])), sizeof(float) * _redTableSize);
+                fixed (void* valuePtr = &value[0])
+                {
+                    SetValue((int)TableTransferProperties.RedTable, PropertyType.Blob, (IntPtr)valuePtr, sizeof(float) * _redTableSize);
+                }
             }
         }
 
@@ -52,7 +57,10 @@ namespace Vortice.Direct2D1.Effects
             get
             {
                 var table = new float[_greenTableSize];
-                GetValue((int)TableTransferProperties.GreenTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref table[0])), sizeof(float) * _greenTableSize);
+                fixed (void* tablePtr = &table[0])
+                {
+                    GetValue((int)TableTransferProperties.GreenTable, PropertyType.Blob, (IntPtr)tablePtr, sizeof(float) * _greenTableSize);
+                }
                 return table;
             }
             set
@@ -60,7 +68,10 @@ namespace Vortice.Direct2D1.Effects
                 if (value.Length == 0)
                     throw new ArgumentException($"{nameof(GreenTable)} length must be greather than 0");
                 _greenTableSize = value.Length;
-                SetValue((int)TableTransferProperties.GreenTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref value[0])), sizeof(float) * _greenTableSize);
+                fixed (void* valuePtr = &value[0])
+                {
+                    SetValue((int)TableTransferProperties.GreenTable, PropertyType.Blob, (IntPtr)valuePtr, sizeof(float) * _greenTableSize);
+                }
             }
         }
 
@@ -75,7 +86,10 @@ namespace Vortice.Direct2D1.Effects
             get
             {
                 var table = new float[_blueTableSize];
-                GetValue((int)TableTransferProperties.BlueTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref table[0])), sizeof(float) * _blueTableSize);
+                fixed (void* tablePtr = &table[0])
+                {
+                    GetValue((int)TableTransferProperties.BlueTable, PropertyType.Blob, (IntPtr)tablePtr, sizeof(float) * _blueTableSize);
+                }
                 return table;
             }
             set
@@ -83,7 +97,10 @@ namespace Vortice.Direct2D1.Effects
                 if (value.Length == 0)
                     throw new ArgumentException($"{nameof(BlueTable)} length must be greather than 0");
                 _blueTableSize = value.Length;
-                SetValue((int)TableTransferProperties.BlueTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref value[0])), sizeof(float) * _blueTableSize);
+                fixed (void* valuePtr = &value[0])
+                {
+                    SetValue((int)TableTransferProperties.BlueTable, PropertyType.Blob, (IntPtr)valuePtr, sizeof(float) * _blueTableSize);
+                }
             }
         }
 
@@ -98,7 +115,10 @@ namespace Vortice.Direct2D1.Effects
             get
             {
                 var table = new float[_alphaTableSize];
-                GetValue((int)TableTransferProperties.AlphaTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref table[0])), sizeof(float) * _alphaTableSize);
+                fixed (void* tablePtr = &table[0])
+                {
+                    GetValue((int)TableTransferProperties.AlphaTable, PropertyType.Blob, (IntPtr)tablePtr, sizeof(float) * _alphaTableSize);
+                }
                 return table;
             }
             set
@@ -106,7 +126,10 @@ namespace Vortice.Direct2D1.Effects
                 if (value.Length == 0)
                     throw new ArgumentException($"{nameof(AlphaTable)} length must be greather than 0");
                 _alphaTableSize = value.Length;
-                SetValue((int)TableTransferProperties.AlphaTable, PropertyType.Blob, new IntPtr(Unsafe.AsPointer(ref value[0])), sizeof(float) * _alphaTableSize);
+                fixed (void* valuePtr = &value[0])
+                {
+                    SetValue((int)TableTransferProperties.AlphaTable, PropertyType.Blob, (IntPtr)valuePtr, sizeof(float) * _alphaTableSize);
+                }
             }
         }
 

--- a/src/Vortice.Direct2D1/ID2D1EffectContext.cs
+++ b/src/Vortice.Direct2D1/ID2D1EffectContext.cs
@@ -18,16 +18,19 @@ namespace Vortice.Direct2D1
             }
         }
 
-        public unsafe T CheckFeatureSupport<T>(Feature feature) where T : struct
+        public unsafe T CheckFeatureSupport<T>(Feature feature) where T : unmanaged
         {
             T featureSupport = default;
-            CheckFeatureSupport(feature, new IntPtr(Unsafe.AsPointer(ref featureSupport)), Unsafe.SizeOf<T>());
+            CheckFeatureSupport(feature, new IntPtr(&featureSupport), sizeof(T));
             return featureSupport;
         }
 
-        public unsafe bool CheckFeatureSupport<T>(Feature feature, ref T featureSupport) where T : struct
+        public unsafe bool CheckFeatureSupport<T>(Feature feature, ref T featureSupport) where T : unmanaged
         {
-            return CheckFeatureSupport(feature, new IntPtr(Unsafe.AsPointer(ref featureSupport)), Unsafe.SizeOf<T>()).Success;
+            fixed (void* featureSupportPtr = &featureSupport)
+            {
+                return CheckFeatureSupport(feature, (IntPtr)featureSupportPtr, sizeof(T)).Success;
+            }
         }
     }
 }

--- a/src/Vortice.Direct2D1/ID2D1TransformShadow.cs
+++ b/src/Vortice.Direct2D1/ID2D1TransformShadow.cs
@@ -27,20 +27,24 @@ namespace Vortice.Direct2D1
                 try
                 {
                     var inputRects = new RawRect[inputRectsCount];
-                    Unsafe.CopyBlock(
-                        Unsafe.AsPointer(ref inputRects[0]),
-                        pInputRects,
-                        (uint)(sizeof(RawRect) * inputRectsCount));
+                    fixed (void* rectsPtr = &inputRects[0])
+                    {
+                        Unsafe.CopyBlock(
+                            rectsPtr,
+                            pInputRects,
+                            (uint)(sizeof(RawRect) * inputRectsCount));
+                    
 
-                    ID2D1Transform @this = (ID2D1Transform)ToShadow<ID2D1TransformShadow>(thisObject).Callback;
-                    @this.MapOutputRectToInputRects(*outputRect, inputRects);
+                        ID2D1Transform @this = (ID2D1Transform)ToShadow<ID2D1TransformShadow>(thisObject).Callback;
+                        @this.MapOutputRectToInputRects(*outputRect, inputRects);
 
-                    Unsafe.CopyBlock(
-                        pInputRects,
-                        Unsafe.AsPointer(ref inputRects[0]),
-                        (uint)(sizeof(RawRect) * inputRectsCount));
+                        Unsafe.CopyBlock(
+                            pInputRects,
+                            rectsPtr,
+                            (uint)(sizeof(RawRect) * inputRectsCount));
 
-                    return Result.Ok.Code;
+                        return Result.Ok.Code;
+                    }
                 }
                 catch (Exception __exception__)
                 {
@@ -55,21 +59,27 @@ namespace Vortice.Direct2D1
                 try
                 {
                     var inputRects = new RawRect[inputRectCount];
-                    Unsafe.CopyBlock(
-                        Unsafe.AsPointer(ref inputRects[0]),
-                        pInputRects,
-                        (uint)(sizeof(RawRect) * inputRectCount));
+                    fixed (void* rectsPtr = &inputRects[0])
+                    {
+                        Unsafe.CopyBlock(
+                            rectsPtr,
+                            pInputRects,
+                            (uint)(sizeof(RawRect) * inputRectCount));
 
-                    var inputOpaqueSubRects = new RawRect[inputRectCount];
-                    Unsafe.CopyBlock(
-                        Unsafe.AsPointer(ref inputOpaqueSubRects[0]),
-                        pInputOpaqueSubRects,
-                        (uint)(sizeof(RawRect) * inputRectCount));
+                        var inputOpaqueSubRects = new RawRect[inputRectCount];
+                        fixed (void* opaqueSubRectsPtr = &inputOpaqueSubRects[0])
+                        {
+                            Unsafe.CopyBlock(
+                                opaqueSubRectsPtr,
+                                pInputOpaqueSubRects,
+                                (uint)(sizeof(RawRect) * inputRectCount));
 
-                    ID2D1Transform @this = (ID2D1Transform)ToShadow<ID2D1TransformShadow>(thisObject).Callback;
-                    @this.MapInputRectsToOutputRect(inputRects, inputOpaqueSubRects, out *outputRect, out *outputOpaqueSubRect);
+                            ID2D1Transform @this = (ID2D1Transform)ToShadow<ID2D1TransformShadow>(thisObject).Callback;
+                            @this.MapInputRectsToOutputRect(inputRects, inputOpaqueSubRects, out *outputRect, out *outputOpaqueSubRect);
 
-                    return Result.Ok.Code;
+                            return Result.Ok.Code;
+                        }
+                    }
                 }
                 catch (Exception __exception__)
                 {

--- a/src/Vortice.Direct2D1/WIC/IWICBitmapFrameEncode.cs
+++ b/src/Vortice.Direct2D1/WIC/IWICBitmapFrameEncode.cs
@@ -47,14 +47,17 @@ namespace Vortice.WIC
             }
         }
 
-        public unsafe void WritePixels<T>(int lineCount, int stride, T[] pixelBuffer) where T : struct
+        public unsafe void WritePixels<T>(int lineCount, int stride, T[] pixelBuffer) where T : unmanaged
         {
             if ((lineCount * stride) > (Unsafe.SizeOf<T>() * pixelBuffer.Length))
             {
                 throw new ArgumentException("lineCount * stride must be <= to sizeof(pixelBuffer)");
             }
 
-            WritePixels(lineCount, stride, lineCount * stride, (IntPtr)Unsafe.AsPointer(ref pixelBuffer[0]));
+            fixed (void* pixelBufferPtr = &pixelBuffer[0])
+            {
+                WritePixels(lineCount, stride, lineCount * stride, (IntPtr)pixelBufferPtr);
+            }
         }
 
         /// <summary>

--- a/src/Vortice.Direct2D1/WIC/IWICBitmapSource.cs
+++ b/src/Vortice.Direct2D1/WIC/IWICBitmapSource.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
 using Vortice.Mathematics;
 
 namespace Vortice.WIC
@@ -30,12 +29,18 @@ namespace Vortice.WIC
 
         public unsafe void CopyPixels(int stride, byte[] data)
         {
-            CopyPixels(IntPtr.Zero, stride, data.Length, (IntPtr)Unsafe.AsPointer(ref data[0]));
+            fixed (void* dataPtr = &data[0])
+            {
+                CopyPixels(IntPtr.Zero, stride, data.Length, (IntPtr)dataPtr);
+            }
         }
 
         public unsafe void CopyPixels(Rectangle rectangle, int stride, byte[] data)
         {
-            CopyPixels(new IntPtr(&rectangle), stride, data.Length, (IntPtr)Unsafe.AsPointer(ref data[0]));
+            fixed (void* dataPtr = &data[0])
+            {
+                CopyPixels(new IntPtr(&rectangle), stride, data.Length, (IntPtr)dataPtr);
+            }
         }
 
         public unsafe void CopyPixels<T>(int stride, T[] data) where T : unmanaged

--- a/src/Vortice.Direct3D11/D3D11.cs
+++ b/src/Vortice.Direct3D11/D3D11.cs
@@ -206,6 +206,7 @@ namespace Vortice.Direct3D11
             {
                 device = default;
                 var adapterPtr = CppObject.ToCallbackPtr<IDXGIAdapter>(adapter);
+                fixed (void* featureLevelsPtr = &featureLevels[0])
                 fixed (void* featureLevelPtr = &featureLevel)
                 {
                     var devicePtr = IntPtr.Zero;
@@ -214,7 +215,7 @@ namespace Vortice.Direct3D11
                         (int)driverType,
                         null,
                         (int)flags,
-                        featureLevels != null && featureLevels.Length > 0 ? Unsafe.AsPointer(ref featureLevels[0]) : null,
+                        featureLevels != null && featureLevels.Length > 0 ? featureLevelsPtr : null,
                         featureLevels?.Length ?? 0,
                         SdkVersion,
                         &devicePtr,
@@ -242,6 +243,7 @@ namespace Vortice.Direct3D11
             unsafe
             {
                 var adapterPtr = CppObject.ToCallbackPtr<IDXGIAdapter>(adapter);
+                fixed (void* featureLevelsPtr = &featureLevels[0])
                 fixed (void* featureLevelPtr = &featureLevel)
                 {
                     Result result = D3D11CreateDevice_(
@@ -249,7 +251,7 @@ namespace Vortice.Direct3D11
                         (int)driverType,
                         null,
                         (int)flags,
-                        featureLevels != null && featureLevels.Length > 0 ? Unsafe.AsPointer(ref featureLevels[0]) : null,
+                        featureLevels != null && featureLevels.Length > 0 ? featureLevelsPtr : null,
                         featureLevels?.Length ?? 0,
                         SdkVersion,
                         null,

--- a/src/Vortice.Direct3D11/ID3D11Device.cs
+++ b/src/Vortice.Direct3D11/ID3D11Device.cs
@@ -27,13 +27,16 @@ namespace Vortice.Direct3D11
         public unsafe T CheckFeatureSupport<T>(Feature feature) where T : unmanaged
         {
             T featureSupport = default;
-            CheckFeatureSupport(feature, new IntPtr(Unsafe.AsPointer(ref featureSupport)), sizeof(T));
+            CheckFeatureSupport(feature, new IntPtr(&featureSupport), sizeof(T));
             return featureSupport;
         }
 
         public unsafe bool CheckFeatureSupport<T>(Feature feature, ref T featureSupport) where T : unmanaged
         {
-            return CheckFeatureSupport(feature, new IntPtr(Unsafe.AsPointer(ref featureSupport)), sizeof(T)).Success;
+            fixed (void* featureSupportPtr = &featureSupport)
+            {
+                return CheckFeatureSupport(feature, (IntPtr)featureSupportPtr, sizeof(T)).Success;
+            }
         }
 
         /// <summary>
@@ -78,7 +81,10 @@ namespace Vortice.Direct3D11
             if (description.SizeInBytes == 0)
                 description.SizeInBytes = sizeof(T);
 
-            return CreateBuffer(description, new SubresourceData((IntPtr)Unsafe.AsPointer(ref data)));
+            fixed (void* dataPtr = &data)
+            {
+                return CreateBuffer(description, new SubresourceData((IntPtr)dataPtr));
+            }
         }
 
         public unsafe ID3D11Buffer CreateBuffer<T>(T[] data, BufferDescription description) where T : unmanaged
@@ -86,7 +92,10 @@ namespace Vortice.Direct3D11
             if (description.SizeInBytes == 0)
                 description.SizeInBytes = sizeof(T) * data.Length;
 
-            return CreateBuffer(description, new SubresourceData((IntPtr)Unsafe.AsPointer(ref data[0])));
+            fixed (void* dataPtr = &data[0])
+            {
+                return CreateBuffer(description, new SubresourceData((IntPtr)dataPtr));
+            }
         }
 
         public unsafe ID3D11VertexShader CreateVertexShader(byte[] shaderBytecode, ID3D11ClassLinkage classLinkage = null)

--- a/src/Vortice.Direct3D11/ID3D11Device3.cs
+++ b/src/Vortice.Direct3D11/ID3D11Device3.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
 using Vortice.Mathematics;
 
 namespace Vortice.Direct3D11
@@ -56,29 +55,38 @@ namespace Vortice.Direct3D11
             ID3D11Resource destinationResource, int destinationSubresource,
             T[] sourceData, int sourceRowPitch, int srcDepthPitch) where T : unmanaged
         {
-            WriteToSubresource(
-                destinationResource, destinationSubresource, null,
-                (IntPtr)Unsafe.AsPointer(ref sourceData[0]), sourceRowPitch, srcDepthPitch
-                );
+            fixed (void* sourceDataPtr = &sourceData[0])
+            {
+                WriteToSubresource(
+                    destinationResource, destinationSubresource, null,
+                    (IntPtr)sourceDataPtr, sourceRowPitch, srcDepthPitch
+                    );
+            }
         }
 
         public unsafe void WriteToSubresource<T>(
             ID3D11Resource destinationResource, int destinationSubresource, Box destinationBox,
             T[] sourceData, int sourceRowPitch, int srcDepthPitch) where T : unmanaged
         {
-            WriteToSubresource(
-                destinationResource, destinationSubresource, destinationBox,
-                (IntPtr)Unsafe.AsPointer(ref sourceData[0]), sourceRowPitch, srcDepthPitch
-                );
+             fixed (void* sourceDataPtr = &sourceData[0])
+            {
+                WriteToSubresource(
+                    destinationResource, destinationSubresource, destinationBox,
+                    (IntPtr)sourceDataPtr, sourceRowPitch, srcDepthPitch
+                    );
+            }
         }
 
         public unsafe void ReadFromSubresource<T>(
             T[] destination, int destinationRowPitch, int destinationDepthPitch,
             ID3D11Resource sourceResource, int sourceSubresource, Box? sourceBox = null) where T : unmanaged
         {
-            ReadFromSubresource(
-                (IntPtr)Unsafe.AsPointer(ref destination[0]), destinationRowPitch, destinationDepthPitch,
-                sourceResource, sourceSubresource, sourceBox);
+            fixed (void* destinationPtr = &destination[0])
+            {
+                ReadFromSubresource(
+                    (IntPtr)destinationPtr, destinationRowPitch, destinationDepthPitch,
+                    sourceResource, sourceSubresource, sourceBox);
+            }
         }
     }
 }

--- a/src/Vortice.Direct3D11/ID3D11DeviceContext.cs
+++ b/src/Vortice.Direct3D11/ID3D11DeviceContext.cs
@@ -104,10 +104,13 @@ namespace Vortice.Direct3D11
                 unorderedAccessViewsPtr[i] = unorderedAccessViews[i].NativePointer;
             }
 
-            OMSetRenderTargetsAndUnorderedAccessViews(
-                KeepRenderTargetsAndDepthStencil, IntPtr.Zero, (ID3D11DepthStencilView)null,
-                uavStartSlot, unorderedAccessViewCount, (IntPtr)unorderedAccessViewsPtr,
-                (IntPtr)Unsafe.AsPointer(ref s_NegativeOnes[0]));
+            fixed (void* negativeOnesPtr = &s_NegativeOnes[0])
+            {
+                OMSetRenderTargetsAndUnorderedAccessViews(
+                    KeepRenderTargetsAndDepthStencil, IntPtr.Zero, (ID3D11DepthStencilView)null,
+                    uavStartSlot, unorderedAccessViewCount, (IntPtr)unorderedAccessViewsPtr,
+                    (IntPtr)negativeOnesPtr);
+            }
         }
 
         public unsafe void OMSetRenderTargetsAndUnorderedAccessViews(
@@ -192,14 +195,16 @@ namespace Vortice.Direct3D11
                 unorderedAccessViewsPtr[i] = unorderedAccessViews[i].NativePointer;
             }
 
-            OMSetRenderTargetsAndUnorderedAccessViews(renderTargetViewsCount, 
-                (IntPtr)renderTargetViewsPtr,
-                depthStencilView,
-                startSlot,
-                unorderedAccessViewsCount, 
-                (IntPtr)unorderedAccessViewsPtr,
-                (IntPtr)Unsafe.AsPointer(ref s_NegativeOnes[0])
-                );
+            fixed (void* negativeOnesPtr = &s_NegativeOnes[0])
+            {
+                OMSetRenderTargetsAndUnorderedAccessViews(renderTargetViewsCount, 
+                    (IntPtr)renderTargetViewsPtr,
+                    depthStencilView,
+                    startSlot,
+                    unorderedAccessViewsCount, 
+                    (IntPtr)unorderedAccessViewsPtr,
+                    (IntPtr)negativeOnesPtr);
+            }
         }
 
         public unsafe void OMSetRenderTargetsAndUnorderedAccessViews(
@@ -223,13 +228,16 @@ namespace Vortice.Direct3D11
                 unorderedAccessViewsPtr[i] = unorderedAccessViews[i].NativePointer;
             }
 
-            OMSetRenderTargetsAndUnorderedAccessViews(renderTargetViewsCount,
-                (IntPtr)renderTargetViewsPtr,
-                depthStencilView,
-                startSlot,
-                unorderedAccessViewsCount,
-                (IntPtr)unorderedAccessViewsPtr,
-                (IntPtr)Unsafe.AsPointer(ref uavInitialCounts[0]));
+            fixed (void* negativeOnesPtr = &s_NegativeOnes[0])
+            {
+                OMSetRenderTargetsAndUnorderedAccessViews(renderTargetViewsCount, 
+                    (IntPtr)renderTargetViewsPtr,
+                    depthStencilView,
+                    startSlot,
+                    unorderedAccessViewsCount, 
+                    (IntPtr)unorderedAccessViewsPtr,
+                    (IntPtr)negativeOnesPtr);
+            }
         }
 
         public ID3D11CommandList FinishCommandList(bool restoreState)
@@ -254,22 +262,28 @@ namespace Vortice.Direct3D11
             return GetData(data, IntPtr.Zero, 0, flags) == Result.Ok;
         }
 
-        public T GetData<T>(ID3D11Asynchronous data, AsyncGetDataFlags flags) where T : struct
+        public T GetData<T>(ID3D11Asynchronous data, AsyncGetDataFlags flags) where T : unmanaged
         {
             GetData(data, flags, out T result);
             return result;
         }
 
-        public unsafe bool GetData<T>(ID3D11Asynchronous data, AsyncGetDataFlags flags, out T result) where T : struct
+        public unsafe bool GetData<T>(ID3D11Asynchronous data, AsyncGetDataFlags flags, out T result) where T : unmanaged
         {
             result = default;
-            return GetData(data, (IntPtr)Unsafe.AsPointer(ref result), Unsafe.SizeOf<T>(), flags) == Result.Ok;
+            fixed (void* resultPtr = &result)
+            {
+                return GetData(data, (IntPtr)resultPtr, sizeof(T), flags) == Result.Ok;
+            }
         }
 
         public unsafe bool GetData<T>(ID3D11Asynchronous data, out T result) where T : unmanaged
         {
             result = default;
-            return GetData(data, (IntPtr)Unsafe.AsPointer(ref result), sizeof(T), AsyncGetDataFlags.None) == Result.Ok;
+            fixed (void* resultPtr = &result)
+            {
+                return GetData(data, (IntPtr)resultPtr, sizeof(T), AsyncGetDataFlags.None) == Result.Ok;
+            }
         }
 
         public ID3D11BlendState OMGetBlendState()
@@ -326,14 +340,17 @@ namespace Vortice.Direct3D11
             }
         }
 
-        public unsafe void RSSetViewport<T>(T viewport) where T : struct
+        public unsafe void RSSetViewport<T>(T viewport) where T : unmanaged
         {
-            RSSetViewports(1, (IntPtr)Unsafe.AsPointer(ref viewport));
+            RSSetViewports(1, new IntPtr(&viewport));
         }
 
-        public unsafe void RSSetViewports<T>(T[] viewports) where T : struct
+        public unsafe void RSSetViewports<T>(T[] viewports) where T : unmanaged
         {
-            RSSetViewports(viewports.Length, (IntPtr)Unsafe.AsPointer(ref viewports[0]));
+            fixed (void* viewportsPtr = &viewports[0])
+            {
+                RSSetViewports(viewports.Length, (IntPtr)viewportsPtr);
+            }
         }
 
         public unsafe void RSSetViewports<T>(Span<T> viewports) where T : unmanaged
@@ -348,25 +365,34 @@ namespace Vortice.Direct3D11
         {
             int numViewports = 1;
             var viewport = new Viewport();
-            RSGetViewports(ref numViewports, (IntPtr)Unsafe.AsPointer(ref viewport));
+            RSGetViewports(ref numViewports, new IntPtr(&viewport));
             return viewport;
         }
 
         public unsafe void RSGetViewport(ref Viewport viewport)
         {
             int numViewports = 1;
-            RSGetViewports(ref numViewports, (IntPtr)Unsafe.AsPointer(ref viewport));
+            fixed (void* viewportPtr = &viewport)
+            {
+                RSGetViewports(ref numViewports, (IntPtr)viewportPtr);
+            }
         }
 
         public unsafe void RSGetViewports(Viewport[] viewports)
         {
             int numViewports = viewports.Length;
-            RSGetViewports(ref numViewports, (IntPtr)Unsafe.AsPointer(ref viewports[0]));
+            fixed (void* viewportsPtr = &viewports[0])
+            {
+                RSGetViewports(ref numViewports, (IntPtr)viewportsPtr);
+            }
         }
 
         public unsafe void RSGetViewports(int count, Viewport[] viewports)
         {
-            RSGetViewports(ref count, (IntPtr)Unsafe.AsPointer(ref viewports[0]));
+            fixed (void* viewportsPtr = &viewports[0])
+            {
+                RSGetViewports(ref count, (IntPtr)viewportsPtr);
+            }
         }
 
         public unsafe void RSGetViewports(Span<Viewport> viewports)
@@ -378,7 +404,7 @@ namespace Vortice.Direct3D11
             }
         }
 
-        public unsafe void RSGetViewports<T>(int count, T[] viewports) where T : struct
+        public unsafe void RSGetViewports<T>(int count, T[] viewports) where T : unmanaged
         {
 #if DEBUG
             if (Unsafe.SizeOf<T>() != Unsafe.SizeOf<Viewport>())
@@ -387,7 +413,10 @@ namespace Vortice.Direct3D11
             }
 #endif
 
-            RSGetViewports(ref count, (IntPtr)Unsafe.AsPointer(ref viewports[0]));
+            fixed (void* viewportsPtr = &viewports[0])
+            {
+                RSGetViewports(ref count, (IntPtr)viewportsPtr);
+            }
         }
 
         public unsafe void RSGetViewports<T>(Span<T> viewports) where T : unmanaged
@@ -411,7 +440,7 @@ namespace Vortice.Direct3D11
         /// </summary>
         /// <typeparam name="T">An array of viewports,  must be size of <see cref="Viewport"/>.</typeparam>
         /// <param name="viewports"></param>
-        public unsafe void RSGetViewports<T>(T[] viewports) where T : struct
+        public unsafe void RSGetViewports<T>(T[] viewports) where T : unmanaged
         {
 #if DEBUG
             if (Unsafe.SizeOf<T>() != Unsafe.SizeOf<Viewport>())
@@ -421,15 +450,17 @@ namespace Vortice.Direct3D11
 #endif
 
             int numViewports = viewports.Length;
-            void* pBuffer = Unsafe.AsPointer(ref viewports[0]);
-            RSGetViewports(ref numViewports, (IntPtr)pBuffer);
+            fixed (void* viewportsPtr = &viewports[0])
+            {
+                RSGetViewports(ref numViewports, (IntPtr)viewportsPtr);
+            }
         }
 
         /// <summary>	
         /// Get the array of viewports bound  to the rasterizer stage.	
         /// </summary>	
         /// <returns>An array of viewports, must be size of <see cref="Viewport"/></returns>
-        public T[] RSGetViewports<T>() where T : struct
+        public T[] RSGetViewports<T>() where T : unmanaged
         {
 #if DEBUG
             if (Unsafe.SizeOf<T>() != Unsafe.SizeOf<Viewport>())
@@ -499,25 +530,34 @@ namespace Vortice.Direct3D11
         {
             int numRects = 1;
             var rect = new RawRect();
-            RSGetScissorRects(ref numRects, (IntPtr)Unsafe.AsPointer(ref rect));
+            RSGetScissorRects(ref numRects, new IntPtr(&rect));
             return rect;
         }
 
         public unsafe void RSGetScissorRect(ref RawRect rect)
         {
             int numRects = 1;
-            RSGetScissorRects(ref numRects, (IntPtr)Unsafe.AsPointer(ref rect));
+            fixed (void* rectPtr = &rect)
+            {
+                RSGetScissorRects(ref numRects, (IntPtr)rectPtr);
+            }
         }
 
         public unsafe void RSGetScissorRects(RawRect[] rects)
         {
             int numRects = rects.Length;
-            RSGetScissorRects(ref numRects, (IntPtr)Unsafe.AsPointer(ref rects[0]));
+            fixed (void* rectsPtr = &rects[0])
+            {
+                RSGetScissorRects(ref numRects, (IntPtr)rectsPtr);
+            }
         }
 
         public unsafe void RSGetScissorRects(int count, RawRect[] rects)
         {
-            RSGetScissorRects(ref count, (IntPtr)Unsafe.AsPointer(ref rects[0]));
+            fixed (void* rectsPtr = &rects[0])
+            {
+                RSGetScissorRects(ref count, (IntPtr)rectsPtr);
+            }
         }
         #endregion
 
@@ -545,9 +585,12 @@ namespace Vortice.Direct3D11
                 targetsPtr[i] = targets[i] != null ? targets[i].NativePointer : IntPtr.Zero;
             }
 
-            SOSetTargets(buffersCount, (IntPtr)targetsPtr,
-                offsets?.Length > 0 ? (IntPtr)Unsafe.AsPointer(ref offsets[0]) : IntPtr.Zero
-                );
+            fixed (void* offsetsPtr = &offsets[0])
+            {
+                SOSetTargets(buffersCount, (IntPtr)targetsPtr,
+                    offsets?.Length > 0 ? (IntPtr)offsetsPtr : IntPtr.Zero
+                    );
+            }
         }
 
 
@@ -1213,9 +1256,12 @@ namespace Vortice.Direct3D11
         /// <param name="rowPitch">The row pitch.</param>
         /// <param name="depthPitch">The depth pitch.</param>
         /// <param name="region">The region</param>
-        public unsafe void UpdateSubresource<T>(ref T value, ID3D11Resource resource, int subresource = 0, int rowPitch = 0, int depthPitch = 0, Box? region = null) where T : struct
+        public unsafe void UpdateSubresource<T>(ref T value, ID3D11Resource resource, int subresource = 0, int rowPitch = 0, int depthPitch = 0, Box? region = null) where T : unmanaged
         {
-            UpdateSubresource(resource, subresource, region, (IntPtr)Unsafe.AsPointer(ref value), rowPitch, depthPitch);
+            fixed (void* valuePtr = &value)
+            {
+                UpdateSubresource(resource, subresource, region, (IntPtr)valuePtr, rowPitch, depthPitch);
+            }
         }
 
         /// <summary>
@@ -1228,9 +1274,12 @@ namespace Vortice.Direct3D11
         /// <param name="rowPitch">The row pitch.</param>
         /// <param name="depthPitch">The depth pitch.</param>
         /// <param name="region">A region that defines the portion of the destination subresource to copy the resource data into. Coordinates are in bytes for buffers and in texels for textures.</param>
-        public unsafe void UpdateSubresource<T>(T[] data, ID3D11Resource resource, int subresource = 0, int rowPitch = 0, int depthPitch = 0, Box? region = null) where T : struct
+        public unsafe void UpdateSubresource<T>(T[] data, ID3D11Resource resource, int subresource = 0, int rowPitch = 0, int depthPitch = 0, Box? region = null) where T : unmanaged
         {
-            UpdateSubresource(resource, subresource, region, (IntPtr)Unsafe.AsPointer(ref data[0]), rowPitch, depthPitch);
+            fixed (void* dataPtr = &data[0])
+            {
+                UpdateSubresource(resource, subresource, region, (IntPtr)dataPtr, rowPitch, depthPitch);
+            }
         }
 
         /// <summary>
@@ -1288,11 +1337,14 @@ namespace Vortice.Direct3D11
         /// <remarks>
         /// This method is implementing the <a href="http://blogs.msdn.com/b/chuckw/archive/2010/07/28/known-issue-direct3d-11-updatesubresource-and-deferred-contexts.aspx">workaround for deferred context</a>.
         /// </remarks>
-        public void UpdateSubresourceSafe<T>(ref T value, ID3D11Resource resource, int srcBytesPerElement, int subresource = 0, int rowPitch = 0, int depthPitch = 0, bool isCompressedResource = false) where T : struct
+        public void UpdateSubresourceSafe<T>(ref T value, ID3D11Resource resource, int srcBytesPerElement, int subresource = 0, int rowPitch = 0, int depthPitch = 0, bool isCompressedResource = false) where T : unmanaged
         {
             unsafe
             {
-                UpdateSubresourceSafe(resource, subresource, null, (IntPtr)Unsafe.AsPointer(ref value), rowPitch, depthPitch, srcBytesPerElement, isCompressedResource);
+                fixed (void* valuePtr = &value)
+                {
+                    UpdateSubresourceSafe(resource, subresource, null, (IntPtr)valuePtr, rowPitch, depthPitch, srcBytesPerElement, isCompressedResource);
+                }
             }
         }
 
@@ -1310,11 +1362,14 @@ namespace Vortice.Direct3D11
         /// <remarks>
         /// This method is implementing the <a href="http://blogs.msdn.com/b/chuckw/archive/2010/07/28/known-issue-direct3d-11-updatesubresource-and-deferred-contexts.aspx">workaround for deferred context</a>.
         /// </remarks>
-        public void UpdateSubresourceSafe<T>(T[] data, ID3D11Resource resource, int srcBytesPerElement, int subresource = 0, int rowPitch = 0, int depthPitch = 0, bool isCompressedResource = false) where T : struct
+        public void UpdateSubresourceSafe<T>(T[] data, ID3D11Resource resource, int srcBytesPerElement, int subresource = 0, int rowPitch = 0, int depthPitch = 0, bool isCompressedResource = false) where T : unmanaged
         {
             unsafe
             {
-                UpdateSubresourceSafe(resource, subresource, null, (IntPtr)Unsafe.AsPointer(ref data[0]), rowPitch, depthPitch, srcBytesPerElement, isCompressedResource);
+                fixed (void* dataPtr = &data[0])
+                {
+                    UpdateSubresourceSafe(resource, subresource, null, (IntPtr)dataPtr, rowPitch, depthPitch, srcBytesPerElement, isCompressedResource);
+                }
             }
         }
 

--- a/src/Vortice.Direct3D11/ID3D11DeviceContext1.cs
+++ b/src/Vortice.Direct3D11/ID3D11DeviceContext1.cs
@@ -16,7 +16,10 @@ namespace Vortice.Direct3D11
 
         public unsafe void ClearView(ID3D11View view, Color4 color, RawRect[] rects)
         {
-            ClearView(view, color, (IntPtr)Unsafe.AsPointer(ref rects[0]), rects.Length);
+            fixed (RawRect* pRects = rects)
+            {
+                ClearView(view, color, (IntPtr)pRects, rects.Length);
+            }
         }
 
         public unsafe void ClearView(ID3D11View view, Color4 color, ReadOnlySpan<RawRect> rects)
@@ -34,7 +37,10 @@ namespace Vortice.Direct3D11
 
         public unsafe void ClearView(ID3D11View view, System.Drawing.Color color, RawRect[] rects)
         {
-            ClearView(view, new Color4(color), (IntPtr)Unsafe.AsPointer(ref rects[0]), rects.Length);
+            fixed (RawRect* pRects = rects)
+            {
+                ClearView(view, new Color4(color), (IntPtr)pRects, rects.Length);
+            }
         }
 
         public unsafe void ClearView(ID3D11View view, System.Drawing.Color color, ReadOnlySpan<RawRect> rects)
@@ -71,7 +77,10 @@ namespace Vortice.Direct3D11
         {
             unsafe
             {
-                DiscardView1(view, (IntPtr)Unsafe.AsPointer(ref rects[0]), rects.Length);
+                fixed (RawRect* pRects = rects)
+                {
+                    DiscardView1(view, (IntPtr)pRects, rects.Length);
+                }
             }
         }
 
@@ -101,9 +110,13 @@ namespace Vortice.Direct3D11
             var nativePtr = constantBuffer == null ? IntPtr.Zero : constantBuffer.NativePointer;
             unsafe
             {
-                VSSetConstantBuffers1(slot, 1, new IntPtr(&nativePtr),
-                    (IntPtr)Unsafe.AsPointer(ref firstConstant[0]),
-                    (IntPtr)Unsafe.AsPointer(ref numConstants[0]));
+                fixed (void* firstConstantPtr = &firstConstant[0])
+                fixed (void* numConstantsPtr = &numConstants[0])
+                {
+                    VSSetConstantBuffers1(slot, 1, new IntPtr(&nativePtr),
+                        (IntPtr)firstConstantPtr,
+                        (IntPtr)numConstantsPtr);
+                }
             }
         }
 
@@ -119,9 +132,13 @@ namespace Vortice.Direct3D11
             var nativePtr = constantBuffer == null ? IntPtr.Zero : constantBuffer.NativePointer;
             unsafe
             {
-                PSSetConstantBuffers1(slot, 1, new IntPtr(&nativePtr),
-                    (IntPtr)Unsafe.AsPointer(ref firstConstant[0]),
-                    (IntPtr)Unsafe.AsPointer(ref numConstants[0]));
+                fixed (void* firstConstantPtr = &firstConstant[0])
+                fixed (void* numConstantsPtr = &numConstants[0])
+                {
+                    PSSetConstantBuffers1(slot, 1, new IntPtr(&nativePtr),
+                        (IntPtr)firstConstantPtr,
+                        (IntPtr)numConstantsPtr);
+                }
             }
         }
 
@@ -137,9 +154,13 @@ namespace Vortice.Direct3D11
             var nativePtr = constantBuffer == null ? IntPtr.Zero : constantBuffer.NativePointer;
             unsafe
             {
-                DSSetConstantBuffers1(slot, 1, new IntPtr(&nativePtr),
-                    (IntPtr)Unsafe.AsPointer(ref firstConstant[0]),
-                    (IntPtr)Unsafe.AsPointer(ref numConstants[0]));
+                fixed (void* firstConstantPtr = &firstConstant[0])
+                fixed (void* numConstantsPtr = &numConstants[0])
+                {
+                    DSSetConstantBuffers1(slot, 1, new IntPtr(&nativePtr),
+                        (IntPtr)firstConstantPtr,
+                        (IntPtr)numConstantsPtr);
+                }
             }
         }
 
@@ -155,9 +176,13 @@ namespace Vortice.Direct3D11
             var nativePtr = constantBuffer == null ? IntPtr.Zero : constantBuffer.NativePointer;
             unsafe
             {
-                HSSetConstantBuffers1(slot, 1, new IntPtr(&nativePtr),
-                    (IntPtr)Unsafe.AsPointer(ref firstConstant[0]),
-                    (IntPtr)Unsafe.AsPointer(ref numConstants[0]));
+                fixed (void* firstConstantPtr = &firstConstant[0])
+                fixed (void* numConstantsPtr = &numConstants[0])
+                {
+                    HSSetConstantBuffers1(slot, 1, new IntPtr(&nativePtr),
+                        (IntPtr)firstConstantPtr,
+                        (IntPtr)numConstantsPtr);
+                }
             }
         }
 
@@ -173,9 +198,13 @@ namespace Vortice.Direct3D11
             var nativePtr = constantBuffer == null ? IntPtr.Zero : constantBuffer.NativePointer;
             unsafe
             {
-                GSSetConstantBuffers1(slot, 1, new IntPtr(&nativePtr),
-                    (IntPtr)Unsafe.AsPointer(ref firstConstant[0]),
-                    (IntPtr)Unsafe.AsPointer(ref numConstants[0]));
+                fixed (void* firstConstantPtr = &firstConstant[0])
+                fixed (void* numConstantsPtr = &numConstants[0])
+                {
+                    GSSetConstantBuffers1(slot, 1, new IntPtr(&nativePtr),
+                        (IntPtr)firstConstantPtr,
+                        (IntPtr)numConstantsPtr);
+                }
             }
         }
 
@@ -191,9 +220,13 @@ namespace Vortice.Direct3D11
             var nativePtr = constantBuffer == null ? IntPtr.Zero : constantBuffer.NativePointer;
             unsafe
             {
-                CSSetConstantBuffers1(slot, 1, new IntPtr(&nativePtr),
-                    (IntPtr)Unsafe.AsPointer(ref firstConstant[0]),
-                    (IntPtr)Unsafe.AsPointer(ref numConstants[0]));
+                fixed (void* firstConstantPtr = &firstConstant[0])
+                fixed (void* numConstantsPtr = &numConstants[0])
+                {
+                    CSSetConstantBuffers1(slot, 1, new IntPtr(&nativePtr),
+                        (IntPtr)firstConstantPtr,
+                        (IntPtr)numConstantsPtr);
+                }
             }
         }
 

--- a/src/Vortice.Direct3D12/CommandSignatureDescription.cs
+++ b/src/Vortice.Direct3D12/CommandSignatureDescription.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using SharpGen.Runtime;
 
@@ -59,10 +58,13 @@ namespace Vortice.Direct3D12
             if (@ref.NumArgumentDescs > 0)
             {
                 @ref.pArgumentDescs = Interop.Alloc<IndirectArgumentDescription>(@ref.NumArgumentDescs);
-                MemoryHelpers.CopyMemory(
-                    @ref.pArgumentDescs,
-                    (IntPtr)Unsafe.AsPointer(ref IndirectArguments[0]),
-                    @ref.NumArgumentDescs * sizeof(IndirectArgumentDescription));
+                fixed (void* indirectArgumentsPtr = &IndirectArguments[0])
+                {
+                    MemoryHelpers.CopyMemory(
+                        @ref.pArgumentDescs,
+                        (IntPtr)indirectArgumentsPtr,
+                        @ref.NumArgumentDescs * sizeof(IndirectArgumentDescription));
+                }
             }
             @ref.NodeMask = NodeMask;
         }

--- a/src/Vortice.Direct3D12/GraphicsPipelineStateDescription.cs
+++ b/src/Vortice.Direct3D12/GraphicsPipelineStateDescription.cs
@@ -122,10 +122,13 @@ namespace Vortice.Direct3D12
             if (RenderTargetFormats.Length > 0)
             {
                 @ref.NumRenderTargets = Math.Min(RenderTargetFormats.Length, D3D12.SimultaneousRenderTargetCount);
-                MemoryHelpers.CopyMemory(
-                    (IntPtr)Unsafe.AsPointer(ref @ref.RenderTargetFormats),
-                    (IntPtr)Unsafe.AsPointer(ref RenderTargetFormats[0]),
-                    @ref.NumRenderTargets * sizeof(Format));
+                fixed (void* renderTargetFormatsPtr = &RenderTargetFormats[0])
+                {
+                    MemoryHelpers.CopyMemory(
+                        (IntPtr)Unsafe.AsPointer(ref @ref.RenderTargetFormats),
+                        (IntPtr)renderTargetFormatsPtr,
+                        @ref.NumRenderTargets * sizeof(Format));
+                }
             }
             else
             {

--- a/src/Vortice.Direct3D12/ID3D12Device.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device.cs
@@ -43,13 +43,16 @@ namespace Vortice.Direct3D12
         public unsafe T CheckFeatureSupport<T>(Feature feature) where T : unmanaged
         {
             T featureSupport = default;
-            CheckFeatureSupport(feature, new IntPtr(Unsafe.AsPointer(ref featureSupport)), sizeof(T));
+            CheckFeatureSupport(feature, new IntPtr(&featureSupport), sizeof(T));
             return featureSupport;
         }
 
         public unsafe bool CheckFeatureSupport<T>(Feature feature, ref T featureSupport) where T : unmanaged
         {
-            return CheckFeatureSupport(feature, new IntPtr(Unsafe.AsPointer(ref featureSupport)), sizeof(T)).Success;
+            fixed (void* featureSupportPtr = &featureSupport)
+            {
+                return CheckFeatureSupport(feature, (IntPtr)featureSupportPtr, sizeof(T)).Success;
+            }
         }
 
         public FeatureLevel CheckMaxSupportedFeatureLevel() => CheckMaxSupportedFeatureLevel(D3D12.FeatureLevels);

--- a/src/Vortice.Direct3D12/ID3D12GraphicsCommandList.cs
+++ b/src/Vortice.Direct3D12/ID3D12GraphicsCommandList.cs
@@ -173,19 +173,25 @@ namespace Vortice.Direct3D12
             }
         }
 
-        public unsafe void RSSetViewport<T>(T viewport) where T : struct
+        public unsafe void RSSetViewport<T>(T viewport) where T : unmanaged
         {
-            RSSetViewports(1, (IntPtr)Unsafe.AsPointer(ref viewport));
+            RSSetViewports(1, new IntPtr(&viewport));
         }
 
-        public unsafe void RSSetViewports<T>(T[] viewports) where T : struct
+        public unsafe void RSSetViewports<T>(T[] viewports) where T : unmanaged
         {
-            RSSetViewports(viewports.Length, (IntPtr)Unsafe.AsPointer(ref viewports[0]));
+            fixed (void* viewportsPtr = &viewports[0])
+            {
+                RSSetViewports(viewports.Length, (IntPtr)viewportsPtr);
+            }
         }
 
-        public unsafe void RSSetViewports<T>(int count, T[] viewports) where T : struct
+        public unsafe void RSSetViewports<T>(int count, T[] viewports) where T : unmanaged
         {
-            RSSetViewports(count, (IntPtr)Unsafe.AsPointer(ref viewports[0]));
+            fixed (void* viewportsPtr = &viewports[0])
+            {
+                RSSetViewports(count, (IntPtr)viewportsPtr);
+            }
         }
 
         public unsafe void RSSetViewports<T>(int count, Span<T> viewports) where T : unmanaged
@@ -376,13 +382,16 @@ namespace Vortice.Direct3D12
         /// <param name="numSubresources">The number of subresources in the resource to discard.</param>
         public unsafe void DiscardResource(ID3D12Resource resource, RawRect[] rects, int firstSubresource, int numSubresources)
         {
-            DiscardResource(resource, new DiscardRegion
+            fixed (void* rectsPtr = &rects[0])
             {
-                NumRects = rects.Length,
-                PRects = (IntPtr)Unsafe.AsPointer(ref rects[0]),
-                FirstSubresource = firstSubresource,
-                NumSubresources = numSubresources
-            });
+                DiscardResource(resource, new DiscardRegion
+                {
+                    NumRects = rects.Length,
+                    PRects = (IntPtr)rectsPtr,
+                    FirstSubresource = firstSubresource,
+                    NumSubresources = numSubresources
+                });
+            }
         }
 
         public void Reset(ID3D12CommandAllocator commandAllocator)

--- a/src/Vortice.Direct3D12/ID3D12Resource.cs
+++ b/src/Vortice.Direct3D12/ID3D12Resource.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
 using Vortice.Mathematics;
 
 namespace Vortice.Direct3D12
@@ -71,29 +70,38 @@ namespace Vortice.Direct3D12
             int destinationSubresource,
             T[] sourceData, int sourceRowPitch, int srcDepthPitch) where T : unmanaged
         {
-            WriteToSubresource(
-                destinationSubresource, null,
-                (IntPtr)Unsafe.AsPointer(ref sourceData[0]), sourceRowPitch, srcDepthPitch
-                );
+            fixed (void* sourceDataPtr = &sourceData[0])
+            {
+                WriteToSubresource(
+                    destinationSubresource, null,
+                    (IntPtr)sourceDataPtr, sourceRowPitch, srcDepthPitch
+                    );
+            }
         }
 
         public unsafe void WriteToSubresource<T>(
             int destinationSubresource, Box destinationBox,
             T[] sourceData, int sourceRowPitch, int srcDepthPitch) where T : unmanaged
         {
-            WriteToSubresource(
-                destinationSubresource, destinationBox,
-                (IntPtr)Unsafe.AsPointer(ref sourceData[0]), sourceRowPitch, srcDepthPitch
-                );
+            fixed (void* sourceDataPtr = &sourceData[0])
+            {
+                WriteToSubresource(
+                    destinationSubresource, destinationBox,
+                    (IntPtr)sourceDataPtr, sourceRowPitch, srcDepthPitch
+                    );
+            }
         }
 
         public unsafe void ReadFromSubresource<T>(
             T[] destination, int destinationRowPitch, int destinationDepthPitch,
             int sourceSubresource, Box? sourceBox = null) where T : unmanaged
         {
-            ReadFromSubresource(
-                (IntPtr)Unsafe.AsPointer(ref destination[0]), destinationRowPitch, destinationDepthPitch,
-                sourceSubresource, sourceBox);
+            fixed (void* destinationPtr = &destination[0])
+            {
+                ReadFromSubresource(
+                    (IntPtr)destinationPtr, destinationRowPitch, destinationDepthPitch,
+                    sourceSubresource, sourceBox);
+            }
         }
 
         public static int CalculateSubresource(int mipSlice, int arraySlice, int planeSlice, int mipLevels, int arraySize)

--- a/src/Vortice.Direct3D9/IDirect3DDevice9.cs
+++ b/src/Vortice.Direct3D9/IDirect3DDevice9.cs
@@ -229,7 +229,7 @@ namespace Vortice.Direct3D9
             unsafe
             {
                 T result = default;
-                GetRenderState(state, (IntPtr)Unsafe.AsPointer(ref result));
+                GetRenderState(state, new IntPtr(&result));
                 return result;
             }
         }

--- a/src/Vortice.DirectX/Interop.cs
+++ b/src/Vortice.DirectX/Interop.cs
@@ -23,7 +23,10 @@ namespace Vortice
         {
             unsafe
             {
-                Unsafe.CopyBlockUnaligned((void*)destination, Unsafe.AsPointer(ref value), (uint)(sizeof(T)));
+                fixed (void* valuePtr = &value)
+                {
+                    Unsafe.CopyBlockUnaligned((void*)destination, valuePtr, (uint)(sizeof(T)));
+                }
             }
         }
 

--- a/src/Vortice.Runtime.COM/Win32/ComStreamProxy.cs
+++ b/src/Vortice.Runtime.COM/Win32/ComStreamProxy.cs
@@ -49,10 +49,14 @@ namespace SharpGen.Runtime.Win32
                     return totalRead;
                 }
 
-                Unsafe.CopyBlockUnaligned(
-                    totalRead + (byte*)buffer, 
-                    Unsafe.AsPointer(ref _tempBuffer[0]), 
-                    count);
+
+                fixed (void* bufferPtr = &_tempBuffer[0])
+                {
+                    Unsafe.CopyBlockUnaligned(
+                        totalRead + (byte*)buffer, 
+                        bufferPtr,
+                        count);
+                }
                 numberOfBytesToRead -= count;
                 totalRead += count;
             }

--- a/src/Vortice.XAudio2/AudioBuffer.cs
+++ b/src/Vortice.XAudio2/AudioBuffer.cs
@@ -36,10 +36,13 @@ namespace Vortice.XAudio2
             AudioDataPointer = MemoryHelpers.AllocateMemory(data.Length);
             unsafe
             {
-                Unsafe.CopyBlockUnaligned(
-                    AudioDataPointer.ToPointer(),
-                    Unsafe.AsPointer(ref data[0]),
-                    (uint)data.Length);
+                fixed (void* dataPtr = &data[0])
+                {
+                    Unsafe.CopyBlockUnaligned(
+                        AudioDataPointer.ToPointer(),
+                        dataPtr,
+                        (uint)data.Length);
+                }
             }
 
             _ownsBuffer = true;

--- a/src/Vortice.XAudio2/Emitter.cs
+++ b/src/Vortice.XAudio2/Emitter.cs
@@ -15,7 +15,7 @@ namespace Vortice.XAudio2
     public partial class Emitter
     {
         /// <summary>
-        /// Reference to Cone data.
+        /// Cone data.
         /// </summary>
         public Cone? Cone;
 
@@ -35,7 +35,7 @@ namespace Vortice.XAudio2
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
         internal unsafe struct __Native
         {
-            public void* ConePointer;
+            public Cone* ConePointer;
             public Vector3 OrientFront;
             public Vector3 OrientTop;
             public Vector3 Position;
@@ -52,6 +52,7 @@ namespace Vortice.XAudio2
             public IntPtr ReverbCurvePointer;
             public float CurveDistanceScaler;
             public float DopplerScaler;
+            public Cone Cone;
 
             internal unsafe void __MarshalFree()
             {
@@ -107,8 +108,8 @@ namespace Vortice.XAudio2
             }
             else
             {
-                var coneValue = Cone.Value;
-                @ref.ConePointer = Unsafe.AsPointer(ref coneValue);
+                @ref.Cone = Cone.Value;
+                @ref.ConePointer = (Cone*)Unsafe.AsPointer(ref @ref.Cone);
             }
         }
     }

--- a/src/Vortice.XAudio2/Listener.cs
+++ b/src/Vortice.XAudio2/Listener.cs
@@ -14,7 +14,7 @@ namespace Vortice.XAudio2
     public partial class Listener
     {
         /// <summary>
-        /// Reference to Cone data.
+        /// Cone data.
         /// </summary>
         public Cone? Cone;
 
@@ -26,7 +26,8 @@ namespace Vortice.XAudio2
             public Vector3 OrientTop;
             public Vector3 Position;
             public Vector3 Velocity;
-            public void* ConePointer;
+            public Cone* ConePointer;
+            public Cone Cone;
         }
 
         internal unsafe void __MarshalTo(ref __Native @ref)
@@ -41,8 +42,8 @@ namespace Vortice.XAudio2
             }
             else
             {
-                var coneValue = Cone.Value;
-                @ref.ConePointer = Unsafe.AsPointer(ref coneValue);
+                @ref.Cone = Cone.Value;
+                @ref.ConePointer = (Cone*)Unsafe.AsPointer(ref @ref.Cone);
             }
         }
     }


### PR DESCRIPTION
- As the name implies, ``Unsafe.AsPointer`` is to be used with great caution. It is by no means a replacement for the ``fixed`` statement. It does nothing to prevent managed variables (e.g. arrays) from being relocated.
There are only two uses of ``Unsafe.AsPointer`` left in the codebase ([Listener.cs](https://github.com/SomeAnonDev/Vortice.Windows/blob/ba6ef8ada47834f79c91da270564a1118b650ca6/src/Vortice.XAudio2/Listener.cs#L46) and [Emitter.cs](https://github.com/SomeAnonDev/Vortice.Windows/blob/ba6ef8ada47834f79c91da270564a1118b650ca6/src/Vortice.XAudio2/Emitter.cs#L112)). ``__Native`` never lives on the heap, and as long as the native code doesn't store the pointer to ``Cone``, it should be fine.
- e6205b3 fixes a problem where a pointer to a local variable was stored in a struct that outlives the method where the variable is declared.
- XAudio effect parameters must not be freed immediately, according to [the docs](https://docs.microsoft.com/en-us/windows/win32/api/xaudio2/nf-xaudio2-ixaudio2voice-seteffectparameters).
ba6ef8a is an attempt to address that.