### PR TITLE
Add DXIL validator support.

### DIFF
--- a/src/Vortice.Dxc/DxcValidatorFlags.cs
+++ b/src/Vortice.Dxc/DxcValidatorFlags.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Amer Koleci and contributors.
+// Distributed under the MIT license. See the LICENSE file in the project root for more information.
+
+namespace Vortice.Dxc
+{
+    public enum DxcValidatorFlags : int
+    {
+        Default = 0,
+        InPlaceEdit = 1,
+        RootSignatureOnly = 2,
+        ModuleOnly = 4,
+        ValidMask = 0x7,
+    }
+}

--- a/src/Vortice.Dxc/Dxil.cs
+++ b/src/Vortice.Dxc/Dxil.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Amer Koleci and contributors.
+// Distributed under the MIT license. See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using SharpGen.Runtime;
+
+namespace Vortice.Dxc
+{
+    public static partial class Dxil
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static IDxcValidator? CreateDxilValidator()
+        {
+            DxilCreateInstance(Dxc.CLSID_DxcValidator, out IDxcValidator? result).CheckError();
+            return result;
+        }
+
+
+        public static Result DxilCreateInstance<T>(Guid classGuid, out T? instance) where T : ComObject
+        {
+            Result result = DxcCreateInstance(classGuid, typeof(T).GUID, out IntPtr nativePtr);
+            if (result.Success)
+            {
+                instance = CppObject.FromPointer<T>(nativePtr);
+                return result;
+            }
+
+            instance = null;
+            return result;
+        }
+
+        public static unsafe SharpGen.Runtime.Result DxcCreateInstance(System.Guid rclsid, System.Guid riid, out System.IntPtr ppv)
+        {
+            SharpGen.Runtime.Result __result__;
+            fixed (void* ppv_ = &ppv)
+                __result__ = DxcCreateInstance_(&rclsid, &riid, ppv_);
+            return __result__;
+        }
+
+        [System.Runtime.InteropServices.DllImportAttribute("dxil.dll", EntryPoint = "DxcCreateInstance", CallingConvention = System.Runtime.InteropServices.CallingConvention.StdCall)]
+        private unsafe static extern int DxcCreateInstance_(void* _rclsid, void* _riid, void* _ppv);
+    }
+}

