### PR TITLE
Fix marshalling for DirectStorage Request & RequestOptions structures

### DIFF
--- a/src/Vortice.DirectStorage/Mappings.xml
+++ b/src/Vortice.DirectStorage/Mappings.xml
@@ -35,6 +35,11 @@
     <map enum="DSTORAGE(.+)" name-tmp="$1" />
     <map struct="DSTORAGE(.+)" name-tmp="$1" />
 
+    <!-- DSTORAGE_COMPRESSION_FORMAT -->
+    <map enum-item="DSTORAGE_COMPRESSION_FORMAT_NONE" name="None"/>
+    <map enum-item="DSTORAGE_COMPRESSION_FORMAT_1" name="Format1"/>
+    <map enum-item="DSTORAGE_CUSTOM_COMPRESSION_0" name="Custom0"/>
+
     <remove field="DSTORAGE_ERROR_FIRST_FAILURE::.*"/>
 
     <map method="IDStorageFactory::CreateQueue" visibility="private" hresult="true" check="false"/>
@@ -50,5 +55,7 @@
     <map function="DStorageSetConfiguration" dll='"dstorage.dll"' group="Vortice.DirectStorage.DirectStorage" hresult="true" check="false"/>
     <map function="DStorageGetFactory" dll='"dstorage.dll"' group="Vortice.DirectStorage.DirectStorage" visibility="private" hresult="true" check="false"/>
     <map param="DStorageGetFactory::ppv" attribute="out" return="false" />
+
+    <map struct="DSTORAGE_REQUEST" marshal="true" />
   </mapping>
 </config>

--- a/src/Vortice.DirectStorage/Request.cs
+++ b/src/Vortice.DirectStorage/Request.cs
@@ -1,0 +1,114 @@
+﻿// Copyright © Amer Koleci and Contributors.
+// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
+
+namespace Vortice.DirectStorage;
+
+public partial struct Request
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 0, CharSet = CharSet.Unicode)]
+    internal partial struct __Native
+    {
+        public RequestOptions Options;
+        public Source.__Native Source;
+        public Destination.__Native Destination;
+        public uint UncompressedSize;
+        public ulong CancellationTag;
+        public IntPtr Name;
+    }
+
+    internal unsafe void __MarshalFree(ref __Native @ref)
+    {
+        switch (Options.SourceType)
+        {
+            case RequestSourceType.File:
+                Source.File.__MarshalFree(ref @ref.Source.File);
+                break;
+        }
+        switch (Options.DestinationType)
+        {
+            case RequestDestinationType.Buffer:
+                Destination.Buffer.__MarshalFree(ref @ref.Destination.Buffer);
+                break;
+            case RequestDestinationType.TextureRegion:
+                Destination.Texture.__MarshalFree(ref @ref.Destination.Texture);
+                break;
+            case RequestDestinationType.MultipleSubresources:
+                Destination.MultipleSubresources.__MarshalFree(ref @ref.Destination.MultipleSubresources);
+                break;
+            case RequestDestinationType.Tiles:
+                Destination.Tiles.__MarshalFree(ref @ref.Destination.Tiles);
+                break;
+        }
+        Marshal.FreeHGlobal(@ref.Name);
+    }
+
+    internal unsafe void __MarshalFrom(ref __Native @ref)
+    {
+        Options = @ref.Options;
+        switch (Options.SourceType)
+        {
+            case RequestSourceType.File:
+                Source.File.__MarshalFrom(ref @ref.Source.File);
+                break;
+            case RequestSourceType.Memory:
+                Source.Memory = @ref.Source.Memory;
+                break;
+        }
+        switch (Options.DestinationType)
+        {
+            case RequestDestinationType.Memory:
+                Destination.Memory = @ref.Destination.Memory;
+                break;
+            case RequestDestinationType.Buffer:
+                Destination.Buffer.__MarshalFrom(ref @ref.Destination.Buffer);
+                break;
+            case RequestDestinationType.TextureRegion:
+                Destination.Texture.__MarshalFrom(ref @ref.Destination.Texture);
+                break;
+            case RequestDestinationType.MultipleSubresources:
+                Destination.MultipleSubresources.__MarshalFrom(ref @ref.Destination.MultipleSubresources);
+                break;
+            case RequestDestinationType.Tiles:
+                Destination.Tiles.__MarshalFrom(ref @ref.Destination.Tiles);
+                break;
+        }
+        UncompressedSize = @ref.UncompressedSize;
+        CancellationTag = @ref.CancellationTag;
+        Name = Marshal.PtrToStringAnsi(@ref.Name);
+    }
+
+    internal unsafe void __MarshalTo(ref __Native @ref)
+    {
+        @ref.Options = Options;
+        switch (Options.SourceType)
+        {
+            case RequestSourceType.File:
+                Source.File.__MarshalTo(ref @ref.Source.File);
+                break;
+            case RequestSourceType.Memory:
+                @ref.Source.Memory = Source.Memory;
+                break;
+        }
+        switch (Options.DestinationType)
+        {
+            case RequestDestinationType.Memory:
+                @ref.Destination.Memory = Destination.Memory;
+                break;
+            case RequestDestinationType.Buffer:
+                Destination.Buffer.__MarshalTo(ref @ref.Destination.Buffer);
+                break;
+            case RequestDestinationType.TextureRegion:
+                Destination.Texture.__MarshalTo(ref @ref.Destination.Texture);
+                break;
+            case RequestDestinationType.MultipleSubresources:
+                Destination.MultipleSubresources.__MarshalTo(ref @ref.Destination.MultipleSubresources);
+                break;
+            case RequestDestinationType.Tiles:
+                Destination.Tiles.__MarshalTo(ref @ref.Destination.Tiles);
+                break;
+        }
+        @ref.UncompressedSize = UncompressedSize;
+        @ref.CancellationTag = CancellationTag;
+        @ref.Name = Marshal.StringToHGlobalAnsi(Name);
+    }
+}

