### PR TITLE
Fix IDWriteColorGlyphRunEnumerator.GetCurrentRun() to return ColorGlyphRun

### DIFF
--- a/src/Vortice.Direct2D1/DirectWrite/IDWriteColorGlyphRunEnumerator.cs
+++ b/src/Vortice.Direct2D1/DirectWrite/IDWriteColorGlyphRunEnumerator.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Amer Koleci and contributors.
+// Distributed under the MIT license. See the LICENSE file in the project root for more information.
+
+namespace Vortice.DirectWrite
+{
+    partial class IDWriteColorGlyphRunEnumerator
+    {
+        public ColorGlyphRun CurrentRun => GetCurrentRun();
+
+        internal unsafe ColorGlyphRun GetCurrentRun()
+        {
+            ColorGlyphRun colorGlyphRun = default;
+            ColorGlyphRun.__Native* colorGlyphRun_ = (ColorGlyphRun.__Native*)GetCurrentRun_();
+            colorGlyphRun.__MarshalFrom(ref *colorGlyphRun_);
+            return colorGlyphRun;
+        }
+    }
+}

--- a/src/Vortice.Direct2D1/DirectWrite/IDWriteColorGlyphRunEnumerator1.cs
+++ b/src/Vortice.Direct2D1/DirectWrite/IDWriteColorGlyphRunEnumerator1.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Amer Koleci and contributors.
+// Distributed under the MIT license. See the LICENSE file in the project root for more information.
+
+namespace Vortice.DirectWrite
+{
+    partial class IDWriteColorGlyphRunEnumerator1
+    {
+        public new ColorGlyphRun1 CurrentRun => GetCurrentRun();
+
+        internal new unsafe ColorGlyphRun1 GetCurrentRun()
+        {
+            ColorGlyphRun1 colorGlyphRun = default;
+            ColorGlyphRun1.__Native* colorGlyphRun_ = (ColorGlyphRun1.__Native*)GetCurrentRun_();
+            colorGlyphRun.__MarshalFrom(ref *colorGlyphRun_);
+            return colorGlyphRun;
+        }
+    }
+}

--- a/src/Vortice.Direct2D1/DirectWrite/IDWriteFactory2.cs
+++ b/src/Vortice.Direct2D1/DirectWrite/IDWriteFactory2.cs
@@ -11,18 +11,21 @@ namespace Vortice.DirectWrite
     public partial class IDWriteFactory2
     {
         public IDWriteColorGlyphRunEnumerator TranslateColorGlyphRun(
-            float baselineOriginX, 
+            float baselineOriginX,
             float baselineOriginY,
             GlyphRun glyphRun)
         {
-            return TranslateColorGlyphRun(
+            var result = TranslateColorGlyphRun(
                 baselineOriginX,
                 baselineOriginY,
                 glyphRun,
                 null,
                 MeasuringMode.Natural,
                 null,
-                0);
+                0,
+                out var colorLayers);
+            result.CheckError();
+            return colorLayers;
         }
     }
 }

--- a/src/Vortice.Direct2D1/Mappings.xml
+++ b/src/Vortice.Direct2D1/Mappings.xml
@@ -488,6 +488,7 @@
     <map method="IDWriteFactory::CreateFontFace" visibility="internal" hresult="true" check="false" />
     <map method="IDWriteFactory::((Unr|R)egisterFont(File|Collection)Loader)" visibility="internal" name="$1_" />
     <map param="IDWriteFactory::CreateTextLayout::stringLength" relation="length(string)" />
+    <map method="IDWriteFactory\d*::TranslateColorGlyphRun" hresult="true" check="false"/>
     
     <!-- IDWriteTextLayout -->
     <map method="IDWriteTextLayout\d*::GetLineMetrics" hresult="true" check="false"/>

--- a/src/Vortice.Direct2D1/Mappings.xml
+++ b/src/Vortice.Direct2D1/Mappings.xml
@@ -488,7 +488,7 @@
     <map method="IDWriteFactory::CreateFontFace" visibility="internal" hresult="true" check="false" />
     <map method="IDWriteFactory::((Unr|R)egisterFont(File|Collection)Loader)" visibility="internal" name="$1_" />
     <map param="IDWriteFactory::CreateTextLayout::stringLength" relation="length(string)" />
-
+    
     <!-- IDWriteTextLayout -->
     <map method="IDWriteTextLayout\d*::GetLineMetrics" hresult="true" check="false"/>
     <map param="IDWriteTextLayout\d*::GetLineMetrics::maxLineCount" relation="length(lineMetrics)" />
@@ -571,6 +571,9 @@
     <!-- IDWriteTextAnalysisSource -->
     <map interface="IDWriteTextAnalysisSource\d*" callback="true" callback-dual="false"/>
 
+    <!-- IDWriteColorGlyphRunEnumerator -->
+    <map method="IDWriteColorGlyphRunEnumerator\d*::GetCurrentRun" visibility="internal" name="GetCurrentRun_"  property="false"/>
+    
     <!-- IWICBitmapEncoder -->
     <map method="IWICBitmapEncoder::Initialize" visibility="internal" name="Initialize_" />
     <map param="IWICBitmapEncoder::CreateNewFrame::ppIFrameEncode" attribute="out" return="true"/>


### PR DESCRIPTION
https://github.com/amerkoleci/Vortice.Windows/commit/0dd4c3db7061700c2f607d8cfc7237232ee037ad
Fix `IDWriteColorGlyphRunEnumerator.GetCurrentRun()` to return `ColorGlyphRun` instead of `IntPtr`.

https://github.com/amerkoleci/Vortice.Windows/commit/84917aa791b8d7dd369bfaa1c93eb363127728d0
Remove error check in TranslateColorGlyphRun, be able to switch processing by status code instead of the exception.

switch by status code
```C#
var result = factory.TranslateColorGlyphRun(...);
if(result.Success)
{
    /* draw color glyph run */
}
else
{
    /* draw glyph run */
}
```

switch by exception
```C#
try
{
    factory.TranslateColorGlyphRun(...);
    /* draw color glyph run */
}
catch
{
    /* draw glyph run */
}
```
If switch by exception, many error messages will be displayed on debug console, this will be slow performance when  debugging.