### PR TITLE
Make more vtables static to avoid reallocating them for every shadow object

### DIFF
--- a/src/Vortice.Direct2D1/DirectWrite/IDWriteFontCollectionLoader.cs
+++ b/src/Vortice.Direct2D1/DirectWrite/IDWriteFontCollectionLoader.cs
@@ -16,7 +16,9 @@ namespace Vortice.DirectWrite
 
     internal class IDWriteFontCollectionLoaderShadow : ComObjectShadow
     {
-        protected override CppObjectVtbl Vtbl => new FontCollectionLoaderVtbl();
+        private static readonly ComObjectVtbl _vTable = new FontCollectionLoaderVtbl();
+
+        protected override CppObjectVtbl Vtbl => _vTable;
 
         private IDWriteFactory _factory;
 
@@ -41,7 +43,7 @@ namespace Vortice.DirectWrite
             [UnmanagedFunctionPointer(CallingConvention.StdCall)]
             private delegate int CreateEnumeratorFromKeyDelegate(IntPtr thisPtr, IntPtr factory, IntPtr collectionKey, int collectionKeySize, out IntPtr fontFileEnumerator);
 
-            private static unsafe int CreateEnumeratorFromKeyImpl(IntPtr thisPtr, IntPtr factory, IntPtr collectionKey, int collectionKeySize, out IntPtr fontFileEnumerator)
+            private static int CreateEnumeratorFromKeyImpl(IntPtr thisPtr, IntPtr factory, IntPtr collectionKey, int collectionKeySize, out IntPtr fontFileEnumerator)
             {
                 fontFileEnumerator = IntPtr.Zero;
                 try

--- a/src/Vortice.Direct2D1/DirectWrite/IDWriteFontFileEnumerator.cs
+++ b/src/Vortice.Direct2D1/DirectWrite/IDWriteFontFileEnumerator.cs
@@ -10,22 +10,24 @@ namespace Vortice.DirectWrite
     [Shadow(typeof(IDWriteFontFileEnumeratorShadow))]
     public partial interface IDWriteFontFileEnumerator
     {
-        /// <summary>	
-        /// Advances to the next font file in the collection. When it is first created, the enumerator is positioned before the first element of the collection and the first call to MoveNext advances to the first file. 	
-        /// </summary>	
+        /// <summary>
+        /// Advances to the next font file in the collection. When it is first created, the enumerator is positioned before the first element of the collection and the first call to MoveNext advances to the first file.
+        /// </summary>
         /// <returns>the value TRUE if the enumerator advances to a file; otherwise, FALSE if the enumerator advances past the last file in the collection.</returns>
         bool MoveNext();
 
-        /// <summary>	
-        /// Gets a reference to the current font file. 	
-        /// </summary>	
+        /// <summary>
+        /// Gets a reference to the current font file.
+        /// </summary>
         /// <returns>a reference to the newly created <see cref="IDWriteFontFile"/> object.</returns>
         IDWriteFontFile CurrentFontFile { get; }
     }
 
     internal class IDWriteFontFileEnumeratorShadow : ComObjectShadow
     {
-        protected override CppObjectVtbl Vtbl => new FontFileEnumeratorVtbl();
+        private static readonly ComObjectVtbl _vTable = new FontFileEnumeratorVtbl();
+
+        protected override CppObjectVtbl Vtbl => _vTable;
 
         /// <summary>
         /// Return a pointer to the unmanaged version of this callback.
@@ -42,9 +44,9 @@ namespace Vortice.DirectWrite
                 AddMethod(new GetCurrentFontFileDelegate(GetCurrentFontFileImpl));
             }
 
-            /// <summary>	
-            /// Advances to the next font file in the collection. When it is first created, the enumerator is positioned before the first element of the collection and the first call to MoveNext advances to the first file. 	
-            /// </summary>	
+            /// <summary>
+            /// Advances to the next font file in the collection. When it is first created, the enumerator is positioned before the first element of the collection and the first call to MoveNext advances to the first file.
+            /// </summary>
             /// <returns>the value TRUE if the enumerator advances to a file; otherwise, FALSE if the enumerator advances past the last file in the collection.</returns>
             /// <unmanaged>HRESULT IDWriteFontFileEnumerator::MoveNext([Out] BOOL* hasCurrentFile)</unmanaged>
             [UnmanagedFunctionPointer(CallingConvention.StdCall)]
@@ -66,9 +68,9 @@ namespace Vortice.DirectWrite
                 return Result.Ok.Code;
             }
 
-            /// <summary>	
-            /// Gets a reference to the current font file. 	
-            /// </summary>	
+            /// <summary>
+            /// Gets a reference to the current font file.
+            /// </summary>
             /// <returns>a reference to the newly created <see cref="IDWriteFontFile"/> object.</returns>
             [UnmanagedFunctionPointer(CallingConvention.StdCall)]
             private delegate int GetCurrentFontFileDelegate(IntPtr thisPtr, out IntPtr fontFile);

--- a/src/Vortice.Runtime.COM/ComObjectShadow.cs
+++ b/src/Vortice.Runtime.COM/ComObjectShadow.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -18,9 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
-using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace SharpGen.Runtime
 {
@@ -29,6 +27,8 @@ namespace SharpGen.Runtime
     /// </summary>
     public class ComObjectShadow : CppObjectShadow
     {
+        private static readonly ComObjectVtbl _vTable = new ComObjectVtbl(0);
+
         private Result QueryInterface(Guid guid, out IntPtr output)
         {
             output = Callback.Shadow.Find(guid);
@@ -44,7 +44,7 @@ namespace SharpGen.Runtime
 
         }
 
-        protected override CppObjectVtbl Vtbl { get; } = new ComObjectVtbl(0);
+        protected override CppObjectVtbl Vtbl { get; } = _vTable;
 
         protected class ComObjectVtbl : CppObjectVtbl
         {

--- a/src/Vortice.Runtime.COM/InspectableShadow.cs
+++ b/src/Vortice.Runtime.COM/InspectableShadow.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,6 +27,9 @@ namespace SharpGen.Runtime
     /// </summary>
     public class InspectableShadow : ComObjectShadow
     {
+        private static readonly ComObjectVtbl _vTable = new InspectableVtbl();
+
+        protected override CppObjectVtbl Vtbl { get; } = _vTable;
 
         protected class InspectableVtbl : ComObjectVtbl
         {
@@ -41,7 +44,7 @@ namespace SharpGen.Runtime
                 }
             }
 
-            //        virtual HRESULT STDMETHODCALLTYPE GetIids( 
+            //        virtual HRESULT STDMETHODCALLTYPE GetIids(
             ///* [out] */ __RPC__out ULONG *iidCount,
             ///* [size_is][size_is][out] */ __RPC__deref_out_ecount_full_opt(*iidCount) IID **iids) = 0;
 
@@ -71,7 +74,7 @@ namespace SharpGen.Runtime
                 return Result.Ok.Code;
             }
 
-            //virtual HRESULT STDMETHODCALLTYPE GetRuntimeClassName( 
+            //virtual HRESULT STDMETHODCALLTYPE GetRuntimeClassName(
             //    /* [out] */ __RPC__deref_out_opt HSTRING *className) = 0;
 
             [UnmanagedFunctionPointer(CallingConvention.StdCall)]
@@ -83,7 +86,7 @@ namespace SharpGen.Runtime
                     var shadow = ToShadow<InspectableShadow>(thisPtr);
                     var callback = (IInspectable)shadow.Callback;
                     // Use the name of the callback class
-                    
+
                     var name = callback.GetType().FullName;
                     Win32.WinRTStrings.WindowsCreateString(name, (uint)name.Length, out IntPtr str);
                     *className = str;
@@ -95,7 +98,7 @@ namespace SharpGen.Runtime
                 return Result.Ok.Code;
             }
 
-            //virtual HRESULT STDMETHODCALLTYPE GetTrustLevel( 
+            //virtual HRESULT STDMETHODCALLTYPE GetTrustLevel(
             //    /* [out] */ __RPC__out TrustLevel *trustLevel) = 0;
             private enum TrustLevel
             {
@@ -123,7 +126,5 @@ namespace SharpGen.Runtime
             }
 
         }
-
-        protected override CppObjectVtbl Vtbl { get; } = new InspectableVtbl();
     }
 }


### PR DESCRIPTION
This fixes #100 for me,  although I am not quite sure _why_, since it should have kept them alive regardless. But this does ensure the vtables never go away so this cannot happen again.

Additionally I noticed the following: The vtables are allocated in unmanaged memory, and _never_ released, meaning that this also fixes a memory leak since the vtable is currently being allocated per-shadow, and is **never** freed.

What is somewhat worrisome: The vtable's also seem to be per-shadow in the generated shadow interfaces.... I don't know what to do about these.