### PR TITLE
Fix ID3D12CommandQueue.ExecuteCommandLists

### DIFF
--- a/src/Vortice.Direct3D12/ID3D12CommandQueue.cs
+++ b/src/Vortice.Direct3D12/ID3D12CommandQueue.cs
@@ -37,7 +37,6 @@ namespace Vortice.Direct3D12
         {
             var commandListsPtr = (IntPtr*)0;
 
-            count = commandLists.Length;
             IntPtr* tempPtr = stackalloc IntPtr[count];
             commandListsPtr = tempPtr;
             for (int i = 0; i < count; i++)


### PR DESCRIPTION
This fixes the ExecuteCommandLists(count, commandLists) method, which currently ignores the "count" parameter and always uses the length of the "commandLists" array instead.