### PR TITLE
 workaround for dotnet/runtime#35171

### DIFF
--- a/src/Vortice.Direct2D1/DirectWrite/IDWriteFontCollectionLoader.cs
+++ b/src/Vortice.Direct2D1/DirectWrite/IDWriteFontCollectionLoader.cs
@@ -11,7 +11,7 @@ namespace Vortice.DirectWrite
     [Shadow(typeof(IDWriteFontCollectionLoaderShadow))]
     public partial interface IDWriteFontCollectionLoader
     {
-        IDWriteFontFileEnumerator CreateEnumeratorFromKey(IDWriteFactory factory, Span<byte> collectionKey);
+        IDWriteFontFileEnumerator CreateEnumeratorFromKey(IDWriteFactory factory, IntPtr collectionKey, int size);
     }
 
     internal class IDWriteFontCollectionLoaderShadow : ComObjectShadow
@@ -49,7 +49,7 @@ namespace Vortice.DirectWrite
                     var shadow = ToShadow<IDWriteFontCollectionLoaderShadow>(thisPtr);
                     var callback = (IDWriteFontCollectionLoader)shadow.Callback;
                     Debug.Assert(factory == shadow._factory.NativePointer);
-                    var enumerator = callback.CreateEnumeratorFromKey(shadow._factory, new Span<byte>(collectionKey.ToPointer(), collectionKeySize));
+                    var enumerator = callback.CreateEnumeratorFromKey(shadow._factory, collectionKey, collectionKeySize);
                     fontFileEnumerator = IDWriteFontFileEnumeratorShadow.ToIntPtr(enumerator);
                 }
                 catch (Exception exception)


### PR DESCRIPTION
repro : https://github.com/yinyue200/SpanDxTest


```
 Generating code...
1>    Interop code generated.
1>  Compiling interop code
1>  Generating System.Reflection.DispatchProxy proxy code.
1>  Cleaning up unreferenced code
1>  Generating native code
1>C:\Users\username\.nuget\packages\microsoft.net.native.compiler\2.2.8-rel-28605-00\tools\Microsoft.NetNative.targets(801,5): error : Error: NUTC300D:Internal Compiler Error: Type 'System.Span`1<System.Byte>' is not valid for use outside of the managed environment, but is passed to native code while compiling method 'static System.Int32 __Interop.Intrinsics.StdCall__97(System.IntPtr, System.Void*, System.Void*, System.Span`1<System.Byte>, System.Void*)'.
1>C:\Users\username\.nuget\packages\microsoft.net.native.compiler\2.2.8-rel-28605-00\tools\Microsoft.NetNative.targets(801,5): error : ILT0005: 'C:\Users\username\.nuget\packages\runtime.win10-x86.microsoft.net.native.compiler\2.2.8-rel-28605-00\tools\x86\ilc\Tools\nutc_driver.exe @"C:\Users\username\Source\Repos\SpanDxTest\SpanDxTest\obj\x86\Release\ilc\intermediate\MDIL\SpanDxTest.rsp"' returned exit code 1
========== Build: 0 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========
```