### PR TITLE
fix Windows App Certification Kit (WACK) failure

### DIFF
--- a/src/Vortice.Runtime.COM/VorticePlatformDetection.cs
+++ b/src/Vortice.Runtime.COM/VorticePlatformDetection.cs
@@ -78,13 +78,13 @@ namespace SharpGen.Runtime
 
         private static uint GetWindowsVersion()
         {
-            var result = RtlGetVersionEx(out var osvi);
+            var result = GetVersionExWEx(out var osvi);
             Debug.Assert(result == 0);
             return osvi.dwMajorVersion;
         }
         private static uint GetWindowsMinorVersion()
         {
-            var result = RtlGetVersionEx(out var osvi);
+            var result = GetVersionExWEx(out var osvi);
             Debug.Assert(result == 0);
             return osvi.dwMinorVersion;
         }
@@ -92,18 +92,18 @@ namespace SharpGen.Runtime
         [DllImport("kernel32.dll", ExactSpelling = true)]
         private static extern int GetCurrentApplicationUserModelId(ref uint applicationUserModelIdLength, byte[] applicationUserModelId);
 
-        [DllImport("ntdll.dll", ExactSpelling = true)]
-        private static extern int RtlGetVersion(ref RTL_OSVERSIONINFOEX lpVersionInformation);
+        [DllImport("kernel32.dll", ExactSpelling = true)]
+        private static extern int GetVersionExW(ref OSVERSIONINFOEX lpVersionInformation);
 
-        private static unsafe int RtlGetVersionEx(out RTL_OSVERSIONINFOEX osvi)
+        private static unsafe int GetVersionExWEx(out OSVERSIONINFOEX osvi)
         {
             osvi = default;
-            osvi.dwOSVersionInfoSize = (uint)sizeof(RTL_OSVERSIONINFOEX);
-            return RtlGetVersion(ref osvi);
+            osvi.dwOSVersionInfoSize = (uint)sizeof(OSVERSIONINFOEX);
+            return GetVersionExW(ref osvi);
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        private unsafe struct RTL_OSVERSIONINFOEX
+        private unsafe struct OSVERSIONINFOEX
         {
             internal uint dwOSVersionInfoSize;
             internal uint dwMajorVersion;

--- a/src/Vortice.XInput/XInput.cs
+++ b/src/Vortice.XInput/XInput.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Amer Koleci and contributors.
+ï»¿// Copyright (c) Amer Koleci and contributors.
 // Distributed under the MIT license. See the LICENSE file in the project root for more information.
 
 using System;
@@ -17,11 +17,11 @@ namespace Vortice.XInput
         {
             get
             {
-                var osvi = new RTL_OSVERSIONINFOEX
+                var osvi = new OSVERSIONINFOEX
                 {
-                    dwOSVersionInfoSize = sizeof(RTL_OSVERSIONINFOEX)
+                    dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX)
                 };
-                var result = RtlGetVersion(ref osvi);
+                var result = GetVersionExW(ref osvi);
                 Debug.Assert(result == 0);
                 var WindowsVersion = new Version(osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
                 return WindowsVersion.Major == 6 && WindowsVersion.Minor == 1;
@@ -176,7 +176,7 @@ namespace Vortice.XInput
         /// <summary>
         /// Retrieves the battery type and charge status of a wireless controller.
         /// </summary>
-        /// <param name="userIndex">Index of the user's controller. Can be a value in the range 0–3. </param>
+        /// <param name="userIndex">Index of the user's controller. Can be a value in the range 0â€“3. </param>
         /// <param name="batteryDeviceType">Type of the battery device.</param>
         /// <returns>Instance of <see cref="BatteryInformation"/>.</returns>
         public static BatteryInformation GetBatteryInformation(int userIndex, BatteryDeviceType batteryDeviceType)
@@ -188,7 +188,7 @@ namespace Vortice.XInput
         /// <summary>
         /// Retrieves the battery type and charge status of a wireless controller.
         /// </summary>
-        /// <param name="userIndex">Index of the user's controller. Can be a value in the range 0–3. </param>
+        /// <param name="userIndex">Index of the user's controller. Can be a value in the range 0â€“3. </param>
         /// <param name="batteryDeviceType">Type of the battery device.</param>
         /// <param name="batteryInformation">The battery information.</param>
         /// <returns>True if succeed, false otherwise.</returns>
@@ -200,7 +200,7 @@ namespace Vortice.XInput
         /// <summary>
         /// Retrieves the capabilities and features of a connected controller.
         /// </summary>
-        /// <param name="userIndex">Index of the user's controller. Can be a value in the range 0–3. </param>
+        /// <param name="userIndex">Index of the user's controller. Can be a value in the range 0â€“3. </param>
         /// <param name="deviceQueryType">Type of the device query.</param>
         /// <param name="capabilities">The capabilities of this controller.</param>
         /// <returns>True if the controller is connected and succeed, false otherwise.</returns>
@@ -212,7 +212,7 @@ namespace Vortice.XInput
         /// <summary>
         /// Retrieves a gamepad input event.
         /// </summary>
-        /// <param name="userIndex">Index of the user's controller. Can be a value in the range 0–3. </param>
+        /// <param name="userIndex">Index of the user's controller. Can be a value in the range 0â€“3. </param>
         /// <param name="keystroke">The keystroke.</param>
         /// <returns>False if the controller is not connected and no new keys have been pressed, true otherwise.</returns>
         public static bool GetKeystroke(int userIndex, out Keystroke keystroke)
@@ -229,7 +229,7 @@ namespace Vortice.XInput
         private static extern int GetCurrentApplicationUserModelId(ref uint applicationUserModelIdLength, byte[] applicationUserModelId);
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        private unsafe struct RTL_OSVERSIONINFOEX
+        private unsafe struct OSVERSIONINFOEX
         {
             internal int dwOSVersionInfoSize;
             internal int dwMajorVersion;
@@ -239,8 +239,8 @@ namespace Vortice.XInput
             internal fixed char szCSDVersion[128];
         }
 
-        [DllImport("ntdll.dll", ExactSpelling = true)]
-        private static extern int RtlGetVersion(ref RTL_OSVERSIONINFOEX lpVersionInformation);
+        [DllImport("kernel32.dll", ExactSpelling = true)]
+        private static extern int GetVersionExW(ref OSVERSIONINFOEX lpVersionInformation);
         #endregion
     }
 }


### PR DESCRIPTION
RtlGetVersion  is not allowed in uwp apps. This pr replaces RtlGetVersion with GetVersionExW which is allowed by the WACK tool.
Here is an example of WACK failing report:

Supported API test
FAILED
    Supported APIs
    Error Found: The supported APIs test detected the following errors:
        API RtlGetVersion in ntdll.dll is not supported for this application type. example.dll calls this API.
    Impact if not fixed: Using an API that is not part of the Windows SDK for Microsoft Store apps violates the Microsoft Store certification requirements.
    How to fix: Review the error messages to identify the API that is not part of the Windows SDK for Microsoft Store apps. Please note, apps that are built in a debug configuration or without .NET Native enabled (where applicable) can fail this test as these environments may pull in unsupported APIs. Retest your app in a release configuration, and with .NET Native enabled if applicable. See the link below for more information:
    Alternatives to Windows APIs in Microsoft Store apps. (http://go.microsoft.com/fwlink/?LinkID=244022)