### PR TITLE
Breaking change: return non-nullable interfaces from Dxc methods.

### DIFF
--- a/src/Vortice.Dxc/DxcCompiler.cs
+++ b/src/Vortice.Dxc/DxcCompiler.cs
@@ -10,10 +10,10 @@ namespace Vortice.Dxc
 {
     public static class DxcCompiler
     {
-        public static readonly IDxcUtils? Utils = Dxc.CreateDxcUtils();
-        public static readonly IDxcCompiler3? Compiler = Dxc.CreateDxcCompiler3();
+        public static readonly IDxcUtils Utils = Dxc.CreateDxcUtils();
+        public static readonly IDxcCompiler3 Compiler = Dxc.CreateDxcCompiler3();
 
-        public static IDxcResult? Compile(string shaderSource, string[] arguments, IDxcIncludeHandler? includeHandler = null)
+        public static IDxcResult Compile(string shaderSource, string[] arguments, IDxcIncludeHandler? includeHandler = null)
         {
             if (includeHandler == null)
             {
@@ -33,7 +33,7 @@ namespace Vortice.Dxc
             }
         }
 
-        public static IDxcResult? Compile(DxcShaderStage shaderStage, string source, string entryPoint,
+        public static IDxcResult Compile(DxcShaderStage shaderStage, string source, string entryPoint,
             DxcCompilerOptions? options = null,
             string? fileName = null,
             DxcDefine[]? defines = null,

--- a/src/Vortice.Dxc/IDxcCompiler.cs
+++ b/src/Vortice.Dxc/IDxcCompiler.cs
@@ -15,7 +15,7 @@ namespace Vortice.Dxc
         }
 
         #region Compile
-        public IDxcOperationResult? Compile(IDxcBlob source,
+        public IDxcOperationResult Compile(IDxcBlob source,
             string sourceName,
             string entryPoint,
             string targetProfile,
@@ -34,7 +34,7 @@ namespace Vortice.Dxc
                 includeHandler);
         }
 
-        public unsafe IDxcOperationResult? Compile(IDxcBlob source,
+        public unsafe IDxcOperationResult Compile(IDxcBlob source,
             string sourceName,
             string entryPoint,
             string targetProfile,
@@ -52,20 +52,13 @@ namespace Vortice.Dxc
                     argumentsPtr = Interop.AllocToPointers(arguments, argumentsCount);
                 }
 
-                Result hr = Compile(source, sourceName,
+                Compile(source, sourceName,
                     entryPoint, targetProfile,
                     (IntPtr)argumentsPtr, argumentsCount,
                     defines,
                     includeHandler,
-                    out IDxcOperationResult? result);
-
-                if (hr.Failure)
-                {
-                    result = default;
-                    return result;
-                }
-
-                return result;
+                    out IDxcOperationResult? result).CheckError();
+                return result!;
             }
             finally
             {
@@ -142,7 +135,7 @@ namespace Vortice.Dxc
         #endregion Compile
 
         #region Preprocess
-        public IDxcOperationResult? Preprocess(IDxcBlob source,
+        public IDxcOperationResult Preprocess(IDxcBlob source,
             string sourceName,
             string[] arguments,
             DxcDefine[] defines,
@@ -157,7 +150,7 @@ namespace Vortice.Dxc
                 includeHandler);
         }
 
-        public unsafe IDxcOperationResult? Preprocess(IDxcBlob source,
+        public unsafe IDxcOperationResult Preprocess(IDxcBlob source,
             string sourceName,
             string[] arguments,
             int argumentsCount,
@@ -173,19 +166,13 @@ namespace Vortice.Dxc
                     argumentsPtr = Interop.AllocToPointers(arguments, argumentsCount);
                 }
 
-                Result hr = Preprocess(source, sourceName,
+                Preprocess(source, sourceName,
                     (IntPtr)argumentsPtr, argumentsCount,
                     defines,
                     includeHandler,
-                    out IDxcOperationResult? result);
+                    out IDxcOperationResult? result).CheckError();
 
-                if (hr.Failure)
-                {
-                    result = default;
-                    return default;
-                }
-
-                return result;
+                return result!;
             }
             finally
             {

--- a/src/Vortice.Dxc/IDxcCompiler2.cs
+++ b/src/Vortice.Dxc/IDxcCompiler2.cs
@@ -9,7 +9,7 @@ namespace Vortice.Dxc
 {
     public partial class IDxcCompiler2
     {
-        public IDxcOperationResult? CompileWithDebug(IDxcBlob source,
+        public IDxcOperationResult CompileWithDebug(IDxcBlob source,
             string sourceName,
             string entryPoint,
             string targetProfile,
@@ -30,7 +30,7 @@ namespace Vortice.Dxc
                 out debugBlobName, out debugBlob);
         }
 
-        public unsafe IDxcOperationResult? CompileWithDebug(IDxcBlob source,
+        public unsafe IDxcOperationResult CompileWithDebug(IDxcBlob source,
             string sourceName,
             string entryPoint,
             string targetProfile,
@@ -52,7 +52,7 @@ namespace Vortice.Dxc
                     argumentsPtr = Interop.AllocToPointers(arguments, argumentsCount);
                 }
 
-                Result hr = CompileWithDebug(source,
+                CompileWithDebug(source,
                     sourceName,
                     entryPoint, targetProfile,
                     (IntPtr)argumentsPtr, argumentsCount,
@@ -60,7 +60,7 @@ namespace Vortice.Dxc
                     includeHandler,
                     out IDxcOperationResult? result,
                     new IntPtr(&debugBlobNameOut),
-                    out debugBlob);
+                    out debugBlob).CheckError();
 
                 if (debugBlobNameOut != IntPtr.Zero)
                 {
@@ -71,13 +71,7 @@ namespace Vortice.Dxc
                     debugBlobName = string.Empty;
                 }
 
-                if (hr.Failure)
-                {
-                    result = default;
-                    return default;
-                }
-
-                return result;
+                return result!;
             }
             finally
             {

--- a/src/Vortice.Dxc/IDxcCompiler3.cs
+++ b/src/Vortice.Dxc/IDxcCompiler3.cs
@@ -10,10 +10,10 @@ namespace Vortice.Dxc
 {
     public partial class IDxcCompiler3
     {
-        public unsafe IDxcResult? Compile(string source, string[] arguments, IDxcIncludeHandler includeHandler)
+        public unsafe IDxcResult Compile(string source, string[] arguments, IDxcIncludeHandler includeHandler)
         {
             Compile(source, arguments, includeHandler, out IDxcResult? result).CheckError();
-            return result;
+            return result!;
         }
 
         public unsafe Result Compile<T>(string source, string[] arguments, IDxcIncludeHandler includeHandler, out T? result) where T : ComObject
@@ -61,10 +61,10 @@ namespace Vortice.Dxc
             }
         }
 
-        public T? Disassemble<T>(in DxcBuffer buffer) where T : IDxcResult
+        public T Disassemble<T>(in DxcBuffer buffer) where T : IDxcResult
         {
-            Disassemble(buffer, out T? result);
-            return result;
+            Disassemble(buffer, out T? result).CheckError();
+            return result!;
         }
 
         public unsafe Result Disassemble<T>(DxcBuffer buffer, out T? result) where T : IDxcResult
@@ -80,10 +80,10 @@ namespace Vortice.Dxc
             return hr;
         }
 
-        public T? Disassemble<T>(string source) where T : IDxcResult
+        public T Disassemble<T>(string source) where T : IDxcResult
         {
-            Disassemble(source, out T? result);
-            return result;
+            Disassemble(source, out T? result).CheckError();
+            return result!;
         }
 
         public unsafe Result Disassemble<T>(string source, out T? result) where T : IDxcResult

--- a/src/Vortice.Dxc/IDxcExtraOutputs.cs
+++ b/src/Vortice.Dxc/IDxcExtraOutputs.cs
@@ -8,14 +8,9 @@ namespace Vortice.Dxc
 {
     public partial class IDxcExtraOutputs
     {
-        public T? GetOutput<T>(int index, out IDxcBlobUtf16 outputType, out IDxcBlobUtf16 outputName) where T : IDxcBlob
+        public T GetOutput<T>(int index, out IDxcBlobUtf16 outputType, out IDxcBlobUtf16 outputName) where T : IDxcBlob
         {
-            Result result = GetOutput(index, typeof(T).GUID, out IntPtr nativePtr, out outputType, out outputName);
-            if (result.Failure)
-            {
-                return default;
-            }
-
+            GetOutput(index, typeof(T).GUID, out IntPtr nativePtr, out outputType, out outputName).CheckError();
             return MarshallingHelpers.FromPointer<T>(nativePtr);
         }
 

--- a/src/Vortice.Dxc/IDxcLinker.cs
+++ b/src/Vortice.Dxc/IDxcLinker.cs
@@ -8,16 +8,16 @@ namespace Vortice.Dxc
 {
     public partial class IDxcLinker
     {
-        public IDxcOperationResult? Link(string entryName, string targetProfile, string[] libNames, string[] arguments)
+        public IDxcOperationResult Link(string entryName, string targetProfile, string[] libNames, string[] arguments)
         {
-            Link(entryName, targetProfile, libNames, arguments, out IDxcOperationResult? result);
-            return result;
+            Link(entryName, targetProfile, libNames, arguments, out IDxcOperationResult? result).CheckError();
+            return result!;
         }
 
-        public IDxcOperationResult? Link(string entryName, string targetProfile, string[] libNames, int libCount, string[] arguments, int argumentsCount)
+        public IDxcOperationResult Link(string entryName, string targetProfile, string[] libNames, int libCount, string[] arguments, int argumentsCount)
         {
-            Link(entryName, targetProfile, libNames, libCount, arguments, argumentsCount, out IDxcOperationResult? result);
-            return result;
+            Link(entryName, targetProfile, libNames, libCount, arguments, argumentsCount, out IDxcOperationResult? result).CheckError();
+            return result!;
         }
 
         public unsafe Result Link(string entryName, string targetProfile, string[] libNames, string[] arguments, out IDxcOperationResult? result)

--- a/src/Vortice.Dxc/IDxcPdbUtils.cs
+++ b/src/Vortice.Dxc/IDxcPdbUtils.cs
@@ -7,13 +7,9 @@ namespace Vortice.Dxc
 {
     public partial class IDxcPdbUtils
     {
-        public IDxcResult? CompileForFullPDB()
+        public IDxcResult CompileForFullPDB()
         {
-            if (CompileForFullPDB(out IDxcResult result).Failure)
-            {
-                return default;
-            }
-
+            CompileForFullPDB(out IDxcResult result).CheckError();
             return result;
         }
     }

--- a/src/Vortice.Dxc/IDxcResult.cs
+++ b/src/Vortice.Dxc/IDxcResult.cs
@@ -49,38 +49,23 @@ namespace Vortice.Dxc
             }
         }
 
-        public IDxcBlob? GetOutput(DxcOutKind kind)
+        public IDxcBlob GetOutput(DxcOutKind kind)
         {
-            Result result = GetOutput(kind, typeof(IDxcBlob).GUID, out IntPtr nativePtr, IntPtr.Zero);
-            if (result.Failure)
-            {
-                return default;
-            }
-
+            GetOutput(kind, typeof(IDxcBlob).GUID, out IntPtr nativePtr, IntPtr.Zero).CheckError();
             return new IDxcBlob(nativePtr);
         }
 
 
-        public T? GetOutput<T>(DxcOutKind kind) where T : ComObject
+        public T GetOutput<T>(DxcOutKind kind) where T : ComObject
         {
-            Result result = GetOutput(kind, typeof(T).GUID, out IntPtr nativePtr, IntPtr.Zero);
-            if (result.Failure)
-            {
-                return default;
-            }
-
+            GetOutput(kind, typeof(T).GUID, out IntPtr nativePtr, IntPtr.Zero).CheckError();
             return MarshallingHelpers.FromPointer<T>(nativePtr);
         }
 
-        public unsafe T? GetOutput<T>(DxcOutKind kind, out IDxcBlobUtf16? outputName) where T : ComObject
+        public unsafe T GetOutput<T>(DxcOutKind kind, out IDxcBlobUtf16? outputName) where T : ComObject
         {
             IntPtr outputNamePtr = IntPtr.Zero;
-            Result result = GetOutput(kind, typeof(T).GUID, out IntPtr nativePtr, new IntPtr(&outputNamePtr));
-            if (result.Failure)
-            {
-                outputName = default;
-                return default;
-            }
+            GetOutput(kind, typeof(T).GUID, out IntPtr nativePtr, new IntPtr(&outputNamePtr)).CheckError();
 
             outputName = new IDxcBlobUtf16(outputNamePtr);
             return MarshallingHelpers.FromPointer<T>(nativePtr);

--- a/src/Vortice.Dxc/IDxcUtils.cs
+++ b/src/Vortice.Dxc/IDxcUtils.cs
@@ -48,17 +48,17 @@ namespace Vortice.Dxc
             return MarshallingHelpers.FromPointer<T>(nativePtr);
         }
 
-        public IDxcCompilerArgs? BuildArguments(string sourceName, string entryPoint, string targetProfile, string[] arguments, DxcDefine[] defines)
+        public IDxcCompilerArgs BuildArguments(string sourceName, string entryPoint, string targetProfile, string[] arguments, DxcDefine[] defines)
         {
-            BuildArguments(sourceName, entryPoint, targetProfile, arguments, defines, out IDxcCompilerArgs? args);
-            return args;
+            BuildArguments(sourceName, entryPoint, targetProfile, arguments, defines, out IDxcCompilerArgs? args).CheckError();
+            return args!;
         }
 
-        public IDxcCompilerArgs? BuildArguments(string sourceName, string entryPoint, string targetProfile,
+        public IDxcCompilerArgs BuildArguments(string sourceName, string entryPoint, string targetProfile,
             string[] arguments, int argumentsCount, DxcDefine[] defines, int defineCount)
         {
-            BuildArguments(sourceName, entryPoint, targetProfile, arguments, argumentsCount, defines, defineCount, out IDxcCompilerArgs? args);
-            return args;
+            BuildArguments(sourceName, entryPoint, targetProfile, arguments, argumentsCount, defines, defineCount, out IDxcCompilerArgs? args).CheckError();
+            return args!;
         }
 
         public unsafe Result BuildArguments(string sourceName, string entryPoint, string targetProfile,

--- a/src/tests/Vortice.Dxc.Test/CompileTests.cs
+++ b/src/tests/Vortice.Dxc.Test/CompileTests.cs
@@ -18,9 +18,9 @@ namespace Vortice.Dxc.Test
         {
             string shaderSource = File.ReadAllText(Path.Combine(AssetsPath, "TriangleSingleFile.hlsl"));
 
-            using IDxcResult? results = DxcCompiler.Compile(DxcShaderStage.Vertex, shaderSource, "VSMain");
+            using IDxcResult results = DxcCompiler.Compile(DxcShaderStage.Vertex, shaderSource, "VSMain");
 
-            Assert.True(results!.GetStatus().Success);
+            Assert.True(results.GetStatus().Success);
 
             var shaderCode = results.GetObjectBytecodeArray();
 
@@ -34,9 +34,9 @@ namespace Vortice.Dxc.Test
         {
             string shaderSource = File.ReadAllText(Path.Combine(AssetsPath, "TriangleError.hlsl"));
 
-            using IDxcResult? results = DxcCompiler.Compile(DxcShaderStage.Vertex, shaderSource, "VSMain");
+            using IDxcResult results = DxcCompiler.Compile(DxcShaderStage.Vertex, shaderSource, "VSMain");
 
-            Assert.True(results!.GetStatus().Failure);
+            Assert.True(results.GetStatus().Failure);
 
             var error = results.GetErrors();
 
@@ -50,9 +50,9 @@ namespace Vortice.Dxc.Test
 
             using (var includeHandler = new ShaderIncludeHandler(AssetsPath))
             {
-                using IDxcResult? results = DxcCompiler.Compile(DxcShaderStage.Vertex, shaderSource, "VSMain", includeHandler: includeHandler);
+                using IDxcResult results = DxcCompiler.Compile(DxcShaderStage.Vertex, shaderSource, "VSMain", includeHandler: includeHandler);
 
-                Assert.True(results!.GetStatus().Success);
+                Assert.True(results.GetStatus().Success);
 
                 var shaderCode = results.GetObjectBytecodeArray();
 
@@ -69,9 +69,9 @@ namespace Vortice.Dxc.Test
 
             var defines = new DxcDefine[] { new DxcDefine { Name = "TEST", Value = "1" } };
 
-            using IDxcResult? results = DxcCompiler.Compile(DxcShaderStage.Vertex, shaderSource, "VSMain", defines: defines);
+            using IDxcResult results = DxcCompiler.Compile(DxcShaderStage.Vertex, shaderSource, "VSMain", defines: defines);
 
-            Assert.True(results!.GetStatus().Success);
+            Assert.True(results.GetStatus().Success);
 
             var shaderCode = results.GetObjectBytecodeArray();
 


### PR DESCRIPTION
If these methods fail they now throw an exception instead of returning null. If throwing an exception is undesired, users can call the Result-returning overloads instead.

I notice IDxcIncludeHandler.LoadSource() has incorrect nullability (includeSource should be nullable), but I'm unsure how to fix it as it is in the generated code (is there a nullability option in Mappings.xml?)