### PR TITLE
Fix some MediaFoundation issue

### DIFF
--- a/src/Vortice.MediaFoundation/IMFAttributes.cs
+++ b/src/Vortice.MediaFoundation/IMFAttributes.cs
@@ -198,15 +198,21 @@ namespace Vortice.MediaFoundation
                 return;
             }
 
-            if (typeof(T) == typeof(long) || typeof(T) == typeof(ulong))
+            if (value is long lvalue)
             {
-                Set_(guidKey, Convert.ToInt64(value));
+                Set_(guidKey, unchecked((ulong)lvalue));
+                return;
+            }
+
+            if(value is ulong ulvalue)
+            {
+                Set_(guidKey, ulvalue);
                 return;
             }
 
             if (typeof(T) == typeof(IntPtr))
             {
-                Set_(guidKey, ((IntPtr)(object)value).ToInt64());
+                Set_(guidKey, unchecked((ulong)((IntPtr)(object)value).ToInt64()));
                 return;
             }
 

--- a/src/Vortice.MediaFoundation/IMFAttributes.cs
+++ b/src/Vortice.MediaFoundation/IMFAttributes.cs
@@ -194,37 +194,37 @@ namespace Vortice.MediaFoundation
             if (typeof(T) == typeof(int) || typeof(T) == typeof(bool) || typeof(T) == typeof(byte) || typeof(T) == typeof(uint) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort) || typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte)
                 || typeof(T).IsEnum)
             {
-                Set(guidKey, Convert.ToInt32(value));
+                Set_(guidKey, Convert.ToInt32(value));
                 return;
             }
 
             if (typeof(T) == typeof(long) || typeof(T) == typeof(ulong))
             {
-                Set(guidKey, Convert.ToInt64(value));
+                Set_(guidKey, Convert.ToInt64(value));
                 return;
             }
 
             if (typeof(T) == typeof(IntPtr))
             {
-                Set(guidKey, ((IntPtr)(object)value).ToInt64());
+                Set_(guidKey, ((IntPtr)(object)value).ToInt64());
                 return;
             }
 
             if (typeof(T) == typeof(Guid))
             {
-                Set(guidKey, (Guid)(object)value);
+                Set_(guidKey, (Guid)(object)value);
                 return;
             }
 
             if (typeof(T) == typeof(string))
             {
-                Set(guidKey, value.ToString());
+                Set_(guidKey, value.ToString());
                 return;
             }
 
             if (typeof(T) == typeof(double) || typeof(T) == typeof(float))
             {
-                Set(guidKey, Convert.ToDouble(value));
+                Set_(guidKey, Convert.ToDouble(value));
                 return;
             }
 
@@ -245,7 +245,7 @@ namespace Vortice.MediaFoundation
 
             if (typeof(T) == typeof(ComObject) || typeof(IUnknown).IsAssignableFrom(typeof(T)))
             {
-                Set(guidKey, ((IUnknown)(object)value));
+                Set_(guidKey, ((IUnknown)(object)value));
                 return;
             }
 

--- a/src/Vortice.MediaFoundation/IMFAttributes.cs
+++ b/src/Vortice.MediaFoundation/IMFAttributes.cs
@@ -191,10 +191,16 @@ namespace Vortice.MediaFoundation
             // ComObject
             // Guid
 
-            if (typeof(T) == typeof(int) || typeof(T) == typeof(bool) || typeof(T) == typeof(byte) || typeof(T) == typeof(uint) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort) || typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte)
+            if (typeof(T) == typeof(int) || typeof(T) == typeof(bool) || typeof(T) == typeof(byte) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort) || typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte)
                 || typeof(T).IsEnum)
             {
                 Set_(guidKey, Convert.ToInt32(value));
+                return;
+            }
+
+            if (value is uint uivalue)
+            {
+                Set_(guidKey, unchecked((int)uivalue));
                 return;
             }
 

--- a/src/Vortice.MediaFoundation/Mappings.xml
+++ b/src/Vortice.MediaFoundation/Mappings.xml
@@ -694,13 +694,13 @@
 
     <map method="IMFAttributes::GetUnknown" visibility="internal"/>
 
