### PR TITLE
Direct2D1: ID2D1GeometrySink is IDisposable

### DIFF
--- a/src/Vortice.Direct2D1/ID2D1GeometrySink.cs
+++ b/src/Vortice.Direct2D1/ID2D1GeometrySink.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Amer Koleci and contributors.
+// Distributed under the MIT license. See the LICENSE file in the project root for more information.
+
+namespace Vortice.Direct2D1
+{
+    public partial interface ID2D1GeometrySink : IDisposable { }
+}


### PR DESCRIPTION
This is useful because ID2D1PathGeometry::Open returns a
ID2D1GeometrySink backed by a ID2D1GeometrySinkNative and failing
to release that native COM object will result in a memory leak.

I suspect this breaks nobody as implementing a managed ID2D1GeometrySink
already entails subclassing CallbackBase which implements IDisposable. However,
anyone using PathGeometry.Open should probably pull this change in & call disposers accordingly.

Here is an example use-case:

```
using ID2D1PathGeometry pathGeometry = d2dFactory.CreatePathGeometry();
using ID2D1GeometrySink geometrySink = pathGeometry.Open(); // before this using wouldn't be possible.
```