### PR TITLE
Fix effect property setter/getter type

### DIFF
--- a/src/Vortice.Direct2D1/Effects/ConvolveMatrix.cs
+++ b/src/Vortice.Direct2D1/Effects/ConvolveMatrix.cs
@@ -31,14 +31,14 @@ public sealed class ConvolveMatrix : ID2D1Effect
 
     public int KernelSizeX
     {
-        set => SetValue((int)ConvolveMatrixProperties.KernelSizeX, value);
-        get => GetIntValue((int)ConvolveMatrixProperties.KernelSizeX);
+        set => SetValue((int)ConvolveMatrixProperties.KernelSizeX, (uint)value);
+        get => (int)GetUintValue((int)ConvolveMatrixProperties.KernelSizeX);
     }
 
     public int KernelSizeY
     {
-        set => SetValue((int)ConvolveMatrixProperties.KernelSizeY, value);
-        get => GetIntValue((int)ConvolveMatrixProperties.KernelSizeY);
+        set => SetValue((int)ConvolveMatrixProperties.KernelSizeY, (uint)value);
+        get => (int)GetUintValue((int)ConvolveMatrixProperties.KernelSizeY);
     }
 
     public  unsafe float[] KernelMatrix

--- a/src/Vortice.Direct2D1/Effects/Histogram.cs
+++ b/src/Vortice.Direct2D1/Effects/Histogram.cs
@@ -17,8 +17,8 @@ public sealed class Histogram : ID2D1Effect
 
     public int NumBins
     {
-        get => GetIntValue((int)HistogramProperties.NumBins);
-        set => SetValue((int)HistogramProperties.NumBins, value);
+        get => (int)GetUintValue((int)HistogramProperties.NumBins);
+        set => SetValue((int)HistogramProperties.NumBins, (uint)value);
     }
 
     public ChannelSelector ChannelSelect

--- a/src/Vortice.Direct2D1/Effects/Morphology.cs
+++ b/src/Vortice.Direct2D1/Effects/Morphology.cs
@@ -1,36 +1,35 @@
 ﻿// Copyright (c) Amer Koleci and contributors.
 // Distributed under the MIT license. See the LICENSE file in the project root for more information.
 
-namespace Vortice.Direct2D1.Effects
+namespace Vortice.Direct2D1.Effects;
+
+public sealed class Morphology : ID2D1Effect
 {
-    public sealed class Morphology : ID2D1Effect
+    public Morphology(ID2D1DeviceContext context)
+        : base(context.CreateEffect(EffectGuids.Morphology))
     {
-        public Morphology(ID2D1DeviceContext context)
-            : base(context.CreateEffect(EffectGuids.Morphology))
-        {
-        }
+    }
 
-        public Morphology(ID2D1EffectContext context)
-            : base(context.CreateEffect(EffectGuids.Morphology))
-        {
-        }
+    public Morphology(ID2D1EffectContext context)
+        : base(context.CreateEffect(EffectGuids.Morphology))
+    {
+    }
 
-        public MorphologyMode Mode
-        {
-            get => GetEnumValue<MorphologyMode>((int)MorphologyProperties.Mode);
-            set => SetValue((int)MorphologyProperties.Mode, value);
-        }
+    public MorphologyMode Mode
+    {
+        get => GetEnumValue<MorphologyMode>((int)MorphologyProperties.Mode);
+        set => SetValue((int)MorphologyProperties.Mode, value);
+    }
 
-        public int Width
-        {
-            get => GetIntValue((int)MorphologyProperties.Width);
-            set => SetValue((int)MorphologyProperties.Width, value);
-        }
+    public int Width
+    {
+        get => (int)GetUintValue((int)MorphologyProperties.Width);
+        set => SetValue((int)MorphologyProperties.Width, (uint)value);
+    }
 
-        public int Height
-        {
-            get => GetIntValue((int)MorphologyProperties.Height);
-            set => SetValue((int)MorphologyProperties.Height, value);
-        }
+    public int Height
+    {
+        get => (int)GetUintValue((int)MorphologyProperties.Height);
+        set => SetValue((int)MorphologyProperties.Height, (uint)value);
     }
 }

--- a/src/Vortice.Direct2D1/Effects/Posterize.cs
+++ b/src/Vortice.Direct2D1/Effects/Posterize.cs
@@ -1,36 +1,35 @@
 ﻿// Copyright (c) Amer Koleci and contributors.
 // Distributed under the MIT license. See the LICENSE file in the project root for more information.
 
-namespace Vortice.Direct2D1.Effects
+namespace Vortice.Direct2D1.Effects;
+
+public sealed class Posterize : ID2D1Effect
 {
-    public sealed class Posterize : ID2D1Effect
+    public Posterize(ID2D1DeviceContext context)
+       : base(context.CreateEffect(EffectGuids.Posterize))
     {
-        public Posterize(ID2D1DeviceContext context)
-           : base(context.CreateEffect(EffectGuids.Posterize))
-        {
-        }
+    }
 
-        public Posterize(ID2D1EffectContext context)
-            : base(context.CreateEffect(EffectGuids.Posterize))
-        {
-        }
+    public Posterize(ID2D1EffectContext context)
+        : base(context.CreateEffect(EffectGuids.Posterize))
+    {
+    }
 
-        public int RedValueCount
-        {
-            set => SetValue((int)PosterizeProperties.RedValueCount, value);
-            get => GetIntValue((int)PosterizeProperties.RedValueCount);
-        }
+    public int RedValueCount
+    {
+        set => SetValue((int)PosterizeProperties.RedValueCount, (uint)value);
+        get => (int)GetUintValue((int)PosterizeProperties.RedValueCount);
+    }
 
-        public int GreenValueCount
-        {
-            set => SetValue((int)PosterizeProperties.GreenValueCount, value);
-            get => GetIntValue((int)PosterizeProperties.GreenValueCount);
-        }
+    public int GreenValueCount
+    {
+        set => SetValue((int)PosterizeProperties.GreenValueCount, (uint)value);
+        get => (int)GetUintValue((int)PosterizeProperties.GreenValueCount);
+    }
 
-        public int BlueValueCount
-        {
-            set => SetValue((int)PosterizeProperties.BlueValueCount, value);
-            get => GetIntValue((int)PosterizeProperties.BlueValueCount);
-        }
+    public int BlueValueCount
+    {
+        set => SetValue((int)PosterizeProperties.BlueValueCount, (uint)value);
+        get => (int)GetUintValue((int)PosterizeProperties.BlueValueCount);
     }
 }

