### PR TITLE
Fix IMFTransform.ProcessOutput()

### DIFF
--- a/src/Vortice.MediaFoundation/Mappings.xml
+++ b/src/Vortice.MediaFoundation/Mappings.xml
@@ -742,7 +742,13 @@
     <map method="IMFDXGIDeviceManager::UnlockDevice" visibility="internal" />
 
     <map interface="IMMNotificationClient" callback="true" callback-dual="true" callback-visibility="public" autogen-shadow="true" />
-
+    
+    <!-- IMFTransform -->
+    <map param="IMFTransform::ProcessOutput::dwFlags" type="_MFT_PROCESS_OUTPUT_FLAGS"/>
+    <map param="IMFTransform::ProcessOutput::pdwStatus" type="_MFT_PROCESS_OUTPUT_STATUS" attribute="out"/>
+    <map param="IMFTransform::ProcessOutput::pOutputSamples" attribute="inout"/>
+    <map method="IMFTransform::ProcessOutput" check="false" return="true"/>
+    
     <!-- Functions -->
     <remove function="IMF.*"/>
     <map function="MF.*" dll='"Mfplat.dll"' group="Vortice.MediaFoundation.MediaFactory" />


### PR DESCRIPTION
I fixed some IMFTransform.ProcessOutput() issues.

---
```xml
<map param="IMFTransform::ProcessOutput::dwFlags" type="_MFT_PROCESS_OUTPUT_FLAGS"/>
<map param="IMFTransform::ProcessOutput::pdwStatus" type="_MFT_PROCESS_OUTPUT_STATUS" attribute="out"/>
```
Type specified to `dwFlags` and `pdwStatus`.
Added `out` attribute to `pdwStatus` to make the return value available.

---
```xml
<map param="IMFTransform::ProcessOutput::pOutputSamples" attribute="inout"/>
```
Added `inout` attribute to `pOutputSamples` to get IMFSample allocated in IMFTransform.
Example
```C#
var buffer = new TOutputDataBuffer();
var info = mft.GetOutputStreamInfo(0);
var flags = (OutputStreamInfoFlags)info.Flags;
if (flags.HasFlag(OutputStreamInfoFlags.OutputStreamProvidesSamples))
{
    var res = mft.ProcessOutput(ProcessOutputFlags.None, 1, ref buffer, out _);
    var sample = buffer.Sample;//IMFSample allocated in IMFTransform.
}
```
---
```xml
<map method="IMFTransform::ProcessOutput" check="false" return="true"/>
```
Error checking is now disabled and exceptions can be handled outside of `ProcessOutput`.
This change reduces the amount of error messages displayed in the debug console, and prevents performance degradation due to many error messages during debugging.

Example
```C#
while(true)
{
    var res = mft.ProcessOutput(ProcessOutputFlags.None, 1, ref buffer, out _);
    if (res.Success)
        return buffer.Sample;
    else if(res.Code == MF_E_TRANSFORM_NEED_MORE_INPUT)
    {
        //Send more samples to IMFTransform
    }
    else
        throw new SharpGenException(res);
}
```
