### PR TITLE
Fix ColorContext as PropertyType.ColorContext instead of PropertyType.IUnknown

### DIFF
--- a/src/Vortice.Direct2D1/Effects/ColorManagement.cs
+++ b/src/Vortice.Direct2D1/Effects/ColorManagement.cs
@@ -1,54 +1,53 @@
 ﻿// Copyright (c) Amer Koleci and contributors.
 // Distributed under the MIT license. See the LICENSE file in the project root for more information.
 
-namespace Vortice.Direct2D1.Effects
+namespace Vortice.Direct2D1.Effects;
+
+public class ColorManagement : ID2D1Effect
 {
-    public class ColorManagement : ID2D1Effect
+    public ColorManagement(ID2D1DeviceContext context)
+       : base(context.CreateEffect(EffectGuids.ColorManagement))
     {
-        public ColorManagement(ID2D1DeviceContext context)
-           : base(context.CreateEffect(EffectGuids.ColorManagement))
-        {
-        }
+    }
 
-        public ColorManagement(ID2D1EffectContext context)
-            : base(context.CreateEffect(EffectGuids.ColorManagement))
-        {
-        }
+    public ColorManagement(ID2D1EffectContext context)
+        : base(context.CreateEffect(EffectGuids.ColorManagement))
+    {
+    }
 
-        public ID2D1ColorContext? SourceColorContext
-        {
-            get => GetIUnknownValue<ID2D1ColorContext>((int)ColorManagementProperties.SourceColorContext);
-            set => SetValue((int)ColorManagementProperties.SourceColorContext, value);
-        }
+    public ID2D1ColorContext? SourceColorContext
+    {
+        get => GetColorContextValue((int)ColorManagementProperties.SourceColorContext);
+        set => SetValue((int)ColorManagementProperties.SourceColorContext, value);
+    }
 
-        public ColorManagementRenderingIntent SourceRenderingIntent
-        {
-            set => SetValue((int)ColorManagementProperties.SourceRenderingIntent, value);
-            get => GetEnumValue<ColorManagementRenderingIntent>((int)ColorManagementProperties.SourceRenderingIntent);
-        }
+    public ColorManagementRenderingIntent SourceRenderingIntent
+    {
+        set => SetValue((int)ColorManagementProperties.SourceRenderingIntent, value);
+        get => GetEnumValue<ColorManagementRenderingIntent>((int)ColorManagementProperties.SourceRenderingIntent);
+    }
 
-        public ID2D1ColorContext? DestinationColorContext
-        {
-            get => GetIUnknownValue<ID2D1ColorContext>((int)ColorManagementProperties.DestinationColorContext);
-            set => SetValue((int)ColorManagementProperties.DestinationColorContext, value);
-        }
+    public ID2D1ColorContext? DestinationColorContext
+    {
+        get => GetColorContextValue((int)ColorManagementProperties.DestinationColorContext);
+        set => SetValue((int)ColorManagementProperties.DestinationColorContext, value);
+    }
 
-        public ColorManagementRenderingIntent DestinationRenderingIntent
-        {
-            set => SetValue((int)ColorManagementProperties.DestinationRenderingIntent, value);
-            get => GetEnumValue<ColorManagementRenderingIntent>((int)ColorManagementProperties.DestinationRenderingIntent);
-        }
+    public ColorManagementRenderingIntent DestinationRenderingIntent
+    {
+        set => SetValue((int)ColorManagementProperties.DestinationRenderingIntent, value);
+        get => GetEnumValue<ColorManagementRenderingIntent>((int)ColorManagementProperties.DestinationRenderingIntent);
+    }
 
-        public ColorManagementAlphaMode AlphaMode
-        {
-            set => SetValue((int)ColorManagementProperties.AlphaMode, value);
-            get => GetEnumValue<ColorManagementAlphaMode>((int)ColorManagementProperties.AlphaMode);
-        }
+    public ColorManagementAlphaMode AlphaMode
+    {
+        set => SetValue((int)ColorManagementProperties.AlphaMode, value);
+        get => GetEnumValue<ColorManagementAlphaMode>((int)ColorManagementProperties.AlphaMode);
+    }
 
-        public ColormanagementQuality Quality
-        {
-            set => SetValue((int)ColorManagementProperties.Quality, value);
-            get => GetEnumValue<ColormanagementQuality>((int)ColorManagementProperties.Quality);
-        }
+    public ColormanagementQuality Quality
+    {
+        set => SetValue((int)ColorManagementProperties.Quality, value);
+        get => GetEnumValue<ColormanagementQuality>((int)ColorManagementProperties.Quality);
     }
 }

--- a/src/Vortice.Direct2D1/ID2D1Properties.cs
+++ b/src/Vortice.Direct2D1/ID2D1Properties.cs
@@ -99,6 +99,12 @@ public unsafe partial class ID2D1Properties
         SetValue(index, PropertyType.IUnknown, &ptr, sizeof(IntPtr));
     }
 
+    public void SetValue(int index, ID2D1ColorContext? colorContext)
+    {
+        IntPtr ptr = colorContext?.NativePointer ?? IntPtr.Zero;
+        SetValue(index, PropertyType.ColorContext, &ptr, sizeof(IntPtr));
+    }
+
     public bool GetBoolValue(int index)
     {
         int value = default;
@@ -203,5 +209,11 @@ public unsafe partial class ID2D1Properties
         IntPtr value = default;
         GetValue(index, PropertyType.IUnknown, &value, sizeof(IntPtr));
         return value == IntPtr.Zero ? default : As<T>(value);
+    }
+    public unsafe ID2D1ColorContext? GetColorContextValue(int index)
+    {
+        IntPtr value = default;
+        GetValue(index, PropertyType.ColorContext, &value, sizeof(IntPtr));
+        return value == IntPtr.Zero ? default : new ID2D1ColorContext(value);
     }
 }


### PR DESCRIPTION
I don't know why, but when I set `ColorContext` as `PropertyType.IUnknown`, I get `0x80000003` error code on the application exits.
When using `PropertyType.ColorContext`, the application exits normally.