### PR TITLE
D3D12: Switch to PIX v3 format for BeginEvent and SetMarker

### DIFF
--- a/src/Vortice.Direct3D12/Constants.cs
+++ b/src/Vortice.Direct3D12/Constants.cs
@@ -510,7 +510,5 @@ namespace Vortice.Direct3D12
         public const int WHQLContextCountForResourceLimit = 10;
         public const int WHQLDrawIndexedIndexCount2ToExp = 25;
         public const int WHQLDrawVertexCount2ToExp = 25;
-
-        internal const int PIX_EVENT_UNICODE_VERSION = 0;
     }
 }

--- a/src/Vortice.Direct3D12/ID3D12CommandQueue.cs
+++ b/src/Vortice.Direct3D12/ID3D12CommandQueue.cs
@@ -54,18 +54,18 @@ namespace Vortice.Direct3D12
 
         public unsafe void BeginEvent(string name)
         {
-            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
-            ulong* buffer = stackalloc ulong[sizeInQWords];
+            int bufferSize = PixHelpers.CalculateNoArgsEventSize(name);
+            void* buffer = stackalloc byte[bufferSize];
             PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_BeginEvent_NoArgs, 0, name);
-            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
+            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), bufferSize);
         }
 
         public unsafe void SetMarker(string name)
         {
-            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
-            ulong* buffer = stackalloc ulong[sizeInQWords];
+            int bufferSize = PixHelpers.CalculateNoArgsEventSize(name);
+            void* buffer = stackalloc byte[bufferSize];
             PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_SetMarker_NoArgs, 0, name);
-            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
+            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), bufferSize);
         }
 
         public unsafe void UpdateTileMappings(

--- a/src/Vortice.Direct3D12/ID3D12CommandQueue.cs
+++ b/src/Vortice.Direct3D12/ID3D12CommandQueue.cs
@@ -54,18 +54,18 @@ namespace Vortice.Direct3D12
 
         public unsafe void BeginEvent(string name)
         {
-            fixed (char* chars = name)
-            {
-                BeginEvent(D3D12.PIX_EVENT_UNICODE_VERSION, new IntPtr(chars), (name.Length + 1) * 2);
-            }
+            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
+            ulong* buffer = stackalloc ulong[sizeInQWords];
+            PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_BeginEvent_NoArgs, 0, name);
+            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
         }
 
         public unsafe void SetMarker(string name)
         {
-            fixed (char* chars = name)
-            {
-                SetMarker(D3D12.PIX_EVENT_UNICODE_VERSION, new IntPtr(chars), (name.Length + 1) * 2);
-            }
+            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
+            ulong* buffer = stackalloc ulong[sizeInQWords];
+            PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_SetMarker_NoArgs, 0, name);
+            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
         }
 
         public unsafe void UpdateTileMappings(

--- a/src/Vortice.Direct3D12/ID3D12GraphicsCommandList.cs
+++ b/src/Vortice.Direct3D12/ID3D12GraphicsCommandList.cs
@@ -423,22 +423,22 @@ namespace Vortice.Direct3D12
 
         public void BeginEvent(string name)
         {
-            fixed (char* chars = name)
-            {
-                BeginEvent(D3D12.PIX_EVENT_UNICODE_VERSION, new IntPtr(chars), (name.Length + 1) * 2);
-            }
+            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
+            ulong* buffer = stackalloc ulong[sizeInQWords];
+            PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_BeginEvent_NoArgs, 0, name);
+            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
         }
 
-        public unsafe void SetMarker(string name)
+        public void SetMarker(string name)
         {
-            fixed (char* chars = name)
-            {
-                SetMarker(D3D12.PIX_EVENT_UNICODE_VERSION, new IntPtr(chars), (name.Length + 1) * 2);
-            }
+            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
+            ulong* buffer = stackalloc ulong[sizeInQWords];
+            PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_SetMarker_NoArgs, 0, name);
+            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
         }
 
         /// <summary>
-        /// This method uses the GPU to copy texture data between two locations. 
+        /// This method uses the GPU to copy texture data between two locations.
         /// Both the source and the destination may reference texture data located within either a buffer resource or a texture resource.
         /// </summary>
         /// <param name="destination">Specifies the destination <see cref="TextureCopyLocation"/>. The subresource referred to must be in the <see cref="ResourceStates.CopyDestination"/> state.</param>