--- a/src/Vortice.Dxc/IDxcValidator.cs
+++ b/src/Vortice.Dxc/IDxcValidator.cs
@@ -7,7 +7,7 @@ namespace Vortice.Dxc
 {
     public partial class IDxcValidator
     {
-        public IDxcOperationResult Validate(IDxcBlob shader, int flags)
+        public IDxcOperationResult Validate(IDxcBlob shader, DxcValidatorFlags flags)
         {
             Validate(shader, flags, out IDxcOperationResult result).CheckError();
             return result;

--- a/src/Vortice.Dxc/Mappings.xml
+++ b/src/Vortice.Dxc/Mappings.xml
@@ -13,12 +13,15 @@
 
   <extension>
     <create class="Dxc" visibility="public static" />
+
+    <define enum="Vortice.Dxc.DxcValidatorFlags" underlying="System.Int32" />
   </extension>
 
   <bindings>
     <bind from="uint32_t" to="System.Int32" />
     <bind from="UINT32" to="System.Int32" />
     <bind from="IMalloc" to="SharpGen.Runtime.ComObject" />
+    <bind from="DxcValidatorFlags" to="Vortice.Dxc.DxcValidatorFlags" />
   </bindings>
 
   <naming>
@@ -31,11 +34,11 @@
     <map method="IDxcUtils::(.*)" property="false" hresult="true" check="false"/>
     <map method="IDxcUtils::CreateReflection" visibility="private" hresult="true" check="false"/>
     <map param="IDxcUtils::CreateReflection::ppvReflection" type="void" attribute="out" />
-    
+
     <map method="IDxcUtils::CreateDefaultIncludeHandler" hresult="true" check="false"/>
     <map method="IDxcUtils::BuildArguments" visibility="private" />
     <map param="IDxcUtils::BuildArguments::pArguments" type="void" />
-    
+
     <map method="IDxcResult::GetOutput" visibility="private" hresult="true" check="false"/>
     <map param="IDxcResult::GetOutput::ppOutputName" type="void" attribute="in" />
 
@@ -43,10 +46,10 @@
     <map method="IDxcBlobEncoding::GetEncoding" hresult="true" check="false"/>
 
     <map method="IDxcCompiler::Disassemble" hresult="true" check="false"/>
-    
+
     <map method="IDxcCompiler::Compile" visibility="private" hresult="true" check="false"/>
     <map param="IDxcCompiler::Compile::pArguments" type="void" />
-    
+
     <map method="IDxcCompiler::Preprocess" visibility="private" hresult="true" check="false"/>
     <map param="IDxcCompiler::Preprocess::pArguments" type="void" />
 
@@ -61,18 +64,18 @@
     <map param="IDxcCompiler.*::Preprocess::defineCount" relation="length(pDefines)" />
 
     <map method="IDxcCompilerArgs::AddArguments" visibility="private" hresult="true" check="false"/>
-    
+
     <map method="IDxcCompilerArgs::AddArgumentsUTF8" visibility="private" hresult="true" check="false"/>
     <map method="IDxcCompilerArgs::AddDefines" hresult="true" check="false"/>
     <map param="IDxcCompilerArgs::AddDefines::defineCount" relation="length(pDefines)" />
-    
+
     <map method="IDxcContainerBuilder::(.*)" hresult="true" check="false"/>
-    
+
     <map method="IDxcContainerReflection::(.*)" hresult="true" check="false"/>
     <map method="IDxcContainerReflection::GetPartCount" property="false"/>
     <map method="IDxcContainerReflection::GetPartReflection" visibility="private" hresult="true" check="false"/>
     <map param="IDxcContainerReflection::GetPartReflection::ppvObject" type="void" attribute="out" />
-    
+
     <map method="IDxcExtraOutputs::GetOutputCount" property="false"/>
     <map method="IDxcExtraOutputs::GetOutput" visibility="private" hresult="true" check="false"/>
 
@@ -86,17 +89,18 @@
     <map method="IDxcLinker::Link" visibility="private" />
     <map param="IDxcLinker::Link::pLibNames" type="void" />
     <map param="IDxcLinker::Link::pArguments" type="void" />
-    
+
     <map method="IDxcOperationResult::(.*)" property="false" hresult="true" check="false"/>
 
     <map method="IDxcValidator::(.*)" hresult="true" check="false"/>
+    <map param="IDxcValidator::Validate::Flags" type="DxcValidatorFlags"/>
     <map method="IDxcVersionInfo::(.*)" property="false"  hresult="true" check="false"/>
-    
+
     <map method="IDxcVersionInfo2::(.*)" hresult="true" check="false"/>
     <map param="IDxcVersionInfo2::GetCommitInfo::pCommitHash" type="void" attribute="out" />
 
     <map method="IDxcPdbUtils::(.*)" hresult="true" check="false"/>
-    
+
     <map function="DxcCreateInstance" dll='"dxcompiler.dll"' group="Vortice.Dxc.Dxc" hresult="true" check="false"/>
     <map function="DxcCreateInstance2" dll='"dxcompiler.dll"' group="Vortice.Dxc.Dxc" hresult="true" check="false"/>
   </mapping>


### PR DESCRIPTION
Compiling shaders with DXC was failing to sign the code even though dxil.dll was next to dxcompiler.dll.

In order to get around the issue I tried loading dxil.dll manually to help find the DLL but the compiler was still saying it was missing. I think this is due to the fact that I was running it in an MSBuild task and it was searching next to the MSBuild exe since it appears dxcompiler.dll needs to find dxil.dll.

I tried validating manually but it still didn't work. I discovered that `IDxcValidator` must be created by PInvoking to dxil.dll directly. I just copied the generated code from DXC and changed the assembly name. I also updated the flags property to the proper enum.

I got the hint from here: https://www.wihlidal.com/blog/pipeline/2018-09-16-dxil-signing-post-compile/
and here: https://github.com/gwihlidal/dxil-signing/blob/master/cpp/main.cpp#L78