### PR TITLE
Memory allocation issues - playback distortion

### DIFF
--- a/src/Vortice.XAudio2/AudioBuffer.cs
+++ b/src/Vortice.XAudio2/AudioBuffer.cs
@@ -60,11 +60,21 @@ namespace Vortice.XAudio2
         /// Initializes a new instance of the <see cref="AudioBuffer" /> class.
         /// </summary>
         /// <param name="stream">The stream to get the audio buffer from.</param>
-        public AudioBuffer(DataStream stream)
+        public AudioBuffer(DataStream stream, BufferFlags flags = BufferFlags.EndOfStream)
         {
-            AudioDataPointer = stream.PositionPointer;
-            Flags = BufferFlags.EndOfStream;
+            int length = (int)stream.Length - (int)stream.Position;
+
+            AudioDataPointer = MemoryHelpers.AllocateMemory(length);
+
+            unsafe
+            {
+                Unsafe.CopyBlockUnaligned(AudioDataPointer.ToPointer(), stream.PositionPointer.ToPointer(), (uint)length);
+            }
+
+            Flags = flags;
             AudioBytes = (int)stream.Length;
+
+            _ownsBuffer = true;
         }
 
         public static unsafe AudioBuffer Create<T>(ReadOnlySpan<T> data, BufferFlags flags = BufferFlags.EndOfStream) where T : unmanaged


### PR DESCRIPTION
Pull request is more informational but the change may need some verification.

Code implementation is executing high pitch sound replay/distortion.

```
  SoundStream soundSample_ = new SoundStream(fileStream_);
  
  _targetBuffer = new AudioBuffer(soundSample_);
  
  int encodng_ = (int)soundSample_.Format.Encoding;
  
  _waveFormat = soundSample_.Format;
  
  uint[] _encoding = soundSample_.DecodedPacketsInfo;
```

presents sound distortion and high frequency playback among things.  I've changed the audiobuffer function code to copy the buffer in and set OwnBuffer.  I believe this will fix some strange underlying issue.  The sample below works as I have used the alternative constructor in the code below, In this sample I copy the stream to a byte buffer to invoke a constructor that does copy the data in and set OwnBuffer.

```
  SoundStream soundSample_ = new SoundStream(fileStream_);
  
  byte[] arry_ = new byte[soundSample_.Length];
  
  soundSample_.Read(arry_, 0, arry_.Length);
  
  _targetBuffer = new AudioBuffer(arry_, BufferFlags.EndOfStream);
  
  int encodng_ = (int)soundSample_.Format.Encoding;
  
  _waveFormat = soundSample_.Format;
  
  uint[] _encoding = soundSample_.DecodedPacketsInfo;
```