--- a/src/Vortice.DirectStorage/RequestOptions.cs
+++ b/src/Vortice.DirectStorage/RequestOptions.cs
@@ -27,6 +27,6 @@ public partial struct RequestOptions
     public RequestDestinationType DestinationType
     {
         get => (RequestDestinationType)((_Type & 254ul) >> 1);
-        set => _Type = (_Type & ~254ul) | (((ulong)value & 127ul) << 1);
+        set => _Type = (_Type & ~254ul) | (((ulong)value << 1) & 254ul);
     }
 }

--- a/src/Vortice.DirectStorage/RequestOptions.cs
+++ b/src/Vortice.DirectStorage/RequestOptions.cs
@@ -7,35 +7,26 @@ namespace Vortice.DirectStorage;
 public partial struct RequestOptions
 {
     [FieldOffset(0)]
-    internal byte _CompressionFormat;
+    internal CompressionFormat _CompressionFormat;
+
     public CompressionFormat CompressionFormat
     {
-        get => (CompressionFormat)((_CompressionFormat >> 0) & 255);
-        set => _CompressionFormat = (byte)((_CompressionFormat & ~(255 << 0)) | (((byte)value & 255) << 0));
+        get => _CompressionFormat;
+        set => _CompressionFormat = value;
     }
 
-    [FieldOffset(0)]
-    internal long _SourceType;
+    [FieldOffset(8)]
+    internal ulong _Type;
 
     public RequestSourceType SourceType
     {
-        get => (RequestSourceType)((_SourceType >> 8) & 1);
-        set => _SourceType = (_SourceType & ~(1 << 8)) | (((long)value & 1) << 8);
+        get => (RequestSourceType)(_Type & 1);
+        set => _Type = (_Type & ~1ul) | ((ulong)value & 1ul);
     }
 
-    [FieldOffset(0)]
-    internal long _DestinationType;
     public RequestDestinationType DestinationType
     {
-        get => (RequestDestinationType)((_DestinationType >> 9) & 127);
-        set => _DestinationType = (long)((_DestinationType & ~(127 << 9)) | (((long)value & 127) << 9));
-    }
-
-    [FieldOffset(0)]
-    internal ulong _Reserved;
-    internal ulong Reserved
-    {
-        get => (_Reserved >> 16) & 65535;
-        set => _Reserved = (ulong)((_Reserved & ~(65535 << 16)) | ((value & 65535) << 16));
+        get => (RequestDestinationType)((_Type & 254ul) >> 1);
+        set => _Type = (_Type & ~254ul) | (((ulong)value & 127ul) << 1);
     }
 }

--- a/src/samples/HelloDirectStorage/HelloDirectStorage.csproj
+++ b/src/samples/HelloDirectStorage/HelloDirectStorage.csproj
@@ -12,4 +12,10 @@
     <ProjectReference Include="..\..\Vortice.DirectStorage\Vortice.DirectStorage.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Test.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/src/samples/HelloDirectStorage/Test.txt
+++ b/src/samples/HelloDirectStorage/Test.txt
@@ -1,0 +1,1 @@
+Hello there!


### PR DESCRIPTION
* Request.Source and Request.Destination are unions, and the marshalling was reading/writing every member of the union. I've fixed it so that only a single member of these structures is marshalled.
* According to my testing in C++, RequestOptions is 16 bytes, with the compression format taking the first 8 bytes and the source and destination types taking the second 8 bytes. Looking at the struct definition I would not have guessed this to be the case.
* I added the test.txt file that the DirectStorage sample needs.
* The CompressionFormat enum had some broken names, so I fixed it.