--- a/src/Vortice.Direct3D12/ID3D12GraphicsCommandList.cs
+++ b/src/Vortice.Direct3D12/ID3D12GraphicsCommandList.cs
@@ -423,18 +423,18 @@ namespace Vortice.Direct3D12
 
         public void BeginEvent(string name)
         {
-            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
-            ulong* buffer = stackalloc ulong[sizeInQWords];
+            int bufferSize = PixHelpers.CalculateNoArgsEventSize(name);
+            void* buffer = stackalloc byte[bufferSize];
             PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_BeginEvent_NoArgs, 0, name);
-            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
+            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), bufferSize);
         }
 
         public void SetMarker(string name)
         {
-            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
-            ulong* buffer = stackalloc ulong[sizeInQWords];
+            int bufferSize = PixHelpers.CalculateNoArgsEventSize(name);
+            void* buffer = stackalloc byte[bufferSize];
             PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_SetMarker_NoArgs, 0, name);
-            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
+            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), bufferSize);
         }
 
         /// <summary>

--- a/src/Vortice.Direct3D12/PixHelpers.cs
+++ b/src/Vortice.Direct3D12/PixHelpers.cs
@@ -24,27 +24,28 @@ namespace Vortice.Direct3D12
         }
 
         /// <summary>
-        /// Calculates the size of the buffer required, in qwords (eight byte chunks).
+        /// Calculates the size of the buffer required, in bytes.
         /// </summary>
         /// <param name="message"> The text to be embedded in the event. </param>
-        /// <returns> The size of the buffer required, in qwords (eight byte chunks). </returns>
-        internal static int CalculateNoArgsEventSizeInQWords(string message)
-        {
-            return 3 /* start marker, color, copy chunk size */ +
-                   message.Length / 4 /* 8 bytes / 2 bytes per character */ +
-                   1 /* null terminator */ +
-                   1 /* end marker */;
-        }
+        /// <returns> The size of the buffer required, in bytes. </returns>
+        internal static int CalculateNoArgsEventSize(string message) =>
+            (3 /* start marker, color, copy chunk size */ +
+            message.Length / 4 /* 8 bytes / 2 bytes per character */ +
+            1 /* null terminator */ +
+            1 /* end marker */) * 8;
 
         /// <summary>
         /// Writes a formatted PIX no-arg event to the given buffer.
         /// </summary>
-        /// <param name="buffer"> The buffer to write to. </param>
+        /// <param name="outputBuffer"> The buffer to write to. </param>
         /// <param name="eventType"> The PIX event type. </param>
         /// <param name="color"> Either a color index, or an RGB color. </param>
         /// <param name="message"> The message to embed in the buffer. </param>
