### PR TITLE
Add layout properties to DXC options.

### DIFF
--- a/src/Vortice.Dxc/DxcCompiler.cs
+++ b/src/Vortice.Dxc/DxcCompiler.cs
@@ -163,6 +163,13 @@ namespace Vortice.Dxc
                 }
             }
 
+            if (options.UseGlLayout)
+                arguments.Add("-fvk-use-gl-layout");
+            if (options.UseDxLayout)
+                arguments.Add("-fvk-use-dx-layout");
+            if (options.UseScalarLayout)
+                arguments.Add("-fvk-use-scalar-layout");
+
             if (includeHandler == null)
             {
                 using (includeHandler = Utils!.CreateDefaultIncludeHandler())

--- a/src/Vortice.Dxc/DxcCompilerOptions.cs
+++ b/src/Vortice.Dxc/DxcCompilerOptions.cs
@@ -28,5 +28,9 @@ namespace Vortice.Dxc
         /// Generate SPIR-V code
         /// </summary>
         public bool GenerateSPIRV { get; set; } = false;
+
+        public bool UseGlLayout { get; set; } = false;
+        public bool UseDxLayout { get; set; } = false;
+        public bool UseScalarLayout { get; set; } = false;
     }
 }


### PR DESCRIPTION
I'm using DXC to compile HLSL to SPIR-V, then using SPIRV-Cross to generate GLSL for source code for OpenGL and Vulkan.

I ran into some issues due to alignment differences so adding options to set the layout in the options object.