### PR TITLE
let HitTestTextRange and GetLineMetrics return hresult

### DIFF
--- a/src/Vortice.Direct2D1/Mappings.xml
+++ b/src/Vortice.Direct2D1/Mappings.xml
@@ -548,6 +548,10 @@
     
     <!-- IDWriteTextLayout -->
     <map method="IDWriteTextLayout::GetLineMetrics" visibility="internal" hresult="true" check="false"/>
+    <map method="IDWriteTextLayout::HitTestTextRange" hresult="true" check="false"/>
+
+    <!-- IDWriteTextLayout3 -->
+    <map method="IDWriteTextLayout3::GetLineMetrics" hresult="true" check="false"/>
     
     <!-- IDWriteFont -->
     <map param="IDWriteFont::CreateFontFace::fontFace" attribute="out" return="true" />


### PR DESCRIPTION
It painful to write code like this
```
int actualLineCount=0;
try
{
    textlayout.GetLineMetrics(null, 0, out actualLineCount);
}
catch
{
    var lineMetrics = new LineMetrics1[actualLineCount];
    if (actualLineCount > 0)
    {
        GetLineMetrics(lineMetrics, lineMetrics.Length, out _);
    }
    return lineMetrics;
}
return new LineMetrics1[0];
```
so it's better to let these methods return hresult.

If you want to let these methods work like [IDWriteTextLayout.GetLineMetrics](https://github.com/amerkoleci/Vortice.Windows/blob/master/src/Vortice.Direct2D1/DirectWrite/IDWriteTextLayout.cs) that good but I believed my commit is ok. And either is better than it is now.