-        internal static unsafe void FormatNoArgsEventToBuffer(ulong* buffer, PixEventType eventType, ulong color, string message)
+        internal static unsafe void FormatNoArgsEventToBuffer(void* outputBuffer, PixEventType eventType, ulong color, string message)
         {
+            // The buffer is written to in quad-word-sized chunks.
+            ulong* buffer = (ulong*)outputBuffer;
+
             // The first word contains the event type and the timestamp.
             // Bits 10-19 (10 bits) for the event type.
             // Bits 20-63 (44 bits) for timestamp (as produced by QueryPerformanceCounter).

--- a/src/Vortice.Direct3D12/PixHelpers.cs
+++ b/src/Vortice.Direct3D12/PixHelpers.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Amer Koleci and contributors.
+// Distributed under the MIT license. See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+namespace Vortice.Direct3D12
+{
+    /// <summary>
+    /// Helper functions related to PIX for Windows. See https://devblogs.microsoft.com/pix/winpixeventruntime/
+    /// </summary>
+    internal static class PixHelpers
+    {
+        internal const int WinPIXEventPIX3BlobVersion = 2;
+        private const ulong PIXEventsBlockEndMarker = 0xFFF80;
+
+        internal enum PixEventType
+        {
+            PIXEvent_EndEvent           = 0x000,
+            PIXEvent_BeginEvent_VarArgs = 0x001,
+            PIXEvent_BeginEvent_NoArgs  = 0x002,
+            PIXEvent_SetMarker_VarArgs  = 0x007,
+            PIXEvent_SetMarker_NoArgs   = 0x008,
+        }
+
+        /// <summary>
+        /// Calculates the size of the buffer required, in qwords (eight byte chunks).
+        /// </summary>
+        /// <param name="message"> The text to be embedded in the event. </param>
+        /// <returns> The size of the buffer required, in qwords (eight byte chunks). </returns>
+        internal static int CalculateNoArgsEventSizeInQWords(string message)
+        {
+            return 3 /* start marker, color, copy chunk size */ +
+                   message.Length / 4 /* 8 bytes / 2 bytes per character */ +
+                   1 /* null terminator */ +
+                   1 /* end marker */;
+        }
+
+        /// <summary>
+        /// Writes a formatted PIX no-arg event to the given buffer.
+        /// </summary>
+        /// <param name="buffer"> The buffer to write to. </param>
+        /// <param name="eventType"> The PIX event type. </param>
+        /// <param name="color"> Either a color index, or an RGB color. </param>
+        /// <param name="message"> The message to embed in the buffer. </param>
+        internal static unsafe void FormatNoArgsEventToBuffer(ulong* buffer, PixEventType eventType, ulong color, string message)
+        {
+            // The first word contains the event type and the timestamp.
+            // Bits 10-19 (10 bits) for the event type.
+            // Bits 20-63 (44 bits) for timestamp (as produced by QueryPerformanceCounter).
+            var timestamp = (ulong)Stopwatch.GetTimestamp();
+            buffer[0] = ((timestamp & 0x00000FFFFFFFFFFF) << 20) |
+                        (((ulong)eventType & 0x00000000000003FF) << 10);
+
+            // 0xff000000 | (r << 16) | (g << 8) | b
+            // or: color index (byte)i
+            buffer[1] = color;
+
+            // Bit 53: isShortcut
+            // Bit 54: isANSI
+            // Bit 55-59: copyChunkSize
+            // Bits 60-63: alignment
+            buffer[2] = (8UL /* copyChunkSize */ & 0x1F) << 55;
+
+            // Write message, with a null terminator.
+            int strIndex = 0, bufferIndex = 3;
+            var str = message.AsSpan();
+            while (true)
+            {
+                // char #1
+                if (strIndex >= message.Length)
+                {
+                    buffer[bufferIndex++] = 0;
+                    break;
+                }
+                uint c = str[strIndex++];
+                ulong longValue = c;
+
+                // char #2
+                if (strIndex >= message.Length)
+                {
+                    buffer[bufferIndex++] = longValue;
+                    break;
+                }
+                c = str[strIndex++];
+                longValue |= (ulong)c << 16;
+
+                // char #3
+                if (strIndex >= message.Length)
+                {
+                    buffer[bufferIndex++] = longValue;
+                    break;
+                }
+                c = str[strIndex++];
+                longValue |= (ulong)c << 32;
+
+                // char #4
+                if (strIndex >= message.Length)
+                {
+                    buffer[bufferIndex++] = longValue;
+                    break;
+                }
+                c = str[strIndex++];
+                longValue |= (ulong)c << 48;
+
+                // Write to the buffer.
+                buffer[bufferIndex++] = longValue;
+            }
+
+            buffer[bufferIndex] = PIXEventsBlockEndMarker;
+        }
+    }
+}

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoDecodeCommandList.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoDecodeCommandList.cs
@@ -69,18 +69,18 @@ namespace Vortice.Direct3D12.Video
 
         public unsafe void BeginEvent(string name)
         {
-            fixed (char* chars = name)
-            {
-                BeginEvent(D3D12.PIX_EVENT_UNICODE_VERSION, new IntPtr(chars), (name.Length + 1) * 2);
-            }
+            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
+            ulong* buffer = stackalloc ulong[sizeInQWords];
+            PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_BeginEvent_NoArgs, 0, name);
+            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
         }
 
         public unsafe void SetMarker(string name)
         {
-            fixed (char* chars = name)
-            {
-                SetMarker(D3D12.PIX_EVENT_UNICODE_VERSION, new IntPtr(chars), (name.Length + 1) * 2);
-            }
+            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
+            ulong* buffer = stackalloc ulong[sizeInQWords];
+            PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_SetMarker_NoArgs, 0, name);
+            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
         }
 
 

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoDecodeCommandList.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoDecodeCommandList.cs
@@ -69,18 +69,18 @@ namespace Vortice.Direct3D12.Video
 
         public unsafe void BeginEvent(string name)
         {
-            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
-            ulong* buffer = stackalloc ulong[sizeInQWords];
+            int bufferSize = PixHelpers.CalculateNoArgsEventSize(name);
+            void* buffer = stackalloc byte[bufferSize];
             PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_BeginEvent_NoArgs, 0, name);
-            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
+            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), bufferSize);
         }
 
         public unsafe void SetMarker(string name)
         {
-            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
-            ulong* buffer = stackalloc ulong[sizeInQWords];
+            int bufferSize = PixHelpers.CalculateNoArgsEventSize(name);
+            void* buffer = stackalloc byte[bufferSize];
             PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_SetMarker_NoArgs, 0, name);
