### PR TITLE
Add missing public D3D12CreateVersionedRootSignatureDeserializer() method

### DIFF
--- a/src/Vortice.Direct3D12/D3D12.cs
+++ b/src/Vortice.Direct3D12/D3D12.cs
@@ -253,5 +253,48 @@ namespace Vortice.Direct3D12
         {
             D3D12EnableExperimentalFeatures(features.Length, features, IntPtr.Zero, null);
         }
+
+        private static Result D3D12CreateVersionedRootSignatureDeserializer<T>(IntPtr signatureData, PointerSize signatureDataLength, out T? device) where T : ID3D12VersionedRootSignatureDeserializer
+        {
+            Result result = D3D12CreateVersionedRootSignatureDeserializer(
+                signatureData,
+                signatureDataLength,
+                typeof(T).GUID,
+                out IntPtr nativePtr);
+
+            if (result.Failure)
+            {
+                device = default;
+                return result;
+            }
+
+            device = MarshallingHelpers.FromPointer<T>(nativePtr);
+            return result;
+        }
+
+        public static unsafe Result D3D12CreateVersionedRootSignatureDeserializer<T>(byte[] signatureData, out T? device) where T : ID3D12VersionedRootSignatureDeserializer
+        {
+            fixed (void* dataPtr = signatureData)
+            {
+                return D3D12CreateVersionedRootSignatureDeserializer(new IntPtr(dataPtr), signatureData.Length, out device);
+            }
+        }
+
+        public static Result D3D12CreateVersionedRootSignatureDeserializer<T>(Blob signatureData, out T? device) where T : ID3D12VersionedRootSignatureDeserializer
+        {
+            return D3D12CreateVersionedRootSignatureDeserializer(signatureData.BufferPointer, signatureData.BufferSize, out device);
+        }
+
+        public static T D3D12CreateVersionedRootSignatureDeserializer<T>(byte[] signatureData) where T : ID3D12VersionedRootSignatureDeserializer
+        {
+            D3D12CreateVersionedRootSignatureDeserializer(signatureData, out T? result).CheckError();
+            return result!;
+        }
+
+        public static T D3D12CreateVersionedRootSignatureDeserializer<T>(Blob signatureData) where T : ID3D12VersionedRootSignatureDeserializer
+        {
+            D3D12CreateVersionedRootSignatureDeserializer(signatureData, out T? result).CheckError();
+            return result!;
+        }
     }
 }

--- a/src/Vortice.Direct3D12/ID3D12VersionedRootSignatureDeserializer.cs
+++ b/src/Vortice.Direct3D12/ID3D12VersionedRootSignatureDeserializer.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Amer Koleci and contributors.
+// Distributed under the MIT license. See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace Vortice.Direct3D12;
+
+public partial class ID3D12VersionedRootSignatureDeserializer
+{
+    public unsafe VersionedRootSignatureDescription GetRootSignatureDescAtVersion(RootSignatureVersion convertToVersion)
+    {
+        IntPtr ptr = GetRootSignatureDescAtVersion_(convertToVersion);
+
+        // Marshal the result.
+        var result = new VersionedRootSignatureDescription();
+        result.__MarshalFrom(ref Unsafe.AsRef<VersionedRootSignatureDescription.__Native>(ptr.ToPointer()));
+        return result;
+    }
+}

--- a/src/Vortice.Direct3D12/Mappings.xml
+++ b/src/Vortice.Direct3D12/Mappings.xml
@@ -1004,12 +1004,16 @@
     <map method="ID3D12PipelineLibrary1::LoadPipeline" visibility="private"/>
     <map param="ID3D12PipelineLibrary1::LoadPipeline::ppPipelineState" attribute="out" type="ID3D12PipelineState" return="true"/>
 
+    <!-- ID3D12VersionedRootSignatureDeserializer methods -->
+    <map method="ID3D12VersionedRootSignatureDeserializer::GetRootSignatureDescAtVersion" name="GetRootSignatureDescAtVersion_" visibility="private"/>
+
     <map function="D3D12.*" dll='"d3d12.dll"' group="Vortice.Direct3D12.D3D12" visibility="internal" />
     <map function="D3D12CreateDevice" check="false"/>
     <map param="D3D12CreateDevice::pAdapter" type="void" attribute="in"/>
     <map function="D3D12GetDebugInterface" hresult="true" check="false"/>
     <map function="D3D12SerializeRootSignature" hresult="true" check="false"/>
     <map function="D3D12SerializeVersionedRootSignature" hresult="true" check="false"/>
+    <map function="D3D12CreateVersionedRootSignatureDeserializer" hresult="true" check="false"/>
     <map method="ID3D12CommandList::GetType" name="GetCommandListType" />
 
     <map field="D3D12_GPU_DESCRIPTOR_HANDLE::ptr" name="ptr"/>


### PR DESCRIPTION
Plus I added a usable version of ID3D12VersionedRootSignatureDeserializer.GetRootSignatureDescAtVersion().

I've tested these two methods and they both work fine, but unfortunately ID3D12VersionedRootSignatureDeserializer.GetUnconvertedRootSignatureDescription() doesn't seem to work.

I think this might be because the delegate indicates a Vortice.Direct3D12.VersionedRootSignatureDescription.__Native is returned but the method itself returns a pointer...? I don't know how to change that in the mappings, so I can't check to find out. Any ideas or tips on how to make this work?
