### PR TITLE
Basepointer added to allow for PositionPointer to remain undisturbed

### DIFF
--- a/src/Vortice.DirectX/DataStream.cs
+++ b/src/Vortice.DirectX/DataStream.cs
@@ -373,6 +373,12 @@ namespace Vortice
         }
 
         /// <summary>
+        /// Gets the undisturbed buffer pointer.
+        /// </summary>
+        /// <value>The undisturbed buffer pointer.</value>
+        public IntPtr BasePointer => (IntPtr)(_buffer);
+
+        /// <summary>
         /// Gets the position pointer.
         /// </summary>
         /// <value>The position pointer.</value>


### PR DESCRIPTION
Simple helper function that allows for basepointer to be referenced without having to play with the Position.