-            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
+            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), bufferSize);
         }
 
 

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoEncodeCommandList.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoEncodeCommandList.cs
@@ -69,18 +69,18 @@ namespace Vortice.Direct3D12.Video
 
         public unsafe void BeginEvent(string name)
         {
-            fixed (char* chars = name)
-            {
-                BeginEvent(D3D12.PIX_EVENT_UNICODE_VERSION, new IntPtr(chars), (name.Length + 1) * 2);
-            }
+            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
+            ulong* buffer = stackalloc ulong[sizeInQWords];
+            PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_BeginEvent_NoArgs, 0, name);
+            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
         }
 
         public unsafe void SetMarker(string name)
         {
-            fixed (char* chars = name)
-            {
-                SetMarker(D3D12.PIX_EVENT_UNICODE_VERSION, new IntPtr(chars), (name.Length + 1) * 2);
-            }
+            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
+            ulong* buffer = stackalloc ulong[sizeInQWords];
+            PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_SetMarker_NoArgs, 0, name);
+            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
         }
 
 

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoEncodeCommandList.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoEncodeCommandList.cs
@@ -69,18 +69,18 @@ namespace Vortice.Direct3D12.Video
 
         public unsafe void BeginEvent(string name)
         {
-            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
-            ulong* buffer = stackalloc ulong[sizeInQWords];
+            int bufferSize = PixHelpers.CalculateNoArgsEventSize(name);
+            void* buffer = stackalloc byte[bufferSize];
             PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_BeginEvent_NoArgs, 0, name);
-            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
+            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), bufferSize);
         }
 
         public unsafe void SetMarker(string name)
         {
-            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
-            ulong* buffer = stackalloc ulong[sizeInQWords];
+            int bufferSize = PixHelpers.CalculateNoArgsEventSize(name);
+            void* buffer = stackalloc byte[bufferSize];
             PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_SetMarker_NoArgs, 0, name);
-            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
+            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), bufferSize);
         }
 
 

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoProcessCommandList.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoProcessCommandList.cs
@@ -69,18 +69,18 @@ namespace Vortice.Direct3D12.Video
 
         public unsafe void BeginEvent(string name)
         {
-            fixed (char* chars = name)
-            {
-                BeginEvent(D3D12.PIX_EVENT_UNICODE_VERSION, new IntPtr(chars), (name.Length + 1) * 2);
-            }
+            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
+            ulong* buffer = stackalloc ulong[sizeInQWords];
+            PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_BeginEvent_NoArgs, 0, name);
+            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
         }
 
         public unsafe void SetMarker(string name)
         {
-            fixed (char* chars = name)
-            {
-                SetMarker(D3D12.PIX_EVENT_UNICODE_VERSION, new IntPtr(chars), (name.Length + 1) * 2);
-            }
+            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
+            ulong* buffer = stackalloc ulong[sizeInQWords];
+            PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_SetMarker_NoArgs, 0, name);
+            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
         }
 
 

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoProcessCommandList.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoProcessCommandList.cs
@@ -69,18 +69,18 @@ namespace Vortice.Direct3D12.Video
 
         public unsafe void BeginEvent(string name)
         {
-            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
-            ulong* buffer = stackalloc ulong[sizeInQWords];
+            int bufferSize = PixHelpers.CalculateNoArgsEventSize(name);
+            void* buffer = stackalloc byte[bufferSize];
             PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_BeginEvent_NoArgs, 0, name);
-            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
+            BeginEvent(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), bufferSize);
         }
 
         public unsafe void SetMarker(string name)
         {
-            int sizeInQWords = PixHelpers.CalculateNoArgsEventSizeInQWords(name);
-            ulong* buffer = stackalloc ulong[sizeInQWords];
+            int bufferSize = PixHelpers.CalculateNoArgsEventSize(name);
+            void* buffer = stackalloc byte[bufferSize];
             PixHelpers.FormatNoArgsEventToBuffer(buffer, PixHelpers.PixEventType.PIXEvent_SetMarker_NoArgs, 0, name);
-            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), sizeInQWords * 8);
+            SetMarker(PixHelpers.WinPIXEventPIX3BlobVersion, new IntPtr(buffer), bufferSize);
         }
 
 


### PR DESCRIPTION
PIX for Windows (https://devblogs.microsoft.com/pix/winpixeventruntime/) has switched to a new format for the BeginEvent and SetMarker payload, and have deprecated the old format. That means calls to BeginEvent() or SetMarker() using Vortice.Windows result in this message in PIX:
```
<deprecated - use pix3.h instead> The message
```

This pull request switches to using the new format, thus avoiding the deprecation message.