### PR TITLE
FIX: IDWriteFontFace.GetDesignGlyphMetrics Infinite Recursion

### DIFF
--- a/src/Vortice.Direct2D1/DirectWrite/IDWriteFontFace.cs
+++ b/src/Vortice.Direct2D1/DirectWrite/IDWriteFontFace.cs
@@ -42,7 +42,7 @@ namespace Vortice.DirectWrite
 
         public Result GetDesignGlyphMetrics(ushort[] glyphIndices, GlyphMetrics[] glyphMetrics, bool isSideways)
         {
-            return GetDesignGlyphMetrics(glyphIndices, glyphMetrics, isSideways);
+            return GetDesignGlyphMetrics(glyphIndices, glyphMetrics, (RawBool)isSideways);
         }
 
         public GlyphMetrics[] GetGdiCompatibleGlyphMetrics(float fontSize, float pixelsPerDip, Matrix3x2? transform, bool useGdiNatural, ushort[] glyphIndices, bool isSideways)


### PR DESCRIPTION
IDWriteFontFace.cs's implementation was erroneously calling itself rather than the Interfaces.cs version that has isSideways as a RawBool. By explicitly type-casting, we can avoid this issue.

# Before my fix

````
Stack overflow.
Repeat 19375 times:
--------------------------------
   at Vortice.DirectWrite.IDWriteFontFace.GetDesignGlyphMetrics(UInt16[], Vortice.DirectWrite.GlyphMetrics[], Boolean)
--------------------------------
   at Vortice.DirectWrite.IDWriteFontFace.GetDesignGlyphMetrics(UInt16[], Boolean)
   at [my code]
   at [my code]
   at [my code]
````

# After my fix

No infinite recursion.