### PR TITLE
Remove XAudio2 targets from buildMultiTargeting since it is not needed.

### DIFF
--- a/src/Vortice.XAudio2/Vortice.XAudio2.csproj
+++ b/src/Vortice.XAudio2/Vortice.XAudio2.csproj
@@ -17,7 +17,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
 
-    <Content Include="Vortice.XAudio2.targets" PackagePath="build\$(TargetFramework);buildMultiTargeting\$(TargetFramework);" />
+    <Content Include="Vortice.XAudio2.targets" PackagePath="build\$(TargetFramework);" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Target is not needed in buildMultiTargeting. Tested on local machine and still works properly.