### PR TITLE
Copy Dxc native assemblies to the correct folder when referencing the…

### DIFF
--- a/src/Vortice.Dxc/Vortice.Dxc.csproj
+++ b/src/Vortice.Dxc/Vortice.Dxc.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Sdk Name="SharpGenTools.Sdk" Version="$(SharpGenVersion)" />
 
@@ -16,14 +16,18 @@
 
   <ItemGroup>
     <Content Include="build\dxcompiler.dll">
+      <Link>dxcompiler.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>build/$(TargetFramework)</PackagePath>
       <Pack>true</Pack>
+      <Visible>false</Visible>
     </Content>
     <Content Include="build\dxil.dll">
+      <Link>dxil.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>build/$(TargetFramework)</PackagePath>
       <Pack>true</Pack>
+      <Visible>false</Visible>
     </Content>
     <Content Include="build\Vortice.Dxc.targets">
       <PackagePath>build/$(TargetFramework)/Vortice.Dxc.targets</PackagePath>


### PR DESCRIPTION
I noticed the shader compiler tests are failing because the native assemblies are not copied to the root folder. This is because they reference the DXC project that has the native assembly files in the build directory but it needs to be copied to the root output bin.

The Link property adds a copy to the root folder of the project but also adds a duplicate in the file explorer. The Visible=false property hides it but the actual file will remain in the build folder in the solution explorer. There may be another way to do this but I'm not aware.