### PR TITLE
Add targets file to XAudio NuGet package

### DIFF
--- a/src/Vortice.XAudio2/Vortice.XAudio2.csproj
+++ b/src/Vortice.XAudio2/Vortice.XAudio2.csproj
@@ -16,8 +16,8 @@
       <PackagePath>runtimes\win-x86\native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    
-    <Content Include="Vortice.XAudio2.targets" PackagePath="build" />
+
+    <Content Include="Vortice.XAudio2.targets" PackagePath="build\$(TargetFramework);buildMultiTargeting\$(TargetFramework);" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Vortice.XAudio2/Vortice.XAudio2.targets
+++ b/src/Vortice.XAudio2/Vortice.XAudio2.targets
@@ -2,8 +2,8 @@
   
   <Target Name="CopyXAudio2Native" AfterTargets="AfterBuild" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <ItemGroup>
-      <_lib_winx64 Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\*.*" />
-      <_lib_winx86 Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x86\native\*.*" />
+      <_lib_winx64 Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\*.*" />
+      <_lib_winx86 Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\*.*" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_lib_winx64)" DestinationFolder="$(OutDir)\x64" />


### PR DESCRIPTION
Add targets file to XAudio NuGet package to ensure assemblies are copied to output on build.

In reference to #122 **Vortice XAudio2 causing exception on latest Windows** 