--- a/src/Vortice.Direct2D1/Effects/Turbulence.cs
+++ b/src/Vortice.Direct2D1/Effects/Turbulence.cs
@@ -3,60 +3,59 @@
 
 using System.Numerics;
 
-namespace Vortice.Direct2D1.Effects
+namespace Vortice.Direct2D1.Effects;
+
+public sealed class Turbulence : ID2D1Effect
 {
-    public sealed class Turbulence : ID2D1Effect
+    public Turbulence(ID2D1DeviceContext context)
+       : base(context.CreateEffect(EffectGuids.Turbulence))
     {
-        public Turbulence(ID2D1DeviceContext context)
-           : base(context.CreateEffect(EffectGuids.Turbulence))
-        {
-        }
+    }
 
-        public Turbulence(ID2D1EffectContext context)
-            : base(context.CreateEffect(EffectGuids.Turbulence))
-        {
-        }
+    public Turbulence(ID2D1EffectContext context)
+        : base(context.CreateEffect(EffectGuids.Turbulence))
+    {
+    }
 
-        public Vector2 Offset
-        {
-            set => SetValue((int)TurbulenceProperties.Offset, value);
-            get => GetVector2Value((int)TurbulenceProperties.Offset);
-        }
+    public Vector2 Offset
+    {
+        set => SetValue((int)TurbulenceProperties.Offset, value);
+        get => GetVector2Value((int)TurbulenceProperties.Offset);
+    }
 
-        public Vector2 Size
-        {
-            set => SetValue((int)TurbulenceProperties.Size, value);
-            get => GetVector2Value((int)TurbulenceProperties.Size);
-        }
+    public Vector2 Size
+    {
+        set => SetValue((int)TurbulenceProperties.Size, value);
+        get => GetVector2Value((int)TurbulenceProperties.Size);
+    }
 
-        public Vector2 BaseFrequency
-        {
-            set => SetValue((int)TurbulenceProperties.BaseFrequency, value);
-            get => GetVector2Value((int)TurbulenceProperties.BaseFrequency);
-        }
+    public Vector2 BaseFrequency
+    {
+        set => SetValue((int)TurbulenceProperties.BaseFrequency, value);
+        get => GetVector2Value((int)TurbulenceProperties.BaseFrequency);
+    }
 
-        public int NumOctaves
-        {
-            set => SetValue((int)TurbulenceProperties.NumOctaves, value);
-            get => GetIntValue((int)TurbulenceProperties.NumOctaves);
-        }
+    public int NumOctaves
+    {
+        set => SetValue((int)TurbulenceProperties.NumOctaves, (uint)value);
+        get => (int)GetUintValue((int)TurbulenceProperties.NumOctaves);
+    }
 
-        public int Seed
-        {
-            set => SetValue((int)TurbulenceProperties.Seed, value);
-            get => GetIntValue((int)TurbulenceProperties.Seed);
-        }
+    public int Seed
+    {
+        set => SetValue((int)TurbulenceProperties.Seed, value);
+        get => GetIntValue((int)TurbulenceProperties.Seed);
+    }
 
-        public TurbulenceNoise Noise
-        {
-            set => SetValue((int)TurbulenceProperties.Noise, value);
-            get => GetEnumValue<TurbulenceNoise>((int)TurbulenceProperties.Noise);
-        }
+    public TurbulenceNoise Noise
+    {
+        set => SetValue((int)TurbulenceProperties.Noise, value);
+        get => GetEnumValue<TurbulenceNoise>((int)TurbulenceProperties.Noise);
+    }
 
-        public bool Stitchable
-        {
-            set => SetValue((int)TurbulenceProperties.Stitchable, value);
-            get => GetBoolValue((int)TurbulenceProperties.Stitchable);
-        }
+    public bool Stitchable
+    {
+        set => SetValue((int)TurbulenceProperties.Stitchable, value);
+        get => GetBoolValue((int)TurbulenceProperties.Stitchable);
     }
 }


### PR DESCRIPTION
Fixed several properties that were failing to set and get.
These properties must be set/get with uint.
- ConvolveMatrix.KernelSizeX / KernelSizeY
- Histogram.NumBins
- Morphology.Width / Height
- Posterize.RedValueCount / GreenValueCount / BlueValueCount
- Turbulence.NumOctaves

[The documents](https://docs.microsoft.com/en-us/windows/win32/api/d2d1effects/ne-d2d1effects-d2d1_turbulence_prop) say that `Turbulence.Seed` must be uint, but in reality, failed to set/get with uint.
So, `Turbulence.Seed` is keep as int.