### PR TITLE
Dxc methods should return a non-nullable object since CheckError() is called

### DIFF
--- a/src/Vortice.Dxc/Dxc.cs
+++ b/src/Vortice.Dxc/Dxc.cs
@@ -134,52 +134,52 @@ namespace Vortice.Dxc
 #endif
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static IDxcCompiler? CreateDxcCompiler()
+        public static IDxcCompiler CreateDxcCompiler()
         {
             DxcCreateInstance(CLSID_DxcCompiler, out IDxcCompiler? result).CheckError();
-            return result;
+            return result!;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static IDxcCompiler2? CreateDxcCompiler2()
+        public static IDxcCompiler2 CreateDxcCompiler2()
         {
             DxcCreateInstance(CLSID_DxcCompiler, out IDxcCompiler2? result).CheckError();
-            return result;
+            return result!;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static IDxcCompiler3? CreateDxcCompiler3()
+        public static IDxcCompiler3 CreateDxcCompiler3()
         {
             DxcCreateInstance(CLSID_DxcCompiler, out IDxcCompiler3? result).CheckError();
-            return result;
+            return result!;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static IDxcUtils? CreateDxcUtils()
+        public static IDxcUtils CreateDxcUtils()
         {
             DxcCreateInstance(CLSID_DxcUtils, out IDxcUtils? result).CheckError();
-            return result;
+            return result!;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static IDxcAssembler? CreateDxcAssembler()
+        public static IDxcAssembler CreateDxcAssembler()
         {
             DxcCreateInstance(CLSID_DxcAssembler, out IDxcAssembler? result).CheckError();
-            return result;
+            return result!;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static IDxcLinker? CreateDxcLinker()
+        public static IDxcLinker CreateDxcLinker()
         {
             DxcCreateInstance(CLSID_DxcLinker, out IDxcLinker? result).CheckError();
-            return result;
+            return result!;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static IDxcContainerReflection? CreateDxcContainerReflection()
+        public static IDxcContainerReflection CreateDxcContainerReflection()
         {
             DxcCreateInstance(CLSID_DxcContainerReflection, out IDxcContainerReflection? result).CheckError();
-            return result;
+            return result!;
         }
 
         public static void LoadDxil()

--- a/src/Vortice.Dxc/Dxil.cs
+++ b/src/Vortice.Dxc/Dxil.cs
@@ -10,10 +10,10 @@ namespace Vortice.Dxc
     public static partial class Dxil
     {
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static IDxcValidator? CreateDxilValidator()
+        public static IDxcValidator CreateDxilValidator()
         {
             DxilCreateInstance(Dxc.CLSID_DxcValidator, out IDxcValidator? result).CheckError();
-            return result;
+            return result!;
         }
 
 


### PR DESCRIPTION
AFAIK since these methods call CheckError() it is guaranteed that the result must be non-null.

Also, there are a lot of overloads in Vortice.Dxc that return a nullable object (e.g. DxcCompiler.Compile(string, string[], IDxcIncludeHandler?)) without calling CheckError(). These are not too useful IMO because you can only tell if there was an error or not (result == null) but you can't tell what the error was. What do you think about changing these methods to return a non-nullable object (i.e. adding CheckError() to these methods)? This would be a breaking change but it's likely to make people's code cleaner since the currently needed null checks would no longer be necessary. I can do a PR if you're okay with the change.