### PR TITLE
Shader compiler constants test.

### DIFF
--- a/src/tests/Vortice.D3DCompiler.Test/CompileTests.cs
+++ b/src/tests/Vortice.D3DCompiler.Test/CompileTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using Vortice.D3DCompiler;
+using Vortice.Direct3D;
 using Xunit;
 
 namespace Vortice.D3DCompiler.Test
@@ -55,6 +56,22 @@ namespace Vortice.D3DCompiler.Test
 
                 Assert.True(shaderCode.Length > 0);
             }
+        }
+
+        [Fact]
+        public void ShaderMacroTest()
+        {
+            string shaderSourceFile = Path.Combine(AssetsPath, "TriangleSingleFile.hlsl");
+
+            var defines = new[] { new ShaderMacro { Name = "TEST", Definition = "1" } };
+
+            var result = Compiler.CompileFromFile(shaderSourceFile, defines, null, "VSMain", "vs_4_0", ShaderFlags.None, EffectFlags.None, out var blob, out var error);
+
+            Assert.True(result.Success);
+
+            var shaderCode = blob.GetBytes();
+
+            Assert.True(shaderCode.Length > 0);
         }
     }
 }

--- a/src/tests/Vortice.Dxc.Test/CompileTests.cs
+++ b/src/tests/Vortice.Dxc.Test/CompileTests.cs
@@ -61,5 +61,23 @@ namespace Vortice.Dxc.Test
                 Assert.True(ShaderCodeHelper.IsCodeSigned(shaderCode), ShaderCodeNotSignedMessage);
             }
         }
+
+        [Fact]
+        public void DxcDefineTest()
+        {
+            string shaderSource = File.ReadAllText(Path.Combine(AssetsPath, "TriangleSingleFile.hlsl"));
+
+            var defines = new DxcDefine[] { new DxcDefine { Name = "TEST", Value = "1" } };
+
+            using IDxcResult? results = DxcCompiler.Compile(DxcShaderStage.Vertex, shaderSource, "VSMain", defines: defines);
+
+            Assert.True(results!.GetStatus().Success);
+
+            var shaderCode = results.GetObjectBytecodeArray();
+
+            Assert.True(shaderCode.Length > 0);
+
+            Assert.True(ShaderCodeHelper.IsCodeSigned(shaderCode), ShaderCodeNotSignedMessage);
+        }
     }
 }


### PR DESCRIPTION
I ran into a compile error with D3DCompiler when compiling with ShaderMacro a couple weeks ago. I narrowed the issue down to the fact that the array must be NULL terminated.

>Pointer to an array of macro definitions (see D3D10_SHADER_MACRO). The last structure in the array serves as a terminator and must have all members set to 0.

https://docs.microsoft.com/en-us/windows/win32/api/d3d10shader/nf-d3d10shader-d3d10compileshader

I checked today and it is no longer causing an error. I suspect that this may just be a coincidence that the memory after the array is clear. Unless you have made a change to add the NULL termination but it doesn't look like it.

I'm not sure if this would be considered a bug since it is documented, but if the error arises again the proper fix is this which I use in my projects. Or Vortice can add the NULL termination in the API for the user.

```
var defines = new DxcDefine[] { new DxcDefine { Name = "TEST", Value = "1" }, new DxcDefine() };
```

This commit is to add tests for D3DCompiler and Dxc.