-    <map method="IMFAttributes::SetItem"    name="Set" visibility="internal" />
-    <map method="IMFAttributes::SetUINT32"  name="Set" visibility="internal" />
-    <map method="IMFAttributes::SetUINT64"  name="Set" visibility="internal" />
-    <map method="IMFAttributes::SetDouble"  name="Set" visibility="internal" />
-    <map method="IMFAttributes::SetGUID"    name="Set" visibility="internal" />
-    <map method="IMFAttributes::SetString"  name="Set" visibility="internal" />
-    <map method="IMFAttributes::SetUnknown" name="Set" visibility="internal" />
+    <map method="IMFAttributes::SetItem"    name="Set_" visibility="internal" />
+    <map method="IMFAttributes::SetUINT32"  name="Set_" visibility="internal" />
+    <map method="IMFAttributes::SetUINT64"  name="Set_" visibility="internal" />
+    <map method="IMFAttributes::SetDouble"  name="Set_" visibility="internal" />
+    <map method="IMFAttributes::SetGUID"    name="Set_" visibility="internal" />
+    <map method="IMFAttributes::SetString"  name="Set_" visibility="internal" />
+    <map method="IMFAttributes::SetUnknown" name="Set_" visibility="internal" />
 
     <map method="IMFAttributes::GetItemByIndex" visibility="internal"/>
     

--- a/src/Vortice.MediaFoundation/Mappings.xml
+++ b/src/Vortice.MediaFoundation/Mappings.xml
@@ -716,6 +716,9 @@
     <map method="IMFSourceResolver::CreateObjectFromByteStream" visibility="internal"/>
     <map param="IMFSourceResolver::CreateObjectFromByteStream::ppObject" attribute="out" type="void"/>
 
+    <!-- IMFSourceReader -->
+    <map param="IMFSourceReader::SetCurrentMediaType::pdwReserved" type="void" relation="const(System.IntPtr.Zero)"/>
+    
     <!-- IMFMediaEvent -->
     <map param="IMFMediaEvent::GetType::pmet" type="MEDIA_EVENT_TYPES"/>
 

--- a/src/Vortice.MediaFoundation/Mappings.xml
+++ b/src/Vortice.MediaFoundation/Mappings.xml
@@ -904,9 +904,12 @@
     <map function="MFCreateVideoSampleFromSurface" dll='"EVR.dll"' group="Vortice.MediaFoundation.MediaFactory" hresult="true" check="false" />
 
     <map function="MFCreateDXGIDeviceManager" visibility="internal" hresult="true" check="false" />
-
-
-
+    
+    <map function="MFCreateSinkWriterFromMediaSink" dll='"Mfreadwrite.dll"'/>
+    <map function="MFCreateSinkWriterFromURL" dll='"Mfreadwrite.dll"'/>
+    <map function="MFCreateSourceReaderFromByteStream" dll='"Mfreadwrite.dll"'/>
+    <map function="MFCreateSourceReaderFromMediaSource" dll='"Mfreadwrite.dll"'/>
+    <map function="MFCreateSourceReaderFromURL" dll='"Mfreadwrite.dll"'/>
 
     <!-- WASAPI -->
     <remove function="ActivateAudioInterfaceAsync"/>


### PR DESCRIPTION
I fixed some issues related to MediaFoundation.

### 1. [Add function mappings of mfreadwrite.h](https://github.com/amerkoleci/Vortice.Windows/commit/7b331be013f4757dea55b495f9766a406b6bcb00)
Fixed `EntryPointNotFoundException` due to incorrectly `dll` attribute

### 2. [Hidden reserved argument](https://github.com/amerkoleci/Vortice.Windows/commit/e3a02a07324ec6ab7ab16cf13e969a68b156f56e)
Hide reserved argument that requires passing `IntPtr.Zero`.

### 3. [Fix infinite recursive loop (StackOverflowException)](https://github.com/amerkoleci/Vortice.Windows/commit/cf0f076c6037ed670306a9ac6ab74d8bface2b09)
`internal void Set(...)` was not being called due to duplicate names, resulting in infinite recursion.
Renamed `internal void Set(...)` to `internal void Set_(...)`.

### 4. [Fix overload issue of Set<long>(...)](https://github.com/amerkoleci/Vortice.Windows/commit/eaaae6477b7a368246c39185c6048aba917b08b3)
Due to an overload problem, `Set<long>(value)` was being passed to `internal Set_(double value)`.
long value is now cast to ulong.

### 5. [Fix OverflowException with uint](https://github.com/amerkoleci/Vortice.Windows/commit/b3d16150fa744852fa06a4f7c9c80171fb194d7a)
Fixed potential OverflowException.
Such as: `Convert.ToInt32(uint.MaxValue)`
