### PR TITLE
DirectML: mostly usable documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ There is a collection of samples available only for **Sponsors** [Vortice.Window
 Library development, contributions and bugfixes by:
 
 - Amer Koleci
+- Aaron Sun (DirectML)
 
 [SharpDX](https://github.com/sharpdx/SharpDX) bindings were used for some platforms to understand how mapping works using SharpGenTools.
 

--- a/src/Vortice.DirectML/ActivationCeluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationCeluOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_CELU_OPERATOR_DESC']/*" />
 public partial struct ActivationCeluOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationEluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationEluOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_ELU_OPERATOR_DESC']/*" />
 public partial struct ActivationEluOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationHardSigmoidOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationHardSigmoidOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC']/*" />
 public partial struct ActivationHardSigmoidOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationHardmaxOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationHardmaxOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_HARDMAX_OPERATOR_DESC']/*" />
 public partial struct ActivationHardmaxOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationIdentityOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationIdentityOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_IDENTITY_OPERATOR_DESC']/*" />
 public partial struct ActivationIdentityOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationLeakyReluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationLeakyReluOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC']/*" />
 public partial struct ActivationLeakyReluOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationLinearOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationLinearOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_LINEAR_OPERATOR_DESC']/*" />
 public partial struct ActivationLinearOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationLogSoftmaxOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationLogSoftmaxOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_LOG_SOFTMAX_OPERATOR_DESC']/*" />
 public partial struct ActivationLogSoftmaxOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationParameterizedReluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationParameterizedReluOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_PARAMETERIZED_RELU_OPERATOR_DESC']/*" />
 public partial struct ActivationParameterizedReluOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationParametricSoftplusOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationParametricSoftplusOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC']/*" />
 public partial struct ActivationParametricSoftplusOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationReluGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationReluGradOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC']/*" />
 public partial struct ActivationReluGradOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationReluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationReluOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_RELU_OPERATOR_DESC']/*" />
 public partial struct ActivationReluOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationScaledEluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationScaledEluOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC']/*" />
 public partial struct ActivationScaledEluOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationScaledTanhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationScaledTanhOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC']/*" />
 public partial struct ActivationScaledTanhOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationShrinkOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationShrinkOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SHRINK_OPERATOR_DESC']/*" />
 public partial struct ActivationShrinkOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationSigmoidOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationSigmoidOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SIGMOID_OPERATOR_DESC']/*" />
 public partial struct ActivationSigmoidOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationSoftmaxOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationSoftmaxOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SOFTMAX_OPERATOR_DESC']/*" />
 public partial struct ActivationSoftmaxOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationSoftplusOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationSoftplusOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC']/*" />
 public partial struct ActivationSoftplusOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationSoftsignOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationSoftsignOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC']/*" />
 public partial struct ActivationSoftsignOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationTanhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationTanhOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_TANH_OPERATOR_DESC']/*" />
 public partial struct ActivationTanhOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ActivationThresholdedReluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationThresholdedReluOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC']/*" />
 public partial struct ActivationThresholdedReluOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/AdamOptimizerOperatorDescription.cs
+++ b/src/Vortice.DirectML/AdamOptimizerOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ADAM_OPTIMIZER_OPERATOR_DESC']/*" />
 public partial struct AdamOptimizerOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ArgmaxOperatorDescription.cs
+++ b/src/Vortice.DirectML/ArgmaxOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ARGMAX_OPERATOR_DESC']/*" />
 public partial struct ArgmaxOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ArgminOperatorDescription.cs
+++ b/src/Vortice.DirectML/ArgminOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ARGMIN_OPERATOR_DESC']/*" />
 public partial struct ArgminOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/AveragePoolingGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/AveragePoolingGradOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC']/*" />
 public partial struct AveragePoolingGradOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/AveragePoolingOperatorDescription.cs
+++ b/src/Vortice.DirectML/AveragePoolingOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_AVERAGE_POOLING_OPERATOR_DESC']/*" />
 public partial struct AveragePoolingOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/BatchNormalizationGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/BatchNormalizationGradOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_BATCH_NORMALIZATION_GRAD_OPERATOR_DESC']/*" />
 public partial struct BatchNormalizationGradOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/BatchNormalizationOperatorDescription.cs
+++ b/src/Vortice.DirectML/BatchNormalizationOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_BATCH_NORMALIZATION_OPERATOR_DESC']/*" />
 public partial struct BatchNormalizationOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/CastOperatorDescription.cs
+++ b/src/Vortice.DirectML/CastOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_CAST_OPERATOR_DESC']/*" />
 public partial struct CastOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ConvolutionIntegerOperatorDescription.cs
+++ b/src/Vortice.DirectML/ConvolutionIntegerOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_CONVOLUTION_INTEGER_OPERATOR_DESC']/*" />
 public partial struct ConvolutionIntegerOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ConvolutionOperatorDescription.cs
+++ b/src/Vortice.DirectML/ConvolutionOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_CONVOLUTION_OPERATOR_DESC']/*" />
 public partial struct ConvolutionOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/CumulativeProductOperatorDescription.cs
+++ b/src/Vortice.DirectML/CumulativeProductOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_CUMULATIVE_PRODUCT_OPERATOR_DESC']/*" />
 public partial struct CumulativeProductOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/CumulativeSummationOperatorDescription.cs
+++ b/src/Vortice.DirectML/CumulativeSummationOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_CUMULATIVE_SUMMATION_OPERATOR_DESC']/*" />
 public partial struct CumulativeSummationOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/DepthToSpace1OperatorDescription.cs
+++ b/src/Vortice.DirectML/DepthToSpace1OperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_DEPTH_TO_SPACE1_OPERATOR_DESC']/*" />
 public partial struct DepthToSpace1OperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/DepthToSpaceOperatorDescription.cs
+++ b/src/Vortice.DirectML/DepthToSpaceOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_DEPTH_TO_SPACE_OPERATOR_DESC']/*" />
 public partial struct DepthToSpaceOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/DiagonalMatrixOperatorDescription.cs
+++ b/src/Vortice.DirectML/DiagonalMatrixOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_DIAGONAL_MATRIX_OPERATOR_DESC']/*" />
 public partial struct DiagonalMatrixOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/Documentation.xml
+++ b/src/Vortice.DirectML/Documentation.xml
@@ -1,3 +1,4518 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <comments>
+  <comment id="DML_ELEMENT_WISE_CEIL_OPERATOR_DESC">
+    <summary>
+      <para>Computes the ceiling for each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>. The ceiling of x is the smallest integer that is greater than or equal to x.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_ceil_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CEIL_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CEIL_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CEIL_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_GRAD_OPERATOR_DESC">
+    <summary>
+      <para>Computes backpropagation gradients for max pooling (see <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling2_operator_desc">DML_MAX_POOLING2_OPERATOR_DESC</a>).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_max_pooling_grad_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_GRAD_OPERATOR_DESC::InputTensor">
+    <summary>The input feature tensor. This is typically the same tensor that was provided as the <i>InputTensor</i> to <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling2_operator_desc">DML_MAX_POOLING2_OPERATOR_DESC</a> in the forward pass.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_GRAD_OPERATOR_DESC::InputGradientTensor">
+    <summary>The incoming gradient tensor. This is typically obtained from the output of backpropagation of a preceding layer. Typically this tensor would have the same sizes as the <i>output</i> of the corresponding <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling2_operator_desc">DML_MAX_POOLING2_OPERATOR_DESC</a> in the forward pass.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_GRAD_OPERATOR_DESC::OutputGradientTensor">
+    <summary>An output tensor containing the backpropagated gradients. Typically this tensor would have the same sizes as the <i>input</i> of the corresponding <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling2_operator_desc">DML_MAX_POOLING2_OPERATOR_DESC</a> in the forward pass.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_GRAD_OPERATOR_DESC::DimensionCount">
+    <summary>The number of elements in the <i>Strides</i>, <i>WindowSize</i>, <i>StartPadding</i>, <i>EndPadding</i>, and <i>Dilations</i> arrays. This value must equal the spatial dimension count (InputTensor's DimensionCount - 2). As this operator only supports 4D tensors, the only valid value for this parameter is 2.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_GRAD_OPERATOR_DESC::Strides">
+    <summary>See <i>Strides</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling2_operator_desc">DML_MAX_POOLING2_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_GRAD_OPERATOR_DESC::WindowSize">
+    <summary>See <i>WindowSize</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling2_operator_desc">DML_MAX_POOLING2_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_GRAD_OPERATOR_DESC::StartPadding">
+    <summary>See <i>StartPadding</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling2_operator_desc">DML_MAX_POOLING2_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_GRAD_OPERATOR_DESC::EndPadding">
+    <summary>See <i>EndPadding</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling2_operator_desc">DML_MAX_POOLING2_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_GRAD_OPERATOR_DESC::Dilations">
+    <summary>See <i>Dilations</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling2_operator_desc">DML_MAX_POOLING2_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_BUFFER_TENSOR_DESC">
+    <summary>
+      <para>Describes a tensor that will be stored in a Direct3D 12 buffer resource.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_buffer_tensor_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_BUFFER_TENSOR_DESC::DataType">
+    <summary>The type of the values in the tensor.</summary>
+  </comment>
+  <comment id="DML_BUFFER_TENSOR_DESC::Flags">
+    <summary>Specifies additional options for the tensor.</summary>
+  </comment>
+  <comment id="DML_BUFFER_TENSOR_DESC::DimensionCount">
+    <summary>The number of dimensions of the tensor. This member determines the size of the <i>Sizes</i> and <i>Strides</i> arrays (if provided). In DirectML, all buffer tensors must have a <i>DimensionCount</i> of either 4 or 5. Not all operators support a <i>DimensionCount</i> of 5.</summary>
+  </comment>
+  <comment id="DML_BUFFER_TENSOR_DESC::Sizes">
+    <summary>The size, in elements, of each dimension in the tensor. Specifying a size of zero in any dimension is invalid, and will result in an error. The <i>Sizes</i> member is always specified in the order {N, C, H, W} if <i>DimensionCount</i> is 4, and {N, C, D, H, W} if <i>DimensionCount</i> is 5.</summary>
+  </comment>
+  <comment id="DML_BUFFER_TENSOR_DESC::Strides">
+    <summary>Optional. Determines the number of elements (not bytes) to linearly traverse in order to reach the next element in that dimension. For example, a stride of 5 in dimension 1 means that the distance between elements (n) and (n+1) in that dimension is 5 elements when traversing the buffer linearly. The <i>Strides</i> member is always specified in the order {N, C, H, W} if <i>DimensionCount</i> is 4, and {N, C, D, H, W} if <i>DimensionCount</i> is 5.
+
+<i>Strides</i> can be used to express broadcasting (by specifying a stride of 0) as well as padding (for example, by using a stride larger than the physical size of a row, to pad the end of a row).
+
+If <i>Strides</i> is not specified, each dimension in the tensor is considered to be contiguously packed, with no additional padding.</summary>
+  </comment>
+  <comment id="DML_BUFFER_TENSOR_DESC::TotalTensorSizeInBytes">
+    <summary>Defines a minimum size in bytes for the buffer that will contain this tensor. <i>TotalTensorSizeInBytes</i> must be at least as large as the minimum implied size given the sizes, strides, and data type of the tensor. You can calculate the minimum implied size by calling the <a href="https://docs.microsoft.com/windows/desktop/direct3d12/dml-helper-functions#dmlcalcbuffertensorsize">DMLCalcBufferTensorSize</a> utility free function.
+
+Providing a <i>TotalTensorSizeInBytes</i> that is larger than the minimum implied size may enable additional optimizations by allowing DirectML to elide bounds checking in some cases if the <i>TotalTensorSizeInBytes</i> defines sufficient padding beyond the end of the tensor data.
+
+When binding this tensor, the size of the buffer range must be at least as large as the <i>TotalTensorSizeInBytes</i>. For output tensors, this has the additional effect of permitting DirectML to write to any memory within the <i>TotalTensorSizeInBytes</i>. That is, your application mustn't assume that DirectML will preserve any padding bytes inside output tensors that are inside the <i>TotalTensorSizeInBytes</i>.
+
+The total size of a buffer tensor may not exceed (2^32 - 1) elements—for example, 16GB for a <b>FLOAT32</b> tensor.</summary>
+  </comment>
+  <comment id="DML_BUFFER_TENSOR_DESC::GuaranteedBaseOffsetAlignment">
+    <summary>Optional. Defines a minimum guaranteed alignment in bytes for the base offset of the buffer range that will contain this tensor, or 0 to provide no minimum guaranteed alignment. If specified, this value must be a power of two that is at least as large as the element size.
+
+When binding this tensor, the offset in bytes of the buffer range from the start of the buffer must be a multiple of the <i>GuaranteedBaseOffsetAlignment</i>, if provided.
+
+Buffer tensors always have a minimum alignment of 16 bytes. However, providing a larger value for the <i>GuaranteedBaseOffsetAlignment</i> may allow DirectML to achieve better performance, because a larger alignment enables the use of vectorized load/store instructions.
+
+Although this member is optional, for best performance we recommend that you align tensors to boundaries of 32 bytes or more, where possible.</summary>
+  </comment>
+  <comment id="IDMLCompiledOperator">
+    <summary>
+      <para>Represents a compiled, efficient form of an operator suitable for execution on the GPU. To create this object, call IDMLDevice::CompileOperator.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nn-directml-idmlcompiledoperator" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SIZE_2D">
+    <summary>
+      <para>Contains values that can represent the size (as supplied to a DirectML operator) of a 2-D plane of elements within a tensor, or a 2-D scale, or any 2-D width/height value.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_size_2d" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SIZE_2D::Width">
+    <summary>The width.</summary>
+  </comment>
+  <comment id="DML_SIZE_2D::Height">
+    <summary>The height.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ASIN_OPERATOR_DESC">
+    <summary>
+      <para>Computes the arcsine for each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_asin_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ASIN_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ASIN_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ASIN_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_ELU_OPERATOR_DESC">
+    <summary>
+      <para>Performs an exponential linear unit (ELU) activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_elu_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_ELU_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_ELU_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_ELU_OPERATOR_DESC::Alpha">
+    <summary>The alpha coefficient. A typical default for this value is 1.0.</summary>
+  </comment>
+  <comment id="IDMLBindingTable::BindTemporaryResource">
+    <summary>
+      <para>Binds a buffer to use as temporary scratch memory. You can determine the required size of this buffer range by calling IDMLDispatchable::GetBindingProperties.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmlbindingtable-bindtemporaryresource" /></para>
+      <param name="binding">An optional pointer to a <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_binding_desc">DML_BINDING_DESC</a> containing the description of a tensor resource to bind.</param>
+    </summary>
+  </comment>
+  <comment id="DML_UPSAMPLE_2D_OPERATOR_DESC">
+    <summary>
+      <para>Upsamples the input image, writing the result into the output tensor. The order of the dimensions should be NCHW (BatchSize, ChannelCount, Height, Width) or NCDHW (BatchSize, ChannelCount, Depth, Height, Width), but strides can be used if the data is stored in a different format.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_upsample_2d_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_UPSAMPLE_2D_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the input data. The expected dimensions of the InputTensor are <c>{ InputBatchCount, InputChannelCount, InputHeight, InputWidth }</c> for 4D, and <c>{ InputBatchCount, InputChannelCount, InputDepth, InputHeight, InputWidth }</c> for 5D.</summary>
+  </comment>
+  <comment id="DML_UPSAMPLE_2D_OPERATOR_DESC::OutputTensor">
+    <summary>A tensor containing the input data. The expected dimensions of the OutputTensor are <c>{ InputBatchCount, InputChannelCount, InputHeight * HeightScale, InputWidth * WidthScale }</c> for 4D, and <c>{ InputBatchCount, InputChannelCount, InputDepth, InputHeight * HeightScale, InputWidth * WidthScale }</c> for 5D.</summary>
+  </comment>
+  <comment id="DML_UPSAMPLE_2D_OPERATOR_DESC::ScaleSize">
+    <summary>The width and height scales of type UINT to apply when upsampling the input. <c>0 &lt; ScaleSize.Height &lt;= UINT_MAX / InputHeight</c> and <c>0 &lt; ScaleSize.Width &lt;= UINT_MAX / InputWidth</c>.</summary>
+  </comment>
+  <comment id="DML_UPSAMPLE_2D_OPERATOR_DESC::InterpolationMode">
+    <summary>This field determines the kind of interpolation used to choose output pixels.
+
+- <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_interpolation_mode">DML_INTERPOLATION_MODE_NEAREST_NEIGHBOR</a>. Uses the <i>Nearest Neighbor</i> algorithm, which chooses the input element nearest to the corresponding pixel center for each output element.
+- <b>DML_INTERPOLATION_MODE_LINEAR</b>. Uses the <i>Bilinear</i> algorithm, which computes the output element by doing the weighted average of the 2 nearest neighboring input elements in the height dimension, and the 2 nearest neighboring input elements in the width dimension, for a total of 4 elements. This is true even if the input/output DimensionCount is 5. That is, samples are only ever averaged along the width and height dimensions, and never along the batch, channel, or depth.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ADD_OPERATOR_DESC">
+    <summary>
+      <para>Adds every element in <i>ATensor</i> to its corresponding element in <i>BTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_add_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ADD_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ADD_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ADD_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="IDMLObject::SetPrivateDataInterface">
+    <summary>
+      <para>Associates an IUnknown-derived interface with the DirectML device object, and associates that interface with an application-defined GUID.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmlobject-setprivatedatainterface" /></para>
+      <param name="guid">The <b>GUID</b> to associate with the interface.</param>
+      <param name="data">A pointer to the <a href="https://docs.microsoft.com/windows/win32/api/unknwn/nn-unknwn-iunknown">IUnknown</a>-derived interface to be associated with the device object.</param>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC">
+    <summary>
+      <para>Performs a parametric softplus activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_softplus_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC::OutputTensor">
+    <summary>The <b>Steepness</b> coefficient. A typical default for this value is 1.0. This value cannot be less than 1.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC::Steepness">
+    <summary>The steepness value.</summary>
+  </comment>
+  <comment id="DML_INTERMEDIATE_GRAPH_EDGE_DESC">
+    <summary>
+      <para>Describes a connection within a graph of DirectML operators defined by <a href="https://docs.microsoft.com/windows/desktop/api/directml/ns-directml-dml_graph_desc">DML_GRAPH_DESC</a> and passed to [IDMLDevice1::CompileGraph](/windows/desktop/api/directml/nf-directml-idmldevice1-compilegraph). This structure is used to define a connection between internal nodes.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_intermediate_graph_edge_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_INTERMEDIATE_GRAPH_EDGE_DESC::FromNodeIndex">
+    <summary>The index of the graph node from which a connection to another node is specified.</summary>
+  </comment>
+  <comment id="DML_INTERMEDIATE_GRAPH_EDGE_DESC::FromNodeOutputIndex">
+    <summary>The index of the output on the node at index <i>FromNodeIndex</i> where the connection is specified.</summary>
+  </comment>
+  <comment id="DML_INTERMEDIATE_GRAPH_EDGE_DESC::ToNodeIndex">
+    <summary>The index of the graph node into which a connection from another node is specified.</summary>
+  </comment>
+  <comment id="DML_INTERMEDIATE_GRAPH_EDGE_DESC::ToNodeInputIndex">
+    <summary>The index of the input on the node at index <i>ToNodeIndex</i> where the connection is specified.</summary>
+  </comment>
+  <comment id="DML_INTERMEDIATE_GRAPH_EDGE_DESC::Name">
+    <summary>An optional name for the graph connection. If provided, this might be used within certain error messages emitted by the DirectML debug layer.</summary>
+  </comment>
+  <comment id="DML_SPLIT_OPERATOR_DESC">
+    <summary>
+      <para>Splits an input tensor along an axis into multiple output tensors.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_split_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SPLIT_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to split into multiple output tensors.</summary>
+  </comment>
+  <comment id="DML_SPLIT_OPERATOR_DESC::OutputCount">
+    <summary>This field determines the size of the <i>OutputTensors</i> array. This value must be greater than 0.</summary>
+  </comment>
+  <comment id="DML_SPLIT_OPERATOR_DESC::OutputTensors">
+    <summary>An array containing the descriptions of the tensors split off from the input tensor. The output sizes must have the same sizes as the input tensor except for the split axis.</summary>
+  </comment>
+  <comment id="DML_SPLIT_OPERATOR_DESC::Axis">
+    <summary>The index of the dimension of the input tensor to split. All input and output tensors must have identical sizes in all dimensions except for this axis. This value must be in the range <c>[0, InputTensor.DimensionCount - 1]</c>.</summary>
+  </comment>
+  <comment id="DML_RANDOM_GENERATOR_OPERATOR_DESC">
+    <summary>
+      <para>Fills an output tensor with deterministically-generated, pseudo-random, uniformly-distributed bits. This operator optionally may also output an updated internal generator state, which can be used during subsequent executions of the operator.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_random_generator_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_RANDOM_GENERATOR_OPERATOR_DESC::InputStateTensor">
+    <summary>An input tensor containing the internal generator state. The size and format of this input tensor depends on the <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_random_generator_type">DML_RANDOM_GENERATOR_TYPE</a>.
+
+For <b>DML_RANDOM_GENERATOR_TYPE_PHILOX_4X32_10</b>, this tensor must be of type <b>UINT32</b>, and have sizes <c>{1,1,1,6}</c>. The first four 32-bit values contain a monotonically increasing 128-bit counter. The last two 32-bit values contain the 64-bit key value for the generator.
+
+<code>
+    Element        0       1       2       3       4       5
+(32-bits each) |-------|-------|-------|-------|-------|-------|
+                &lt;--------128-bit counter------&gt; &lt;-64-bit key--&gt;
+</code>
+
+When initializing the generator's input state for the first time, typically the 128-bit counter (the first four 32-bit UINT32 values) should be initialized to 0. The key can be arbitrarily chosen; different key values will produce different sequences of numbers. The value for the key is usually generated using a user-provided <i>seed</i>.</summary>
+  </comment>
+  <comment id="DML_RANDOM_GENERATOR_OPERATOR_DESC::OutputTensor">
+    <summary>An output tensor which holds the resulting pseudo-random values. This tensor can be of any size.</summary>
+  </comment>
+  <comment id="DML_RANDOM_GENERATOR_OPERATOR_DESC::OutputStateTensor">
+    <summary>An optional output tensor THAT holds the updated internal generator state. If supplied, this operator uses the <i>InputStateTensor</i> to compute an appropriate updated generator state, and writes the result into the <i>OutputStateTensor</i>. Typically, callers would save this result and supply it as the input state on a subsequent execution of this operator.</summary>
+  </comment>
+  <comment id="DML_RANDOM_GENERATOR_OPERATOR_DESC::Type">
+    <summary>One of the values from the <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_random_generator_type">DML_RANDOM_GENERATOR_TYPE</a> enum, indicating the type of generator to use. Currently the only valid value is <b>DML_RANDOM_GENERATOR_TYPE_PHILOX_4X32_10</b>, which generates pseudo-random numbers according to the [Philox 4x32-10 algorithm](http://www.thesalmons.org/john/random123/papers/random123sc11.pdf).</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_DESC">
+    <summary>
+      <para>Computes the C modulus operator for each pair of corresponding elements of the input tensors, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_modulus_truncate_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_RANDOM_GENERATOR_TYPE">
+    <summary>
+      <para>Defines constants that specify types of random random-number generator.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_random_generator_type" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_RANDOM_GENERATOR_TYPE::DML_RANDOM_GENERATOR_TYPE_PHILOX_4X32_10">
+    <summary>Specifies a generator for pseudo-random numbers according to the [Philox 4x32-10 algorithm](http://www.thesalmons.org/john/random123/papers/random123sc11.pdf).</summary>
+  </comment>
+  <comment id="IDMLOperatorInitializer::Reset">
+    <summary>
+      <para>Resets the initializer to handle initialization of a new set of operators.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmloperatorinitializer-reset" /></para>
+      <param name="operatorCount">This parameter determines the number of elements in the array passed in the  <i>operators</i> parameter.</param>
+      <param name="operators">An optional pointer to a constant array of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlcompiledoperator">IDMLCompiledOperator</a> pointers containing the operators that the initializer should initialize.</param>
+    </summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC">
+    <summary>
+      <para>Performs a (standard layers) one-layer gated recurrent unit (GRU) function on the input. This operator uses multiple gates to perform this layer. These gates are performed multiple times in a loop dictated by the sequence length dimension and the <i>SequenceLengthsTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_gru_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the input data, X. Packed (and potentially padded) into one 4D tensor with the <i>Sizes</i> of <c>{ 1, seq_length, batch_size, input_size }</c>. seq_length is the dimension that is mapped to the index, t.</summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC::WeightTensor">
+    <summary>A tensor containing the weight data, W. Concatenation of W_[zrh] and W_B[zrh] (if bidirectional). The tensor has <i>Sizes</i> <c>{ 1, num_directions, 3 * hidden_size, input_size }</c>.</summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC::RecurrenceTensor">
+    <summary>A tensor containing the recurrence data, R. Concatenation of R_[zrh] and R_B[zrh] (if bidirectional). The tensor has <i>Sizes</i> <c>{ 1, num_directions, 3 * hidden_size, hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC::BiasTensor">
+    <summary>An optional tensor containing the bias data, B. Concatenation of (W_b[zrh], R_b[zrh]) and (W_Bb[zrh], R_Bb[zrh]) (if bidirectional). The tensor has <i>Sizes</i> <c>{ 1, 1, num_directions, 6 * hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC::HiddenInitTensor">
+    <summary>An optional tensor containing the hidden node initializer tensor, H_t-1 for the first loop index t. If not specified, then defaults to 0. This tensor has <i>Sizes</i> <c>{ 1, num_directions, batch_size, hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC::SequenceLengthsTensor">
+    <summary>An optional tensor containing an independent seq_length for each element in the batch. If not specified, then all sequences in the batch have length seq_length. This tensor has <i>Sizes</i> <c>{ 1, 1, 1, batch_size }</c>.</summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC::OutputSequenceTensor">
+    <summary>An optional tensor with which to write the concatenation of all the intermediate output values of the hidden nodes, H_t. This tensor has <i>Sizes</i> <c>{ seq_length, num_directions, batch_size, hidden_size }</c>. seq_length is mapped to the loop index t.</summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC::OutputSingleTensor">
+    <summary>An optional tensor with which to write the last output value of the hidden nodes, H_t. This tensor has <i>Sizes</i> <c>{ 1, num_directions, batch_size, hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC::ActivationDescCount">
+    <summary>This field determines the size of the <i>ActivationDescs</i> array.</summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC::ActivationDescs">
+    <summary>An array of <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_operator_desc">DML_OPERATOR_DESC</a> containing the descriptions of the activation operators, f() and g(). Both f() and g() are defined independently of direction, meaning that if <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_recurrent_network_direction">DML_RECURRENT_NETWORK_DIRECTION_FORWARD</a> or <b>DML_RECURRENT_NETWORK_DIRECTION_BACKWARD</b> are supplied in <i>Direction</i>, then two activations must be provided. If <b>DML_RECURRENT_NETWORK_DIRECTION_BIDIRECTIONAL</b> is supplied, then four activations must be provided. For bidirectional, activations must be provided f() and g() for forward followed by f() and g() for backwards.</summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC::Direction">
+    <summary>The direction of the operator—forward, backwards, or bidirectional.</summary>
+  </comment>
+  <comment id="DML_GRU_OPERATOR_DESC::LinearBeforeReset">
+    <summary><b>TRUE</b> to specify that, when computing the output of the hidden gate, the linear transformation should be applied before multiplying by the output of the reset gate. Otherwise, <b>FALSE</b>.</summary>
+  </comment>
+  <comment id="IDMLDeviceChild">
+    <summary>
+      <para>An interface implemented by all objects created from the DirectML device.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nn-directml-idmldevicechild" /></para>
+    </summary>
+  </comment>
+  <comment id="IDMLObject::GetPrivateData">
+    <summary>
+      <para>Gets application-defined data from a DirectML device object.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmlobject-getprivatedata" /></para>
+      <param name="guid">The <b>GUID</b> that is associated with the data.</param>
+      <param name="dataSize">A pointer to a variable that on input contains the size, in bytes, of the buffer that <i>data</i> points to, and on output contains the size, in bytes, of the amount of data that <b>GetPrivateData</b> retrieved.</param>
+      <param name="data">A pointer to a memory block that receives the data from the device object if <i>dataSize</i> points to a value that specifies a buffer large enough to hold the data.</param>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_AND_OPERATOR_DESC">
+    <summary>
+      <para>Performs a logical AND on each pair of corresponding elements of the input tensors, placing the result (1 for true, 0 for false) into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_logical_and_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_AND_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_AND_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_AND_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL_OPERATOR_DESC">
+    <summary>
+      <para>Performs a logical <i>greater than or equal to</i> on each pair of corresponding elements of the input tensors, placing the result (1 for true, 0 for false) into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_logical_greater_than_or_equal_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC">
+    <summary>
+      <para>Performs the following linear quantization function on every element in <i>InputTensor</i> with respect to its corresponding element in <i>ScaleTensor</i> and <c>ZeroPointTensor</c>, placing the results in the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_quantize_linear_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC::InputTensor">
+    <summary>The tensor containing the inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC::ScaleTensor">
+    <summary>The tensor containing the scales.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC::ZeroPointTensor">
+    <summary>The tensor containing the desired zero point for the quantization.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_TOP_K1_OPERATOR_DESC">
+    <summary>
+      <para>Selects the largest or smallest <i>K</i> elements from each sequence along an axis of the <i>InputTensor</i>, and returns the values and indices of those elements in the <i>OutputValueTensor</i> and <i>OutputIndexTensor</i>, respectively.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_top_k1_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_TOP_K1_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor containing elements to select.</summary>
+  </comment>
+  <comment id="DML_TOP_K1_OPERATOR_DESC::OutputValueTensor">
+    <summary>The output tensor to write the values of the top <i>K</i> elements to. The top <i>K</i> elements are selected based on whether they are the largest or the smallest, depending on the value of <i>AxisDirection</i>. This tensor must have sizes equal to the <i>InputTensor</i>, <i>except</i> for the dimension specified by the <i>Axis</i> parameter, which must have a size equal to <i>K</i>.
+
+The <i>K</i> values selected from each input sequence are guaranteed to be sorted descending (largest to smallest) if <i>AxisDirection</i> is <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_axis_direction">DML_AXIS_DIRECTION_DECREASING</a>. Otherwise, the opposite is true and the values selected are guaranteed to be sorted ascending (smallest to largest).</summary>
+  </comment>
+  <comment id="DML_TOP_K1_OPERATOR_DESC::OutputIndexTensor">
+    <summary>The output tensor to write the indices of the top <i>K</i> elements to. This tensor must have sizes equal to the <i>InputTensor</i>, <i>except</i> for the dimension specified by the <i>Axis</i> parameter, which must have a size equal to <i>K</i>.
+
+The indices returned in this tensor are measured relative to the beginning of their sequence (as opposed to the beginning of the tensor). For example, an index of 0 always refers to the first element for all sequences in an axis.
+
+In cases where two or more elements in the top-K have the same value (that is, when there is a tie), the indices of both elements are included, and are guaranteed to be ordered by ascending element index. Note that this is true irrespective of the value of <i>AxisDirection</i>.</summary>
+  </comment>
+  <comment id="DML_TOP_K1_OPERATOR_DESC::Axis">
+    <summary>The index of the dimension to select elements across. This value must be less than the <i>DimensionCount</i> of the <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_TOP_K1_OPERATOR_DESC::K">
+    <summary>The number of elements to select. <i>K</i> must be greater than 0, but less than the number of elements in the <i>InputTensor</i> along the dimension specified by <i>Axis</i>.</summary>
+  </comment>
+  <comment id="DML_TOP_K1_OPERATOR_DESC::AxisDirection">
+    <summary>A value from the <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_axis_direction">DML_AXIS_DIRECTION</a> enumeration. If set to <b>DML_AXIS_DIRECTION_INCREASING</b>, then this operator returns the <i>smallest</i> <i>K</i> elements in order of increasing value. Otherwise, it returns the <i>largest</i> <i>K</i> elements in decreasing order.</summary>
+  </comment>
+  <comment id="IDMLBindingTable::Reset">
+    <summary>
+      <para>Resets the binding table to wrap a new range of descriptors, potentially for a different operator or initializer. This allows dynamic reuse of the binding table.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmlbindingtable-reset" /></para>
+      <param name="desc">An optional pointer to a <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_binding_table_desc">DML_BINDING_TABLE_DESC</a> containing the binding table parameters. This may be <b>nullptr</b>, indicating an empty binding table.</param>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ATANH_OPERATOR_DESC">
+    <summary>
+      <para>Computes the hyperbolic arctangent for each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_atanh_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ATANH_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ATANH_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ATANH_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL_OPERATOR_DESC">
+    <summary>
+      <para>Performs a logical <i>less than or equal to</i> on each pair of corresponding elements of the input tensors, placing the result (1 for true, 0 for false) into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_logical_less_than_or_equal_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="IDMLDevice::CreateOperator">
+    <summary>
+      <para>Creates a DirectML operator.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldevice-createoperator" /></para>
+      <param name="desc">The description of the operator to be created.</param>
+      <param name="riid">A reference to the globally unique identifier (GUID) of the interface that you wish to be returned in <i>ppv</i>. This is expected to be the GUID of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmloperator">IDMLOperator</a>.</param>
+      <param name="ppv">A pointer to a memory block that receives a pointer to the operator. This is the address of a pointer to an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmloperator">IDMLOperator</a>, representing  the operator created.</param>
+    </summary>
+  </comment>
+  <comment id="IDMLDevice1">
+    <summary>
+      <para>Represents a DirectML device, which is used to create operators, binding tables, command recorders, and other objects.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nn-directml-idmldevice1" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_NONZERO_COORDINATES_OPERATOR_DESC">
+    <summary>
+      <para>Computes the N-dimensional coordinates of all non-zero elements of the input tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_nonzero_coordinates_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_NONZERO_COORDINATES_OPERATOR_DESC::InputTensor">
+    <summary>An input tensor.</summary>
+  </comment>
+  <comment id="DML_NONZERO_COORDINATES_OPERATOR_DESC::OutputCountTensor">
+    <summary>An output tensor that holds the count of non-zero elements in the input tensor. This tensor must be a scalar—that is, the Sizes of this tensor must all be 1. The type of this tensor must be <b>UINT32</b>.</summary>
+  </comment>
+  <comment id="DML_NONZERO_COORDINATES_OPERATOR_DESC::OutputCoordinatesTensor">
+    <summary>An output tensor that holds the N-dimensional coordinates of the input elements which are non-zero. 
+
+This tensor must have <i>Sizes</i> of <c>{1,1,M,N}</c> (if <i>DimensionCount</i> is 4), or <c>{1,1,1,M,N}</c> (if <i>DimensionCount</i> is 5), where M is the total number of elements in the <i>InputTensor</i>, and N is greater or equal to the <i>effective rank</i> of <i>InputTensor</i>, up to the <i>DimensionCount</i> of the input.
+
+The effective rank of a tensor is determined by the <i>DimensionCount</i> of that tensor excluding leading dimensions of size 1. For example a tensor with sizes of <c>{1,2,3,4}</c> has effective rank 3, as does a tensor with sizes of <c>{1,1,5,5,5}</c>. A tensor with sizes <c>{1,1,1,1}</c> has effective rank 0.
+
+Consider an <i>InputTensor</i> with <i>Sizes</i> of <c>{1,1,12,5}</c>. This input tensor contains 60 elements, and has an effective rank of 2. In this example all valid sizes of <i>OutputCoordinatesTensor</i> are of the form <c>{1,1,60,N}</c>, where N &gt;= 2 but no greater than the <i>DimensionCount</i> (4 in this example).
+
+The coordinates written into this tensor are guaranteed to be ordered by ascending element index. For example if the input tensor has 3 non-zero values at coordinates {1,0}, {1,2}, and {0,5}, the values written to the <i>OutputCoordinatesTensor</i> will be <c>[[0,5], [1,0], [1,2]]</c>.
+
+While this tensor requires its dimension M to equal the number of elements in the input tensor, this operator will only write a maximum of OutputCount elements to this tensor. The OutputCount is returned through the scalar <i>OutputCountTensor</i>.
+
+> [!NOTE]
+> The remaining elements of this tensor beyond the OutputCount are undefined once this operator completes. You shouldn't rely on the values of these elements.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SHRINK_OPERATOR_DESC">
+    <summary>
+      <para>Performs the shrink activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_shrink_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SHRINK_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SHRINK_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SHRINK_OPERATOR_DESC::Bias">
+    <summary>The value of the bias. A typical default for this value is 0.0.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SHRINK_OPERATOR_DESC::Threshold">
+    <summary>The value of the threshold. A typical default for this value is 0.5.</summary>
+  </comment>
+  <comment id="DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC">
+    <summary>
+      <para>Performs a local response normalization (LRN) function on the input.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_local_response_normalization_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC::InputTensor">
+    <summary>The tensor containing the input data. This tensor's <i>Sizes</i> should be <c>{ BatchCount, ChannelCount, Height, Width }</c>.</summary>
+  </comment>
+  <comment id="DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. This tensor's <i>Sizes</i> should match the <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC::CrossChannel">
+    <summary><b>TRUE</b> if the LRN layer sums across channels; otherwise, <b>FALSE</b>.</summary>
+  </comment>
+  <comment id="DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC::LocalSize">
+    <summary>The number of elements to sum over per dimension: Width, Height, and optionally Channel (if <i>CrossChannel</i> is set). This value must be at least 1.</summary>
+  </comment>
+  <comment id="DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC::Alpha">
+    <summary>The value of the scaling parameter. A value of 0.0001 is recommended as default.</summary>
+  </comment>
+  <comment id="DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC::Beta">
+    <summary>The value of the exponent. A value of 0.75 is recommended as default.</summary>
+  </comment>
+  <comment id="DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC::Bias">
+    <summary>The value of bias. A value of 1 is recommended as default.</summary>
+  </comment>
+  <comment id="IDMLDevice::CompileOperator">
+    <summary>
+      <para>Compiles an operator into an object that can be dispatched to the GPU.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldevice-compileoperator" /></para>
+      <param name="op">The operator (created with [IDMLDevice::CreateOperator](/windows/win32/api/directml/nf-directml-idmldevice-createoperator)) to compile.</param>
+      <param name="flags">Any flags to control the execution of this operator.</param>
+      <param name="riid">A reference to the globally unique identifier (GUID) of the interface that you wish to be returned in <i>ppv</i>. This is expected to be the GUID of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlcompiledoperator">IDMLCompiledOperator</a>.</param>
+      <param name="ppv">A pointer to a memory block that receives a pointer to the compiled operator. This is the address of a pointer to an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlcompiledoperator">IDMLCompiledOperator</a>, representing  the compiled operator created.</param>
+    </summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC">
+    <summary>
+      <para>Performs a convolution of the <i>FilterTensor</i> with the <i>InputTensor</i>. This operator performs forward convolution on quantized data. This operator is mathematically equivalent to dequantizing the inputs, convolving, and then quantizing the output.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_quantized_linear_convolution_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the input data. The expected dimensions of the <i>InputTensor</i> are <c>{ InputBatchCount, InputChannelCount, InputHeight, InputWidth }</c>.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::InputScaleTensor">
+    <summary>A tensor containing the input scale data. The expected dimensions of the <c>InputScaleTensor</c> are <c>{ 1, 1, 1, 1 }</c>. This scale value is used for dequantizing the input values.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::InputZeroPointTensor">
+    <summary>An optional tensor containing the input zero point data. The expected dimensions of the <i>InputZeroPointTensor</i> are <c>{ 1, 1, 1, 1 }</c>. This zero point value is used for dequantizing the input values.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::FilterTensor">
+    <summary>A tensor containing the filter data. The expected dimensions of the <i>FilterTensor</i> are <c>{ FilterBatchCount, FilterChannelCount, FilterHeight, FilterWidth }</c>.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::FilterScaleTensor">
+    <summary>A tensor containing the filter scale data. The expected dimensions of the <c>FilterScaleTensor</c> are <c>{ 1, 1, 1, 1 }</c> if per tensor quantization is required, or <c>{ 1, OutputChannelCount, 1, 1 }</c> if per channel quantization is required. This scale value is used for dequantizing the filter values.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::FilterZeroPointTensor">
+    <summary>An optional tensor containing the filter zero point data. The expected dimensions of the <i>FilterZeroPointTensor</i> are <c>{ 1, 1, 1, 1 }</c> if per tensor quantization is required, or <c>{ 1, OutputChannelCount, 1, 1 }</c> if per channel quantization is required. This zero point value is used for dequantizing the filter values.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::BiasTensor">
+    <summary>A tensor containing the bias data. The bias tensor is a tensor containing data which is broadcasted across the output tensor at the end of the convolution which is added to the result. The expected dimensions of the BiasTensor are <c>{ 1, OutputChannelCount, 1, 1 }</c> for 4D.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::OutputScaleTensor">
+    <summary>A tensor containing the output scale data. The expected dimensions of the OutputScaleTensor are <c>{ 1, 1, 1, 1 }</c>. This input scale value is used for quantizing the convolution output values.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::OutputZeroPointTensor">
+    <summary>An optional tensor containing the filter zero point data. The expected dimensions of the OutputZeroPointTensor are <c>{ 1, 1, 1, 1 }</c>. This input zero point value is used for quantizing the convolution the output values.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::OutputTensor">
+    <summary>A tensor to write the results to. The expected dimensions of the OutputTensor are <c>{ OutputBatchCount, OutputChannelCount, OutputHeight, OutputWidth }</c>.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::DimensionCount">
+    <summary>The number of spatial dimensions for the convolution operation. Spatial dimensions are the lower dimensions of the convolution filter tensor <i>FilterTensor</i>. This value also determines the size of the <i>Strides</i>, <i>Dilations</i>, <i>StartPadding</i>, and <i>EndPadding</i> arrays. Only a value of 2 is supported.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::Strides">
+    <summary>The strides of the convolution operation. These strides are applied to the convolution filter. They are separate from the tensor strides included in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_tensor_desc">DML_TENSOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::Dilations">
+    <summary>The Dilations of the convolution operation. Dilations are strides applied to the elements of the filter kernel. This has the effect of simulating a larger filter kernel by padding the internal filter kernel elements with zeros.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::StartPadding">
+    <summary>The padding values to be applied to the beginning of each spatial dimension of the filter and input tensor of the convolution operation.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::EndPadding">
+    <summary>The padding values to be applied to the end of each spatial dimension of the filter and input tensor of the convolution operation.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC::GroupCount">
+    <summary>The number of groups which to divide the convolution operation into. <i>GroupCount</i> can be used to achieve depth-wise convolution by setting the <i>GroupCount</i> equal to the input channel count. This divides the convolution up into a separate convolution per input channel.</summary>
+  </comment>
+  <comment id="DML_SLICE_GRAD_OPERATOR_DESC">
+    <summary>
+      <para>Computes backpropagation gradients for Slice (see <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_slice1_operator_desc">DML_SLICE1_OPERATOR_DESC</a>).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_slice_grad_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SLICE_GRAD_OPERATOR_DESC::InputGradientTensor">
+    <summary>The incoming gradient tensor. This is typically obtained from the output of backpropagation of a preceding layer. Typically, this tensor would have the same sizes as the <i>output</i> of the corresponding <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_slice1_operator_desc">DML_SLICE1_OPERATOR_DESC</a> in the forward pass.</summary>
+  </comment>
+  <comment id="DML_SLICE_GRAD_OPERATOR_DESC::OutputGradientTensor">
+    <summary>An output tensor containing the backpropagated gradients. Typically, this tensor would have the same sizes as the <i>input</i> of the corresponding <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_slice1_operator_desc">DML_SLICE1_OPERATOR_DESC</a> in the forward pass.</summary>
+  </comment>
+  <comment id="DML_SLICE_GRAD_OPERATOR_DESC::DimensionCount">
+    <summary>The number of elements in the <i>InputWindowOffsets</i>, <i>InputWindowSizes</i>, and <i>InputWindowStrides</i> arrays. This value must equal the <i>DimensionCount</i> provided in the <i>InputGradientTensor</i> and <i>OutputGradientTensor</i>.</summary>
+  </comment>
+  <comment id="DML_SLICE_GRAD_OPERATOR_DESC::InputWindowOffsets">
+    <summary>See <i>InputWindowOffsets</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_slice1_operator_desc">DML_SLICE1_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_SLICE_GRAD_OPERATOR_DESC::InputWindowSizes">
+    <summary>See <i>InputWindowSizes</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_slice1_operator_desc">DML_SLICE1_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_SLICE_GRAD_OPERATOR_DESC::InputWindowStrides">
+    <summary>See <i>InputWindowStrides</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_slice1_operator_desc">DML_SLICE1_OPERATOR_DESC</a>.
+
+Note that unlike <b>DML_SLICE1_OPERATOR_DESC</b>, this operator requires non-zero strides. That's because with a zero stride, it's ambiguous as to which input element should map to each output element, and therefore backpropagation can't be performed. Like <b>DML_SLICE1_OPERATOR_DESC</b>, negative strides flip the input window direction along that axis.</summary>
+  </comment>
+  <comment id="DML_ONE_HOT_OPERATOR_DESC">
+    <summary>
+      <para>Produces a tensor filled with <i>one-hot encoded</i> values. This operator produces an output tensor where, for all sequences in a chosen axis, all but one element in that sequence is set to <i>OffValue</i>, and the remaining single element is set to <i>OnValue</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_one_hot_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ONE_HOT_OPERATOR_DESC::IndicesTensor">
+    <summary>A tensor containing the index in elements of the <i>OnValue</i>, for each sequence along the <i>Axis</i>. Indices are measured relative to the beginning of their sequence (as opposed to the beginning of the tensor). For example, an index of 0 always refers to the first element for all sequences in an axis.
+
+If an index value for a sequence exceeds the number of elements along the <i>Axis</i> dimension in the <i>OutputTensor</i>, then that index value is ignored, and all elements in that sequence will be set to <i>OffValue</i>.
+
+Starting with <c>DML_FEATURE_LEVEL_3_0</c>, this operator supports negative index values when using a signed integral type with this tensor. Negative indices are interpreted as being relative to the end of the sequence. For example, an index of -1 refers to the last element in the sequence.
+
+This tensor must have dimension count and sizes equal to the <i>OutputTensor</i>, <i>except</i> for the dimension specified by the <i>Axis</i> parameter. The size of the <i>Axis</i> dimension must be 1. For example if the <i>OutputTensor</i> has sizes of <c>{2,3,4,5}</c> and <i>Axis</i> is 1, the sizes of the <i>IndicesTensor</i> must be <c>{2,1,4,5}</c>.</summary>
+  </comment>
+  <comment id="DML_ONE_HOT_OPERATOR_DESC::ValuesTensor">
+    <summary>This tensor may have any size, so long as it contains at least two elements. The 0th element of this tensor is interpreted as the <i>OffValue</i>, and the 1st element along the fastest-changing dimension of size >1 is interpreted as the <i>OnValue</i>.</summary>
+  </comment>
+  <comment id="DML_ONE_HOT_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to. This tensor must have dimension count and sizes equal to the <i>IndicesTensor</i>, <i>except</i> for the dimension specified by the <i>Axis</i> parameter. The size of the <i>Axis</i> dimension in this tensor may have any value greater than 0.</summary>
+  </comment>
+  <comment id="DML_ONE_HOT_OPERATOR_DESC::Axis">
+    <summary>The index of the dimension to produce one-hot encoded sequences along. This value must be less than the DimensionCount of the <i>IndicesTensor</i>.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_OR_OPERATOR_DESC">
+    <summary>
+      <para>Computes the bitwise OR between each corresponding element of the input tensors, and writes the result into the output tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_bit_or_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_OR_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_OR_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_OR_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="IDMLDevice::CreateOperatorInitializer">
+    <summary>
+      <para>Creates an object that can be used to initialize compiled operators.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldevice-createoperatorinitializer" /></para>
+      <param name="operatorCount">This parameter determines the number of elements in the array passed in the  <i>operators</i> parameter.</param>
+      <param name="operators">An optional pointer to a constant array of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlcompiledoperator">IDMLCompiledOperator</a> pointers containing the set of operators that this initializer will target. Upon execution of the initializer, the target
+          operators become initialized. This array may be null or empty, indicating that the initializer has no target
+          operators.</param>
+      <param name="riid">A reference to the globally unique identifier (GUID) of the interface that you wish to be returned in <i>ppv</i>. This is expected to be the GUID of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmloperatorinitializer">IDMLOperatorInitializer</a>.</param>
+      <param name="ppv">A pointer to a memory block that receives a pointer to the operator initializer. This is the address of a pointer to an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmloperatorinitializer">IDMLOperatorInitializer</a>, representing  the operator initializer created.</param>
+    </summary>
+  </comment>
+  <comment id="DML_INTERPOLATION_MODE">
+    <summary>
+      <para>Defines constants that specify a mode for the DirectML upsample 2-D operator (as described by the DML_UPSAMPLE_2D_OPERATOR_DESC structure).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_interpolation_mode" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_INTERPOLATION_MODE::DML_INTERPOLATION_MODE_NEAREST_NEIGHBOR">
+    <summary>Specifies the nearest-neighbor mode.</summary>
+  </comment>
+  <comment id="DML_INTERPOLATION_MODE::DML_INTERPOLATION_MODE_LINEAR">
+    <summary>Specifies a linear (including bilinear, trilinear, etc.) mode.</summary>
+  </comment>
+  <comment id="IDMLOperatorInitializer">
+    <summary>
+      <para>Represents a specialized object whose purpose is to initialize compiled operators. To create an instance of this object, call IDMLDevice::CreateOperatorInitializer.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nn-directml-idmloperatorinitializer" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OPERATOR_DESC">
+    <summary>
+      <para>Performs a logical <i>less than</i> on each pair of corresponding elements of the input tensors, placing the result (1 for true, 0 for false) into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_logical_less_than_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SOFTMAX_OPERATOR_DESC">
+    <summary>
+      <para>Performs a softmax activation function on <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_softmax_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SOFTMAX_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from. This tensor must have an <i>effective rank</i> no greater than 2. The effective rank of a tensor is the <i>DimensionCount</i> of the tensor, excluding leftmost dimensions of size 1. For example a tensor size of <c>{ 1, 1, BatchCount, Width }</c> is valid, and is equivalent to a tensor of sizes <c>{ BatchCount, Width }</c>.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SOFTMAX_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OPERATOR_DESC">
+    <summary>
+      <para>Performs a logical <i>greater than</i> on each pair of corresponding elements of the input tensors, placing the result (1 for true, 0 for false) into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_logical_greater_than_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_GRAPH_NODE_DESC">
+    <summary>
+      <para>A generic container for a node within a graph of DirectML operators defined by <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_graph_desc">DML_GRAPH_DESC</a> and passed to [IDMLDevice1::CompileGraph](/windows/desktop/api/directml/nf-directml-idmldevice1-compilegraph).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_graph_node_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_GRAPH_NODE_DESC::Type">
+    <summary>The type of graph node. See <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_graph_node_type">DML_GRAPH_NODE_TYPE</a> for available types.</summary>
+  </comment>
+  <comment id="DML_GRAPH_NODE_DESC::Desc">
+    <summary>A pointer to the graph node description. The type of the pointed-to struct must match the value specified in <i>Type</i>.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_POW_OPERATOR_DESC">
+    <summary>
+      <para>Computes each element of <i>InputTensor</i> raised to the power of the corresponding element of <i>ExponentTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_pow_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_POW_OPERATOR_DESC::InputTensor">
+    <summary>The tensor containing the input values.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_POW_OPERATOR_DESC::ExponentTensor">
+    <summary>The tensor containing the exponent values.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_POW_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_POW_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_SPACE_TO_DEPTH_OPERATOR_DESC">
+    <summary>
+      <para>Rearranges blocks of spatial data into depth. The operator outputs a copy of the input tensor where values from the height and width dimensions are moved to the depth dimension.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_space_to_depth_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SPACE_TO_DEPTH_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from. The input tensor's dimensions are <c>{ Batch, Channels, Height, Width }</c>.</summary>
+  </comment>
+  <comment id="DML_SPACE_TO_DEPTH_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. The output tensor's dimensions are <c>{ Batch, Channels / (BlockSize * BlockSize), Height * BlockSize, Width * BlockSize }</c>.</summary>
+  </comment>
+  <comment id="DML_SPACE_TO_DEPTH_OPERATOR_DESC::BlockSize">
+    <summary>The width and height of the Blocks that are moved.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ASINH_OPERATOR_DESC">
+    <summary>
+      <para>Computes the hyperbolic arcsine for each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_asinh_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ASINH_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ASINH_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ASINH_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_LINEAR_OPERATOR_DESC">
+    <summary>
+      <para>Performs the linear activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_linear_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_LINEAR_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_LINEAR_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_LINEAR_OPERATOR_DESC::Alpha">
+    <summary>The alpha coefficient.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_LINEAR_OPERATOR_DESC::Beta">
+    <summary>The beta coefficient.</summary>
+  </comment>
+  <comment id="DML_INPUT_GRAPH_EDGE_DESC">
+    <summary>
+      <para>Describes a connection within a graph of DirectML operators defined by <a href="https://docs.microsoft.com/windows/desktop/api/directml/ns-directml-dml_graph_desc">DML_GRAPH_DESC</a> and passed to [IDMLDevice1::CompileGraph](/windows/desktop/api/directml/nf-directml-idmldevice1-compilegraph). This structure is used to define a connection from a graph input to an input of an internal node.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_input_graph_edge_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_INPUT_GRAPH_EDGE_DESC::GraphInputIndex">
+    <summary>The index of the graph input from which a connection to an internal node input is specified.</summary>
+  </comment>
+  <comment id="DML_INPUT_GRAPH_EDGE_DESC::ToNodeIndex">
+    <summary>The index of the internal node onto which the connection from the graph input is specified.</summary>
+  </comment>
+  <comment id="DML_INPUT_GRAPH_EDGE_DESC::ToNodeInputIndex">
+    <summary>The index of the input on the internal node where the connection is specified.</summary>
+  </comment>
+  <comment id="DML_INPUT_GRAPH_EDGE_DESC::Name">
+    <summary>An optional name for the graph connection. If provided, this might be used within certain error messages emitted by the DirectML debug layer.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC">
+    <summary>
+      <para>Computes the floor for each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_floor_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC">
+    <summary>
+      <para>Checks each element of <i>InputTensor</i> for IEEE-754 -inf, inf, or both, depending on the given <i>InfinityMode</i>, and places the result (1 for true, 0 for false) into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_is_infinity_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC::InfinityMode">
+    <summary>A <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_is_infinity_mode">DML_IS_INFINITY_MODE</a> determining the sign of the infinity to check for.
+
+* If <b>DML_IS_INFINITY_MODE_EITHER</b>, then 1 will be returned if the element is -inf or inf, otherwise 0.
+* If <b>DML_IS_INFINITY_MODE_POSITIVE</b>, then 1 will be returned if the element is inf, otherwise 0.
+* If <b>DML_IS_INFINITY_MODE_NEGATIVE</b>`, then 1 will be returned if the element is -inf, otherwise 0.</summary>
+  </comment>
+  <comment id="DML_TENSOR_DESC">
+    <summary>
+      <para>A generic container for a DirectML tensor description.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_tensor_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_TENSOR_DESC::Type">
+    <summary>The type of the tensor description. See <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_tensor_type">DML_TENSOR_TYPE</a> for the available types.</summary>
+  </comment>
+  <comment id="DML_TENSOR_DESC::Desc">
+    <summary>A pointer to the tensor description. The type of the pointed-to struct must match the value specified in <i>Type</i>.</summary>
+  </comment>
+  <comment id="DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC">
+    <summary>
+      <para>Performs a matrix multiplication function on integer data.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_matrix_multiply_integer_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the A data. This tensor's dimensions should be <c>{ BatchCount, ChannelCount, M, K }</c>.</summary>
+  </comment>
+  <comment id="DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC::AZeroPointTensor">
+    <summary>An optional tensor containing the ATensor zero point data. The expected dimensions of the <c>AZeroPointTensor</c> are <c>{ 1, 1, 1, 1 }</c> if per tensor quantization is required, or <c>{ 1, 1, M, 1 }</c> if per-row quantization is required. These zero point values are used for dequantizing the <i>ATensor</i> values.</summary>
+  </comment>
+  <comment id="DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the B data. This tensor's dimensions should be <c>{ BatchCount, ChannelCount, K, N }</c>.</summary>
+  </comment>
+  <comment id="DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC::BZeroPointTensor">
+    <summary>An optional tensor containing the <i>BTensor</i> zero point data. The expected dimensions of the <c>BZeroPointTensor</c> are <c>{ 1, 1, 1, 1 }</c> if per tensor quantization is required, or <c>{ 1, 1, 1, N }</c> if per column quantization is required. These zero point values are used for dequantizing the BTensor values.</summary>
+  </comment>
+  <comment id="DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC::OutputTensor">
+    <summary>A tensor with which to write the results to. This tensor's dimensions are <c>{ BatchCount, ChannelCount, M, N }</c>.</summary>
+  </comment>
+  <comment id="IDMLCommandRecorder::RecordDispatch">
+    <summary>
+      <para>Records execution of a dispatchable object (an operator initializer, or a compiled operator) onto a command list.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmlcommandrecorder-recorddispatch" /></para>
+      <param name="commandList">A pointer to an <a href="https://docs.microsoft.com/windows/win32/api/d3d12/nn-d3d12-id3d12commandlist">ID3D12CommandList</a> interface representing the command list to record the execution into. The command list must be open and must have type
+          <a href="https://docs.microsoft.com/windows/win32/api/d3d12/ne-d3d12-d3d12_command_list_type">D3D12_COMMAND_LIST_TYPE_DIRECT</a> or <b>D3D12_COMMAND_LIST_TYPE_COMPUTE</b>.</param>
+      <param name="dispatchable">A pointer to an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmldispatchable">IDMLDispatchable</a> interface representing the object (an operator initializer, or a compiled operator) whose execution will be recorded into the command list.</param>
+      <param name="bindings">A pointer to an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlbindingtable">IDMLBindingTable</a> interface representing the bindings to use for executing the dispatchable object. If the <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_execution_flags">DML_EXECUTION_FLAG_DESCRIPTORS_VOLATILE</a>
+          flag was not set, then you must fill out all required bindings, otherwise an error will result.</param>
+    </summary>
+  </comment>
+  <comment id="DML_RESAMPLE_GRAD_OPERATOR_DESC">
+    <summary>
+      <para>Computes backpropagation gradients for Resample (see <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_resample1_operator_desc">DML_RESAMPLE1_OPERATOR_DESC</a>).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_resample_grad_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_RESAMPLE_GRAD_OPERATOR_DESC::InputGradientTensor">
+    <summary>The incoming gradient tensor. This is typically obtained from the output of backpropagation of a preceding layer. Typically this tensor would have the same sizes as the <i>output</i> of the corresponding <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_resample1_operator_desc">DML_RESAMPLE1_OPERATOR_DESC</a> in the forward pass.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE_GRAD_OPERATOR_DESC::OutputGradientTensor">
+    <summary>An output tensor containing the backpropagated gradients. Typically this tensor would have the same sizes as the <i>input</i> of the corresponding <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_resample1_operator_desc">DML_RESAMPLE1_OPERATOR_DESC</a> in the forward pass.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE_GRAD_OPERATOR_DESC::InterpolationMode">
+    <summary>See <i>InterpolationMode</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_resample1_operator_desc">DML_RESAMPLE1_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE_GRAD_OPERATOR_DESC::DimensionCount">
+    <summary>The number of elements in the <i>Scales</i>, <i>InputPixelOffsets</i>, and <i>OutputPixelOffsets</i> arrays. This value must equal the <i>DimensionCount</i> provided in the <i>InputGradientTensor</i> and <i>OutputGradientTensor</i>.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE_GRAD_OPERATOR_DESC::Scales">
+    <summary>See <i>Scales</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_resample1_operator_desc">DML_RESAMPLE1_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE_GRAD_OPERATOR_DESC::InputPixelOffsets">
+    <summary>See <i>InputPixelOffsets</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_resample1_operator_desc">DML_RESAMPLE1_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE_GRAD_OPERATOR_DESC::OutputPixelOffsets">
+    <summary>See <i>OutputPixelOffsets</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_resample1_operator_desc">DML_RESAMPLE1_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="IDMLDispatchable">
+    <summary>
+      <para>Implemented by objects that can be recorded into a command list for dispatch on the GPU, using IDMLCommandRecorder::RecordDispatch.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nn-directml-idmldispatchable" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_TENSOR_TYPE">
+    <summary>
+      <para>Identifies a type of tensor description.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_tensor_type" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_TENSOR_TYPE::DML_TENSOR_TYPE_INVALID">
+    <summary>Indicates an unknown tensor description type. This value is never valid.</summary>
+  </comment>
+  <comment id="DML_TENSOR_TYPE::DML_TENSOR_TYPE_BUFFER">
+    <summary>Indicates a tensor description that is represented by a Direct3D 12 buffer. The corresponding struct type is <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_buffer_tensor_desc">DML_BUFFER_TENSOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MAX_OPERATOR_DESC">
+    <summary>
+      <para>Takes the greater of two corresponding elements from the input tensors, and places the result into the corresponding element of the output tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_max_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MAX_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MAX_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MAX_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="IDMLDevice">
+    <summary>
+      <para>Represents a DirectML device, which is used to create operators, binding tables, command recorders, and other objects.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nn-directml-idmldevice" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SLICE_OPERATOR_DESC">
+    <summary>
+      <para>Extracts a single subregion (a "slice") of an input tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_slice_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SLICE_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to extract slices from.</summary>
+  </comment>
+  <comment id="DML_SLICE_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the sliced data results to.</summary>
+  </comment>
+  <comment id="DML_SLICE_OPERATOR_DESC::DimensionCount">
+    <summary>The number of dimensions. This field determines the size of the <i>Offsets</i>, <i>Sizes</i>, and <i>Strides</i> arrays. This value must match the <i>DimensionCount</i> of the input and output tensors. This value must be between 1 and 8, inclusively, starting from <c>DML_FEATURE_LEVEL_3_0</c>; earlier feature levels require a value of either 4 or 5.</summary>
+  </comment>
+  <comment id="DML_SLICE_OPERATOR_DESC::Offsets">
+    <summary>An array containing the slice's start along each dimension of the input tensor, in elements.</summary>
+  </comment>
+  <comment id="DML_SLICE_OPERATOR_DESC::Sizes">
+    <summary>An array containing the slice's size along each dimension, in elements. The values in this array must match the sizes specified in the output tensor.</summary>
+  </comment>
+  <comment id="DML_SLICE_OPERATOR_DESC::Strides">
+    <summary>An array containing the slice's stride along each dimension of the input tensor, in elements. A stride larger than 1 indicates that elements of the input tensor may be skipped (for example, a stride of 2 will select every second element along the dimension).</summary>
+  </comment>
+  <comment id="DML_GATHER_ELEMENTS_OPERATOR_DESC">
+    <summary>
+      <para>Gathers elements from the input tensor along the given axis using the indices tensor to remap into the input.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_gather_elements_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_GATHER_ELEMENTS_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from.</summary>
+  </comment>
+  <comment id="DML_GATHER_ELEMENTS_OPERATOR_DESC::IndicesTensor">
+    <summary>The indices into the input tensor along the active axis. The <i>Sizes</i> must match <i>InputTensor.Sizes</i> for every dimension except <i>Axis</i>.
+
+Starting with <c>DML_FEATURE_LEVEL_3_0</c>, this operator supports negative index values when using a signed integral type with this tensor. Negative indices are interpreted as being relative to the end of the axis dimension. For example, an index of -1 refers to the last element along that dimension.</summary>
+  </comment>
+  <comment id="DML_GATHER_ELEMENTS_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. The <i>Sizes</i> must match <i>IndicesTensor.Sizes</i>, and <i>DataType</i> must match <i>InputTensor.DataType</i>.</summary>
+  </comment>
+  <comment id="DML_GATHER_ELEMENTS_OPERATOR_DESC::Axis">
+    <summary>The axis dimension of <i>InputTensor</i> to gather along, ranging <c>[0, <i>InputTensor.DimensionCount</i>)</c>.</summary>
+  </comment>
+  <comment id="DML_GATHER_ND_OPERATOR_DESC">
+    <summary>
+      <para>Gathers elements from the input tensor, using the indices tensor to remap indices to entire subblocks of the input.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_gather_nd_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_GATHER_ND_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from.</summary>
+  </comment>
+  <comment id="DML_GATHER_ND_OPERATOR_DESC::IndicesTensor">
+    <summary>The tensor containing the indices. The <i>DimensionCount</i> of this tensor must match <i>InputTensor.DimensionCount</i>. The last dimension of the <i>IndicesTensor</i> is actually the number of coordinates per index tuple, and it cannot exceed <i>InputTensor.DimensionCount</i>. For example, an indices tensor of <i>Sizes</i> <c>{1,4,5,2}</c> with <i>IndicesDimensionCount</i> = 3 means a 4x5 array of 2-coordinate tuples that index into <i>InputTensor</i>.
+
+Starting with <c>DML_FEATURE_LEVEL_3_0</c>, this operator supports negative index values when using a signed integral type with this tensor. Negative indices are interpreted as being relative to the end of the respective dimension. For example, an index of -1 refers to the last element along that dimension.</summary>
+  </comment>
+  <comment id="DML_GATHER_ND_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. The <i>DimensionCount</i> and <i>DataType</i> of this tensor must match <i>InputTensor.DimensionCount</i>. The expected <i>OutputTensor.Sizes</i> are the concatenation of the <i>IndicesTensor.Sizes</i> leading segments and <i>InputTensor.Sizes</i> trailing segment to yield:
+
+<code>
+indexTupleSize = IndicesTensor.Sizes[IndicesTensor.DimensionCount - 1]
+OutputTensor.Sizes = {
+    1...,
+    IndicesTensor.Sizes[(IndicesTensor.DimensionCount - IndicesDimensionCount) .. (IndicesTensor.DimensionCount - 1)],
+    InputTensor.Sizes[(InputTensor.DimensionCount - indexTupleSize) .. InputTensor.DimensionCount]
+}
+</code>
+
+The output dimensions are right-aligned, with leading 1 values prepended if needed to satisfy up to <i>OutputTensor.DimensionCount</i>.
+
+Here's an example.
+
+<code>
+InputTensor.Sizes = {3,4,5,6,7}
+InputDimensionCount = 5
+IndicesTensor.Sizes = {1,1, 1,2,3}
+IndicesDimensionCount = 3 // can be thought of as a {1,2} array of 3-coordinate tuples
+
+// The {1,2} comes from the indices tensor (ignoring last dimension which is the tuple size),
+// and the {6,7} comes from input tensor, ignoring the first 3 dimensions
+// since the index tuples are 3 elements (from the indices tensor last dimension).
+OutputTensor.Sizes = {1, 1,2,6,7}
+</code></summary>
+  </comment>
+  <comment id="DML_GATHER_ND_OPERATOR_DESC::InputDimensionCount">
+    <summary>The number of actual input dimensions within the <i>InputTensor</i> after ignoring any irrelevant leading ones, ranging <c>[1, <i>InputTensor.DimensionCount</i>]</c>. For example, given <i>InputTensor.Sizes</i> = <c>{1,1,4,6}</c> and <c>InputDimensionCount</c> = 3, the actual meaningful indices are <c>{1,4,6}</c>.</summary>
+  </comment>
+  <comment id="DML_GATHER_ND_OPERATOR_DESC::IndicesDimensionCount">
+    <summary>The number of actual index dimensions within the <i>IndicesTensor</i> after ignoring any irrelevant leading ones, ranging [1, <i>IndicesTensor.DimensionCount</i>]. For example, given <i>IndicesTensor.Sizes</i> = <c>{1,1,4,6}</c>, and <i>IndicesDimensionCount</i> = 3, the actual meaningful indices are <c>{1,4,6}</c>.</summary>
+  </comment>
+  <comment id="DML_BUFFER_BINDING">
+    <summary>
+      <para>Specifies a resource binding described by a range of bytes in a Direct3D 12 buffer, represented by an offset and size into an ID3D12Resource.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_buffer_binding" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_BUFFER_BINDING::Buffer">
+    <summary>An optional pointer to an <a href="https://docs.microsoft.com/windows/win32/api/d3d12/nn-d3d12-id3d12resource">ID3D12Resource</a> interface representing a buffer. The resource must have dimension <a href="https://docs.microsoft.com/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_dimension">D3D12_RESOURCE_DIMENSION_BUFFER</a>, and the
+      range described by this struct must lie within the bounds of the buffer. You may supply <b>nullptr</b> for this member to indicate 'no binding'.</summary>
+  </comment>
+  <comment id="DML_BUFFER_BINDING::Offset">
+    <summary>The offset, in bytes, from the start of the buffer where the range begins. This offset must be aligned to a
+      multiple of <a href="https://docs.microsoft.com/windows/desktop/direct3d12/direct3d-directml-constants">DML_MINIMUM_BUFFER_TENSOR_ALIGNMENT</a> or the <b>GuaranteedBaseOffsetAlignment</b> supplied as part of the
+      <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_buffer_tensor_desc">DML_BUFFER_TENSOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_BUFFER_BINDING::SizeInBytes">
+    <summary>The size of the range, in bytes.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC">
+    <summary>
+      <para>Computes backpropagation gradients for average pooling (see <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_average_pooling_operator_desc">DML_AVERAGE_POOLING_OPERATOR_DESC</a>).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_average_pooling_grad_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC::InputGradientTensor">
+    <summary>The incoming gradient tensor. This is typically obtained from the output of backpropagation of a preceding layer. Typically this tensor would have the same sizes as the <i>output</i> of the corresponding <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_average_pooling_operator_desc">DML_AVERAGE_POOLING_OPERATOR_DESC</a> in the forward pass.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC::OutputGradientTensor">
+    <summary>An output tensor containing the backpropagated gradients. Typically this tensor would have the same sizes as the <i>input</i> of the corresponding <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_average_pooling_operator_desc">DML_AVERAGE_POOLING_OPERATOR_DESC</a> in the forward pass.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC::DimensionCount">
+    <summary>The number of elements in the <i>Strides</i>, <i>WindowSize</i>, <i>StartPadding</i>, and <i>EndPadding</i> arrays. This value must equal the spatial dimension count. The spatial dimension count is 2 if 4D tensors are provided, or 3 if 5D tensors are provided.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC::Strides">
+    <summary>See <i>Strides</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_average_pooling_operator_desc">DML_AVERAGE_POOLING_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC::WindowSize">
+    <summary>See <i>WindowSize</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_average_pooling_operator_desc">DML_AVERAGE_POOLING_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC::StartPadding">
+    <summary>See <i>StartPadding</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_average_pooling_operator_desc">DML_AVERAGE_POOLING_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC::EndPadding">
+    <summary>See <i>EndPadding</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_average_pooling_operator_desc">DML_AVERAGE_POOLING_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC::IncludePadding">
+    <summary>See <i>IncludePadding</i> in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_average_pooling_operator_desc">DML_AVERAGE_POOLING_OPERATOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_GRAPH_NODE_TYPE">
+    <summary>
+      <para>Defines constants that specify a type of graph node. See <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_graph_node_desc">DML_GRAPH_NODE_DESC</a> for the usage of this enumeration.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_graph_node_type" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_GRAPH_NODE_TYPE::DML_GRAPH_NODE_TYPE_INVALID">
+    <summary>Specifies an unknown graph edge type, and is never valid. Using this value results in an error.</summary>
+  </comment>
+  <comment id="DML_GRAPH_NODE_TYPE::DML_GRAPH_NODE_TYPE_OPERATOR">
+    <summary>Specifies that the graph edge is described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_operator_graph_node_desc">DML_OPERATOR_GRAPH_NODE_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOG_OPERATOR_DESC">
+    <summary>
+      <para>Computes the base-e (natural) logarithm of each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_log_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOG_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOG_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOG_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_RNN_OPERATOR_DESC">
+    <summary>
+      <para>Performs a one-layer simple recurrent neural network (RNN) function on the input. This function is often referred to as the Input Gate. This operator performs this function multiple times in a loop, dictated by the sequence length dimension and the <i>SequenceLengthsTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_rnn_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_RNN_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the input data, X. Packed (and potentially padded) into one 4-D tensor with the sizes of <c>{ 1, seq_length, batch_size, input_size }</c>. seq_length is the dimension that is mapped to the index, t.</summary>
+  </comment>
+  <comment id="DML_RNN_OPERATOR_DESC::WeightTensor">
+    <summary>A tensor containing the weight data, W. Concatenation of W_i and W_Bi (if bidirectional). The tensor has sizes <c>{ 1, num_directions, hidden_size, input_size }</c>.</summary>
+  </comment>
+  <comment id="DML_RNN_OPERATOR_DESC::RecurrenceTensor">
+    <summary>An optional tensor containing the recurrence weight data, R. Concatenation of R_i and R_Bi (if bidirectional). This tensor has sizes <c>{ 1, num_directions, hidden_size, hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_RNN_OPERATOR_DESC::BiasTensor">
+    <summary>An optional tensor containing the bias data for the input gate, B. Concatenation of <c>{ W_bi, R_bi }</c>, and <c>{ W_Bbi, R_Bbi }</c> (if bidirectional). This tensor has sizes <c>{ 1, 1, num_directions, 2 * hidden_size }</c>. If not specified, then defaults to 0.</summary>
+  </comment>
+  <comment id="DML_RNN_OPERATOR_DESC::HiddenInitTensor">
+    <summary>An optional tensor containing the hidden node initializer tensor, H_[t-1] for the first loop index t. If not specified, then defaults to 0. This tensor has sizes <c>{ 1, num_directions, batch_size, hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_RNN_OPERATOR_DESC::SequenceLengthsTensor">
+    <summary>An optional tensor containing an independent seq_length for each element in the batch. If not specified, then all sequences in the batch have length seq_length. This tensor has sizes <c>{ 1, 1, 1, batch_size }</c>.</summary>
+  </comment>
+  <comment id="DML_RNN_OPERATOR_DESC::OutputSequenceTensor">
+    <summary>An optional tensor with which to write the concatenation of all the intermediate layer output values of the hidden nodes, H_t. This tensor has sizes <c>{ seq_length, num_directions, batch_size, hidden_size }</c>. seq_length is mapped to the loop index t.</summary>
+  </comment>
+  <comment id="DML_RNN_OPERATOR_DESC::OutputSingleTensor">
+    <summary>An optional tensor with which to write the final output value of the hidden nodes, H_t. This tensor has sizes <c>{ 1, num_directions, batch_size, hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_RNN_OPERATOR_DESC::ActivationDescCount">
+    <summary>This field determines the size of the <i>ActivationDescs</i> array.</summary>
+  </comment>
+  <comment id="DML_RNN_OPERATOR_DESC::ActivationDescs">
+    <summary>An array of <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_operator_desc">DML_OPERATOR_DESC</a> containing the descriptions of the activation operators, f(). The number of activation functions is equal to the number of directions. For forwards and backwards directions there is expected to be 1 activation fuction. For Bidirectional there are expected to be 2.</summary>
+  </comment>
+  <comment id="DML_RNN_OPERATOR_DESC::Direction">
+    <summary>The direction of the operator: forward, backward, or bidirectional.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_COSH_OPERATOR_DESC">
+    <summary>
+      <para>Computes the hyperbolic cosine of each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_cosh_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_COSH_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_COSH_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_COSH_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_INTEGER_OPERATOR_DESC">
+    <summary>
+      <para>Performs a convolution of the <i>FilterTensor</i> with the <i>InputTensor</i>. This operator performs forward convolution on integer data.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_convolution_integer_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_INTEGER_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the input data. The expected dimensions of the <i>InputTensor</i> are <c>{ BatchCount, InputChannelCount, InputHeight, InputWidth }</c>.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_INTEGER_OPERATOR_DESC::InputZeroPointTensor">
+    <summary>An optional tensor containing the input zero point data. The expected dimensions of the <i>InputZeroPointTensor</i> are <c>{ 1, 1, 1, 1 }</c>.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_INTEGER_OPERATOR_DESC::FilterTensor">
+    <summary>A tensor containing the filter data. The expected dimensions of the <i>FilterTensor</i> are <c>{ FilterBatchCount, FilterChannelCount, FilterHeight, FilterWidth }</c>.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_INTEGER_OPERATOR_DESC::FilterZeroPointTensor">
+    <summary>An optional tensor containing the filter zero point data. The expected dimensions of the <i>FilterZeroPointTensor</i> are <c>{ 1, 1, 1, 1 }</c> if per tensor quantization is required, or <c>{ 1, OutputChannelCount, 1, 1 }</c> if per-channel quantization is required.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_INTEGER_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. The expected dimensions of the <i>OutputTensor</i> are <c>{ BatchCount, OutputChannelCount, OutputHeight, OutputWidth }</c>.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_INTEGER_OPERATOR_DESC::DimensionCount">
+    <summary>The number of spatial dimensions for the convolution operation. Spatial dimensions are the lower dimensions of the convolution <i>FilterTensor</i>. This value also determines the size of the <i>Strides</i>, <i>Dilations</i>, <i>StartPadding</i>, and <i>EndPadding</i> arrays. Only a value of 2 is supported.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_INTEGER_OPERATOR_DESC::Strides">
+    <summary>An array containing the strides of the convolution operation. These strides are applied to the convolution filter. They are separate from the tensor strides included in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_tensor_desc">DML_TENSOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_INTEGER_OPERATOR_DESC::Dilations">
+    <summary>An array containing the dilations of the convolution operation. Dilations are strides applied to the elements of the filter kernel. This has the effect of simulating a larger filter kernel by padding the internal filter kernel elements with zeros.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_INTEGER_OPERATOR_DESC::StartPadding">
+    <summary>An array containing the padding values to be applied to the beginning of each spatial dimension of the filter and input tensor of the convolution operation.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_INTEGER_OPERATOR_DESC::EndPadding">
+    <summary>An array containing the padding values to be applied to the end of each spatial dimension of the filter and input tensor of the convolution operation.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_INTEGER_OPERATOR_DESC::GroupCount">
+    <summary>The number of groups which to divide the convolution operation up into. <i>GroupCount</i> can be used to achieve depth-wise convolution by setting the <i>GroupCount</i> equal to the input channel count. This divides the convolution up into a separate convolution per input channel.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC">
+    <summary>
+      <para>Performs a matrix multiplication function on quantized data. This operator is mathematically equivalent to dequantizing the inputs, then performing matrix multiply, and then quantizing the output.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_quantized_linear_matrix_multiply_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the A data. This tensor's dimensions should be <c>{ BatchCount, ChannelCount, M, K }</c>.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC::AScaleTensor">
+    <summary>A tensor containing the ATensor scale data. The expected dimensions of the <c>AScaleTensor</c> are <c>{ 1, 1, 1, 1 }</c> if per tensor quantization is required, or <c>{ 1, 1, M, 1 }</c> if per row quantization is required. These scale values are used for dequantizing the A values.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC::AZeroPointTensor">
+    <summary>An optional tensor containing the <i>ATensor</i> zero point data. The expected dimensions of the AZeroPointTensor are <c>{ 1, 1, 1, 1 }</c> if per tensor quantization is required, or <c>{ 1, 1, M, 1 }</c> if per row quantization is required. These zero point values are used for dequantizing the ATensor values.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the B data. This tensor's dimensions should be <c>{ BatchCount, ChannelCount, K, N }</c>.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC::BScaleTensor">
+    <summary>A tensor containing the <i>BTensor</i> scale data. The expected dimensions of the <c>BScaleTensor</c> are <c>{ 1, 1, 1, 1 }</c> if per tensor quantization is required, or <c>{ 1, 1, 1, N }</c> if per column quantization is required. These scale values are used for dequantizing the <i>BTensor</i> values.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC::BZeroPointTensor">
+    <summary>An optional tensor containing the <i>BTensor</i> zero point data. The expected dimensions of the <c>BZeroPointTensor</c> are <c>{ 1, 1, 1, 1 }</c> if per tensor quantization is required, or <c>{ 1, 1, 1, N }</c> if per column quantization is required. These zero point values are used for dequantizing the <i>BTensor</i> values.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC::OutputScaleTensor">
+    <summary>A tensor containing the filter scale data. The expected dimensions of the <c>OutputScaleTensor</c> are <c>{ 1, 1, 1, 1 }</c> if per tensor quantization is required, or <c>{ 1, 1, M, 1 }</c> if per row quantization is required. This scale value is used for dequantizing the filter values.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC::OutputZeroPointTensor">
+    <summary>An optional tensor containing the filter zero point data. The expected dimensions of the <c>OutputZeroPointTensor</c> are <c>{ 1, 1, 1, 1 }</c> if per tensor quantization is required or <c>{ 1, 1, M, 1 }</c> if per row quantization is required. This zero point value is used for dequantizing the filter values.</summary>
+  </comment>
+  <comment id="DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC::OutputTensor">
+    <summary>A tensor to write the results to. This tensor's dimensions are <c>{ BatchCount, ChannelCount, M, N }</c>.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_IDENTITY_OPERATOR_DESC">
+    <summary>
+      <para>Performs the identity activation, effectively copying every element of <i>InputTensor</i> to the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_identity_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_IDENTITY_OPERATOR_DESC::InputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_IDENTITY_OPERATOR_DESC::OutputTensor">
+    <summary>A pointer to a constant <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_tensor_desc">DML_TENSOR_DESC</a> containing the description of the tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_VALUE_SCALE_2D_OPERATOR_DESC">
+    <summary>
+      <para>Performs an element-wise scale-and-bias function, <c>Output = Scale * Input + Bias</c>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_value_scale_2d_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_VALUE_SCALE_2D_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the Input data. This tensor's dimensions should be <c>{ BatchCount, ChannelCount, Height, Width }</c>.</summary>
+  </comment>
+  <comment id="DML_VALUE_SCALE_2D_OPERATOR_DESC::OutputTensor">
+    <summary>A tensor with which to write the results to. This tensor's dimensions should match the <i>InputTensor</i>'s dimensions.</summary>
+  </comment>
+  <comment id="DML_VALUE_SCALE_2D_OPERATOR_DESC::Scale">
+    <summary>Scale value to be applied to all input values.</summary>
+  </comment>
+  <comment id="DML_VALUE_SCALE_2D_OPERATOR_DESC::ChannelCount">
+    <summary>This field determines the size of the Bias array. This field must be set to either 1 or 3, and must also match the size of the Channel dimension of the input tensor.</summary>
+  </comment>
+  <comment id="DML_VALUE_SCALE_2D_OPERATOR_DESC::Bias">
+    <summary>An array of <i>FLOAT</i> values containing the bias term for each dimension of the input tensor.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_DIVIDE_OPERATOR_DESC">
+    <summary>
+      <para>Computes the quotient of each element of <i>ATensor</i> over the corresponding element of <i>BTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_divide_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_DIVIDE_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_DIVIDE_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_DIVIDE_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_NOT_OPERATOR_DESC">
+    <summary>
+      <para>Computes the bitwise NOT for each element of the input tensor, and writes the result into the output tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_bit_not_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_NOT_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_NOT_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_SCATTER_ND_OPERATOR_DESC">
+    <summary>
+      <para>Copies the whole input tensor to the output, then overwrites selected indices with corresponding values from the updates tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_scatter_nd_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SCATTER_ND_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from.</summary>
+  </comment>
+  <comment id="DML_SCATTER_ND_OPERATOR_DESC::IndicesTensor">
+    <summary>A tensor containing the indices. The <i>DimensionCount</i> of this tensor must match <i>InputTensor.DimensionCount</i>. The last dimension of the <i>IndicesTensor</i> is actually the number of coordinates per index tuple, and it mustn't exceed <i>InputTensor.DimensionCount</i>. For example, an indices tensor of size <c>{1,4,5,2}</c> with <i>IndicesDimensionCount</i> = 3 means a 4x5 array of 2-value coordinate tuples that index into <i>InputTensor</i>.
+
+Starting with <c>DML_FEATURE_LEVEL_3_0</c>, this operator supports negative index values when using a signed integral type with this tensor. Negative indices are interpreted as being relative to the end of the respective dimension. For example, an index of -1 refers to the last element along that dimension.</summary>
+  </comment>
+  <comment id="DML_SCATTER_ND_OPERATOR_DESC::UpdatesTensor">
+    <summary>A tensor containing the new values to replace the existing input values at the corresponding indices. The <i>DimensionCount</i> of this tensor must match <i>InputTensor.DimensionCount</i>. The expected <i>UpdatesTensor.Sizes</i> are the concatenation of the <i>IndicesTensor.Sizes</i> leading segments and <i>InputTensor.Sizes</i> trailing segment to yield the following.
+
+<code>
+indexTupleSize = IndicesTensor.Sizes[IndicesTensor.DimensionCount - 1]
+UpdatesTensor.Sizes = [
+    1...,
+    IndicesTensor.Sizes[(IndicesTensor.DimensionCount - IndicesDimensionCount) .. (IndicesTensor.DimensionCount - 1)],
+    InputTensor.Sizes[(InputTensor.DimensionCount - indexTupleSize) .. InputTensor.DimensionCount]
+]
+</code>
+
+The dimensions are right-aligned, with leading 1 values prepended if needed to satisfy <i>UpdatesTensor.DimensionCount</i>.
+
+Here's an example.
+
+<code>
+InputTensor.Sizes = [3,4,5,6,7]
+InputDimensionCount = 5
+IndicesTensor.Sizes = [1,1, 1,2,3]
+IndicesDimensionCount = 3 // can be thought of as a [1,2] array of 3-coordinate tuples
+
+// The [1,2] comes from the indices tensor (ignoring last dimension, which is the tuple size),
+// and the [6,7] comes from input tensor, ignoring the first 3 dimensions
+// since the index tuples are 3 elements (from the indices tensor last dimension).
+UpdatesTensor.Sizes = [1, 1,2,6,7]
+</code></summary>
+  </comment>
+  <comment id="DML_SCATTER_ND_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. The <i>Sizes</i> and <i>DataType</i> of this tensor must match <i>InputTensor.Sizes</i>.</summary>
+  </comment>
+  <comment id="DML_SCATTER_ND_OPERATOR_DESC::InputDimensionCount">
+    <summary>The number of actual input dimensions within the <i>InputTensor</i> after ignoring any irrelevant leading ones, ranging [1, <i>InputTensor.DimensionCount</i>). For example, given <i>InputTensor.Sizes</i> = {1,1,4,6} and <i>InputDimensionCount</i> = 3, the actual meaningful indices are {1,4,6}.</summary>
+  </comment>
+  <comment id="DML_SCATTER_ND_OPERATOR_DESC::IndicesDimensionCount">
+    <summary>The number of actual index dimensions within the <i>IndicesTensor</i> after ignoring any irrelevant leading ones, ranging [1, <i>IndicesTensor.DimensionCount</i>). For example, given <i>IndicesTensor.Sizes</i> = {1,1,4,6} and <i>IndicesDimensionCount</i> = 3, the actual meaningful indices are {1,4,6}.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_EXP_OPERATOR_DESC">
+    <summary>
+      <para>Applies the natural exponentiation function to each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_exp_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_EXP_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_EXP_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_EXP_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ERF_OPERATOR_DESC">
+    <summary>
+      <para>Performs the Gaussian error function (erf) on each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_erf_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ERF_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ERF_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ERF_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="IDMLDevice::Evict">
+    <summary>
+      <para>Evicts one or more pageable objects from GPU memory. Also see IDMLDevice::MakeResident.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldevice-evict" /></para>
+      <param name="count">This parameter determines the number of elements in the array passed in the  <i>ppObjects</i> parameter.</param>
+      <param name="ppObjects">A pointer to a constant array of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlpageable">IDMLPageable</a> pointers containing the pageable objects to evict from GPU memory.</param>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SIGMOID_OPERATOR_DESC">
+    <summary>
+      <para>Performs the sigmoid function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_sigmoid_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SIGMOID_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SIGMOID_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE1_OPERATOR_DESC">
+    <summary>
+      <para>Resamples elements from the source to the destination tensor, using the scale factors to compute the destination tensor size. You can use a linear or nearest-neighbor interpolation mode.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_resample1_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_RESAMPLE1_OPERATOR_DESC::InputTensor">
+    <summary>The tensor containing the input data.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE1_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the output data to.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE1_OPERATOR_DESC::InterpolationMode">
+    <summary>This field determines the kind of interpolation used to choose output pixels.
+
+- <b>DML_INTERPOLATION_MODE_NEAREST_NEIGHBOR</b>. Uses the <i>Nearest Neighbor</i> algorithm, which chooses the input element nearest to the corresponding pixel center for each output element.
+
+- <b>DML_INTERPOLATION_MODE_LINEAR</b>. Uses the <i>Quadrilinear</i> algorithm, which computes the output element by doing the weighted average of the 2 nearest neighboring input elements per dimension. Since all 4 dimensions can be resampled, the weighted average is computed on a total of 16 input elements for each output element.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE1_OPERATOR_DESC::DimensionCount">
+    <summary>The number of values in the arrays that <i>Scales</i>, <i>InputPixelOffsets</i>, and <i>OutputPixelOffsets</i> point to. This value must match the dimension count of <i>InputTensor</i> and <i>OutputTensor</i>, which has to be 4.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE1_OPERATOR_DESC::Scales">
+    <summary>The scales to apply when resampling the input, where scales &gt; 1 scale up the image and scales &lt; 1 scale down the image for that dimension. Note that the scales don't need to be exactly <c>OutputSize / InputSize</c>. If the input after scaling is larger than the output bound, then we crop it to the output size. On the other hand, if the input after scaling is smaller than the output bound, the output edges are clamped.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE1_OPERATOR_DESC::InputPixelOffsets">
+    <summary>The offsets to apply to the input pixels before resampling. When this value is <c>0</c>, the top left corner of the pixel is used instead of its center, which usually won't give the expected result. To resample the image by using the center of the pixels and to get the same behavior as <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_resample_operator_desc">DML_RESAMPLE_OPERATOR_DESC</a>, this value must be <c>0.5</c>.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE1_OPERATOR_DESC::OutputPixelOffsets">
+    <summary>The offsets to apply to the output pixels after resampling. When this value is <c>0</c>, the top left corner of the pixel is used instead of its center, which usually won't give the expected result. To resample the image by using the center of the pixels and to get the same behavior as <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_resample_operator_desc">DML_RESAMPLE_OPERATOR_DESC</a>, this value must be <c>-0.5</c>.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC">
+    <summary>
+      <para>Performs a mean variance normalization function on the input tensor. This operator will calculate the mean and variance of the input tensor to perform normalization.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_mean_variance_normalization_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the Input data. This tensor's dimensions should be <c>{ BatchCount, ChannelCount, Height, Width }</c>.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC::ScaleTensor">
+    <summary>An optional tensor containing the Scale data. This tensor's dimensions should be <c>{ BatchCount, ChannelCount, Height, Width }</c>. Any dimension can be replaced with 1 to broadcast in that dimension. This tensor is required if the <i>BiasTensor</i> is used.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC::BiasTensor">
+    <summary>An optional tensor containing the bias data. This tensor's dimensions should be <c>{ BatchCount, ChannelCount, Height, Width }</c>. Any dimension can be replaced with 1 to broadcast in that dimension. This tensor is required if the <i>ScaleTensor</i> is used.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC::OutputTensor">
+    <summary>A tensor to write the results to. This tensor's dimensions are <c>{ BatchCount, ChannelCount, Height, Width }</c>.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC::CrossChannel">
+    <summary><b>TRUE</b> if the MeanVariance layer includes channels in the Mean and Variance calculations. Otherwise, <b>FALSE</b>.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC::NormalizeVariance">
+    <summary><b>TRUE</b> if the Normalization layer includes Variance in the normalization calculation. Otherwise, <b>FALSE</b>. If <b>FALSE</b>, then normalization equation is <c>Output = FusedActivation(Scale * (Input - Mean) + Bias)</c>.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC::Epsilon">
+    <summary>The epsilon value to use to avoid division by zero. A value of 0.00001 is recommended as default.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC::FusedActivation">
+    <summary>An optional fused activation layer to apply after the normalization.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC">
+    <summary>
+      <para>Performs a hard sigmoid function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_hard_sigmoid_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC::Alpha">
+    <summary>The alpha coefficient. A typical default for this value is 0.2.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC::Beta">
+    <summary>The beta coefficient. A typical default for this value is 0.5.</summary>
+  </comment>
+  <comment id="DML_OUTPUT_GRAPH_EDGE_DESC">
+    <summary>
+      <para>Describes a connection within a graph of DirectML operators defined by <a href="https://docs.microsoft.com/windows/desktop/api/directml/ns-directml-dml_graph_desc">DML_GRAPH_DESC</a> and passed to [IDMLDevice1::CompileGraph](/windows/desktop/api/directml/nf-directml-idmldevice1-compilegraph). This structure is used to define a connection from an output of an internal node to a graph output.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_output_graph_edge_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_OUTPUT_GRAPH_EDGE_DESC::GraphOutputIndex">
+    <summary>The index of the graph output to which a connection from an internal node output is specified.</summary>
+  </comment>
+  <comment id="DML_OUTPUT_GRAPH_EDGE_DESC::ToNodeIndex">
+    <summary>The index of the internal node from which the connection to the graph output is specified.</summary>
+  </comment>
+  <comment id="DML_OUTPUT_GRAPH_EDGE_DESC::ToNodeOutputIndex">
+    <summary>The index of the output of the internal node where the connection is specified.</summary>
+  </comment>
+  <comment id="DML_OUTPUT_GRAPH_EDGE_DESC::Name">
+    <summary>An optional name for the graph connection. If provided, this might be used within certain error messages emitted by the DirectML debug layer.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_COUNT_OPERATOR_DESC">
+    <summary>
+      <para>Computes the bitwise population count (the number of bits set to 1) for each element of the input tensor, and writes the result into the output tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_bit_count_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_COUNT_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_COUNT_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_PARAMETERIZED_RELU_OPERATOR_DESC">
+    <summary>
+      <para>Performs a parameterized rectified linear unit (ReLU) activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_parameterized_relu_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_PARAMETERIZED_RELU_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_PARAMETERIZED_RELU_OPERATOR_DESC::SlopeTensor">
+    <summary>A tensor containing the slope for each corresponding value of the input.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_PARAMETERIZED_RELU_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_DEPTH_TO_SPACE1_OPERATOR_DESC">
+    <summary>
+      <para>Rearranges (permutes) data from depth into blocks of spatial data. The operator outputs a copy of the input tensor where values from the depth dimension are moved in spatial blocks to the height and width dimensions.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_depth_to_space1_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_DEPTH_TO_SPACE1_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from. The input tensor's dimensions are <c>{ BatchCount, InputChannelCount, InputHeight, InputWidth }</c>.</summary>
+  </comment>
+  <comment id="DML_DEPTH_TO_SPACE1_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. The output tensor's dimensions are <c>{ BatchCount, OutputChannelCount, OutputHeight, OutputWidth }</c>, where:
+
+* OutputChannelCount is computed as InputChannelCount / (<c>BlockSize</c> * <c>BlockSize</c>)
+* OutputHeight is computed as InputHeight * <c>BlockSize</c>
+* OutputWidth is computed as InputWidth * <c>BlockSize</c></summary>
+  </comment>
+  <comment id="DML_DEPTH_TO_SPACE1_OPERATOR_DESC::BlockSize">
+    <summary>The width and height of the blocks that are moved.</summary>
+  </comment>
+  <comment id="DML_DEPTH_TO_SPACE1_OPERATOR_DESC::Order">
+    <summary>See <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_depth_space_order">DML_DEPTH_SPACE_ORDER</a>.</summary>
+  </comment>
+  <comment id="DML_MAX_UNPOOLING_OPERATOR_DESC">
+    <summary>
+      <para>Inverts a max-pooling operation (see <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling1_operator_desc">DML_MAX_POOLING_OPERATOR1_DESC</a> for details) by filling the output tensor <i>OutputTensor</i> with the values in the input tensor <i>InputTensor</i>, as obtained from a max-pooling operation, according to the index values provided in the <i>IndicesTensor</i>. The elements in the output tensor untouched by this process are left with zero values.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_max_unpooling_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_MAX_UNPOOLING_OPERATOR_DESC::InputTensor">
+    <summary>An input tensor of <i>Sizes</i> <c>{ Batch, Channel, Height, Width }</c>. The tensor values are obtained from the values in the <i>OutputTensor</i> of a max-pooling operation.</summary>
+  </comment>
+  <comment id="DML_MAX_UNPOOLING_OPERATOR_DESC::IndicesTensor">
+    <summary>A tensor of indices to the output tensor <i>OutputTensor</i> for the values given in the input tensor <i>InputTensor</i>. These index values are zero-based, and treat the output tensor as a contiguous one-dimensional array. Both the <i>InputTensor</i> and <i>IndicesTensor</i> have the same tensor sizes. The tensor values are obtained from the <i>OutputIndicesTensor</i> of a max-pooling operation.</summary>
+  </comment>
+  <comment id="DML_MAX_UNPOOLING_OPERATOR_DESC::OutputTensor">
+    <summary>An output tensor of the same number of dimensions as the input tensor.</summary>
+  </comment>
+  <comment id="DML_GEMM_OPERATOR_DESC">
+    <summary>
+      <para>Performs a general matrix multiplication function of the form <c>Output = FusedActivation(Alpha * TransA(A) x TransB(B) + Beta * C)</c>, where <c>x</c> denotes matrix multiplication, and <c>*</c> denotes multiplication with a scalar.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_gemm_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_GEMM_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the A matrix. This tensor's <i>Sizes</i> should be <c>{ BatchCount, ChannelCount, M, K }</c> if <i>TransA</i> is <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_matrix_transform">DML_MATRIX_TRANSFORM_NONE</a>, or <c>{ BatchCount, ChannelCount, K, M }</c> if <i>TransA</i> is <b>DML_MATRIX_TRANSFORM_TRANSPOSE</b>.</summary>
+  </comment>
+  <comment id="DML_GEMM_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the B matrix. This tensor's <i>Sizes</i> should be <c>{ BatchCount, ChannelCount, K, N }</c> if <i>TransB</i> is <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_matrix_transform">DML_MATRIX_TRANSFORM_NONE</a>, or <c>{ BatchCount, ChannelCount, N, K }</c> if <i>TransB</i> is <b>DML_MATRIX_TRANSFORM_TRANSPOSE</b>.</summary>
+  </comment>
+  <comment id="DML_GEMM_OPERATOR_DESC::CTensor">
+    <summary>A tensor containing the C matrix, or <c>nullptr</c>. Values default to 0 when not provided. If provided, this tensor's <i>Sizes</i> should be <c>{ BatchCount, ChannelCount, M, N }</c>.</summary>
+  </comment>
+  <comment id="DML_GEMM_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. This tensor's <i>Sizes</i> are <c>{ BatchCount, ChannelCount, M, N }</c>.</summary>
+  </comment>
+  <comment id="DML_GEMM_OPERATOR_DESC::TransA">
+    <summary>The transform to be applied to <i>ATensor</i>; either a transpose, or no transform.</summary>
+  </comment>
+  <comment id="DML_GEMM_OPERATOR_DESC::TransB">
+    <summary>The transform to be applied to <i>BTensor</i>; either a transpose, or no transform.</summary>
+  </comment>
+  <comment id="DML_GEMM_OPERATOR_DESC::Alpha">
+    <summary>The value of the scalar multiplier for the product of inputs <i>ATensor</i> and <i>BTensor</i>.</summary>
+  </comment>
+  <comment id="DML_GEMM_OPERATOR_DESC::Beta">
+    <summary>The value of the scalar multiplier for the optional input <i>CTensor</i>. If <i>CTensor</i> is not provided, then this value is ignored.</summary>
+  </comment>
+  <comment id="DML_GEMM_OPERATOR_DESC::FusedActivation">
+    <summary>An optional fused activation layer to apply after the GEMM.</summary>
+  </comment>
+  <comment id="IDMLCommandRecorder">
+    <summary>
+      <para>Records dispatches of DirectML work into a Direct3D 12 command list.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nn-directml-idmlcommandrecorder" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_LP_NORMALIZATION_OPERATOR_DESC">
+    <summary>
+      <para>Performs an Lp-normalization function along the specified axis of the input tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_lp_normalization_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_LP_NORMALIZATION_OPERATOR_DESC::InputTensor">
+    <summary>The tensor containing the input data.</summary>
+  </comment>
+  <comment id="DML_LP_NORMALIZATION_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. This tensor's <i>Sizes</i> should match the <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_LP_NORMALIZATION_OPERATOR_DESC::Axis">
+    <summary>The axis on which to apply normalization.</summary>
+  </comment>
+  <comment id="DML_LP_NORMALIZATION_OPERATOR_DESC::Epsilon">
+    <summary>The epsilon value to use to avoid division by zero. A value of 0.00001 is recommended as default.</summary>
+  </comment>
+  <comment id="DML_LP_NORMALIZATION_OPERATOR_DESC::P">
+    <summary>The order of the normalization (either 1 or 2).</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SINH_OPERATOR_DESC">
+    <summary>
+      <para>Computes the hyperbolic sine of each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_sinh_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SINH_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SINH_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SINH_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="IDMLBindingTable">
+    <summary>
+      <para>Wraps a range of an application-managed descriptor heap, and is used by DirectML to create bindings for resources. To create this object, call IDMLDevice::CreateBindingTable.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nn-directml-idmlbindingtable" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC">
+    <summary>
+      <para>Performs a logical XOR (exclusive or) on each pair of corresponding elements of the input tensors, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_logical_xor_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SIGN_OPERATOR_DESC">
+    <summary>
+      <para>Returns a value representing the sign of each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_sign_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SIGN_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SIGN_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_LP_POOLING_OPERATOR_DESC">
+    <summary>
+      <para>Computes the Lp-normalized value across the elements within the sliding window over the input tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_lp_pooling_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_LP_POOLING_OPERATOR_DESC::InputTensor">
+    <summary>An input tensor with <i>Sizes</i> <c>{ BatchCount, ChannelCount, Height, Width }</c> for 4D, and <c>{ BatchCount, ChannelCount, Depth, Height, Width }</c> for 5D.</summary>
+  </comment>
+  <comment id="DML_LP_POOLING_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write to. The <i>Sizes</i> of the output tensor can be computed as follows.
+
+<code>
+OutputTensor-&gt;Sizes[0] = InputTensor-&gt;Sizes[0];
+OutputTensor-&gt;Sizes[1] = InputTensor-&gt;Sizes[1];
+
+for (UINT i = 0; i &lt; DimensionCount; ++i) {
+  UINT PaddedSize = InputTensor-&gt;Sizes[i + 2] + StartPadding[i] + EndPadding[i];
+  OutputTensor-&gt;Sizes[i + 2] = (PaddedSize - WindowSizes[i]) / Strides[i] + 1;
+}
+</code></summary>
+  </comment>
+  <comment id="DML_LP_POOLING_OPERATOR_DESC::DimensionCount">
+    <summary>The number of spatial dimensions of the input tensor <i>InputTensor</i>, which also corresponds to the number of dimensions of the sliding window <i>WindowSize</i>. This value also determines the size of the <i>Strides</i>, <i>StartPadding</i>, and <i>EndPadding</i> arrays. It should be set to 2 when <i>InputTensor</i> is 4D, and 3 when it's a 5D tensor.</summary>
+  </comment>
+  <comment id="DML_LP_POOLING_OPERATOR_DESC::Strides">
+    <summary>An array containing the strides for the sliding window dimensions of sizes <c>{ Height, Width }</c> when the <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_LP_POOLING_OPERATOR_DESC::WindowSize">
+    <summary>An array containing the dimensions of the sliding window in <c>{ Height, Width }</c>when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_LP_POOLING_OPERATOR_DESC::StartPadding">
+    <summary>An array containing the number of padding elements to be applied to the beginning of each spatial dimension of the input tensor <i>InputTensor</i>. The values are in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_LP_POOLING_OPERATOR_DESC::EndPadding">
+    <summary>An array containing the number of padding elements to be applied to the end of each spatial dimension of the input tensor <i>InputTensor</i>. The values are in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_LP_POOLING_OPERATOR_DESC::P">
+    <summary>The value of the <c>P</c> variable in the Lp-normalization function <c>Y = (X1^P + X2^P + ... + Xn^P) ^ (1/P)</c>, where <c>X1</c> to <c>Xn</c> representing each of the values within the sliding window. In common use cases, this value is either set to 1 or 2, representing either the L1 or L2 normalization respectively.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_RECIP_OPERATOR_DESC">
+    <summary>
+      <para>Computes the reciprocal for each element of the input tensor, placing the result into the corresponding element of the output tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_recip_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_RECIP_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from for the first input tensor, x.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_RECIP_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_RECIP_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="IDMLDevice1::CompileGraph">
+    <summary>
+      <para>Compiles a graph of DirectML operators into an object that can be dispatched to the GPU.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldevice1-compilegraph" /></para>
+      <param name="desc">A description of the graph to compile. See <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_graph_desc">DML_GRAPH_DESC</a>.</param>
+      <param name="flags">Any flags to control the execution of this operator.</param>
+      <param name="riid">A reference to the globally unique identifier (GUID) of the interface that you wish to be returned in <i>ppv</i>. This is expected to be the GUID of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlcompiledoperator">IDMLCompiledOperator</a>.</param>
+      <param name="ppv">A pointer to a memory block that receives a pointer to the compiled operator. This is the address of a pointer to an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlcompiledoperator">IDMLCompiledOperator</a>, representing  the compiled operator created.</param>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_OR_OPERATOR_DESC">
+    <summary>
+      <para>Performs a logical OR on each pair of corresponding elements of the input tensors, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_logical_or_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_OR_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_OR_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_OR_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC">
+    <summary>
+      <para>Performs a scaled exponential linear unit (ELU) activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_scaled_elu_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC::Alpha">
+    <summary>The value of alpha. A typical default for this value is 1.6732.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC::Gamma">
+    <summary>The value of gamma. A typical default for this value is 1.0507.</summary>
+  </comment>
+  <comment id="DML_EXECUTION_FLAGS">
+    <summary>
+      <para>Supplies options to DirectML to control execution of operators. These flags can be bitwise OR'd together to specify multiple flags at once.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_execution_flags" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_EXECUTION_FLAGS::DML_EXECUTION_FLAG_NONE">
+    <summary>No execution flags are specified.</summary>
+  </comment>
+  <comment id="DML_EXECUTION_FLAGS::DML_EXECUTION_FLAG_ALLOW_HALF_PRECISION_COMPUTATION">
+    <summary>Allows DirectML to perform computation using half-precision floating-point (FP16), if supported by the hardware device.</summary>
+  </comment>
+  <comment id="DML_EXECUTION_FLAGS::DML_EXECUTION_FLAG_DISABLE_META_COMMANDS">
+    <summary>Forces DirectML execute the operator using DirectCompute instead of meta commands. DirectML uses meta commands by default, if available.</summary>
+  </comment>
+  <comment id="DML_EXECUTION_FLAGS::DML_EXECUTION_FLAG_DESCRIPTORS_VOLATILE">
+    <summary>Allows changes to bindings after an operator's execution has been recorded in a command list, but before it has been submitted to the command queue. By default, without this flag set, you must set all bindings on the binding table before you record an operator into a command list.
+
+This flag allows you to perform late binding—that is, to set (or to change) bindings on operators that you've already recorded into a command list. However, this may result in a performance penalty on some hardware, as it prohibits drivers from promoting static descriptor accesses to root descriptor accesses.
+
+For more info, see <a href="https://docs.microsoft.com/windows/win32/direct3d12/root-signature-version-1-1#descriptors_volatile">DESCRIPTORS_VOLATILE</a>.</summary>
+  </comment>
+  <comment id="DML_FILL_VALUE_CONSTANT_OPERATOR_DESC">
+    <summary>
+      <para>Fills a tensor with the given constant <i>Value</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_fill_value_constant_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_FILL_VALUE_CONSTANT_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. This tensor may have any size.</summary>
+  </comment>
+  <comment id="DML_FILL_VALUE_CONSTANT_OPERATOR_DESC::ValueDataType">
+    <summary>The data type of the <i>Value</i> field, which must match <i>OutputTensor.DataType</i>.</summary>
+  </comment>
+  <comment id="DML_FILL_VALUE_CONSTANT_OPERATOR_DESC::Value">
+    <summary>A constant value to fill the output, with <i>ValueDataType</i> determining how to interpret the field.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CLIP_OPERATOR_DESC">
+    <summary>
+      <para>Performs the following operation for each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>. This operator clamps (or limits) every element in the input within the closed interval [Min, Max].</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_clip_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CLIP_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CLIP_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CLIP_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CLIP_OPERATOR_DESC::Min">
+    <summary>The minimum value, below which the operator replaces the value with <i>Min</i>.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CLIP_OPERATOR_DESC::Max">
+    <summary>The maximum value, above which the operator replaces the value with <i>Max</i>.</summary>
+  </comment>
+  <comment id="DML_PADDING_OPERATOR_DESC">
+    <summary>
+      <para>Inflates the input tensor with constant or mirrored values on the edges, and writes the result to the output.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_padding_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_PADDING_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the input data.</summary>
+  </comment>
+  <comment id="DML_PADDING_OPERATOR_DESC::OutputTensor">
+    <summary>A tensor containing the output data. For each dimension <c>i</c>, <c>OutputTensor.Sizes[i] = InputTensor.Sizes[i] + StartPadding[i] + EndPadding[i]</c>.</summary>
+  </comment>
+  <comment id="DML_PADDING_OPERATOR_DESC::PaddingMode">
+    <summary>The padding mode to use when filling the padding regions.
+
+- <b>DML_PADDING_MODE_CONSTANT</b>. Uses a single constant value defined by <i>PaddingValue</i> for all padding values (see <b>Example 1</b>).
+- <b>DML_PADDING_MODE_EDGE</b>. For each dimension, use the edge values of that dimension for all padding values (see <b>Example 2</b>).
+- <b>DML_PADDING_MODE_REFLECTION</b>. Mirror the values of the tensor as if we folded it right on the edges, which means that edges are not mirrored. Note that <c>StartPadding[i] &gt;= InputTensor.Sizes[i]</c>, and <c>EndPadding[i] &gt;= InputTensor.Sizes[i]</c> is valid, which means that we can mirror new padding regions periodically by folding them over previous padding regions (see <b>Example 3</b>).
+- <b>DML_PADDING_MODE_SYMMETRIC</b>. Similar to <b>DML_PADDING_MODE_REFLECTION</b>, but edges are also mirrored. Note that <c>StartPadding[i] &gt; InputTensor.Sizes[i]</c>, and <c>EndPadding[i] &gt; InputTensor.Sizes[i]</c> is valid, which means that we can mirror new padding regions periodically by folding them over previous padding regions (see <b>Example 4</b>). <b>This mode was introduced in feature level <c>DML_FEATURE_LEVEL_3_0</c></b>.</summary>
+  </comment>
+  <comment id="DML_PADDING_OPERATOR_DESC::PaddingValue">
+    <summary>The padding value to use when <c>PaddingMode == DML_PADDING_MODE_CONSTANT</c>. This value is ignored for other padding modes. Note that if the <i>DataType</i> of the tensors is not <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_tensor_data_type">DML_TENSOR_DATA_TYPE_FLOAT16</a> or <b>DML_TENSOR_DATA_TYPE_FLOAT32</b>, then the value might be truncated (for example, 10.6 will become 10).</summary>
+  </comment>
+  <comment id="DML_PADDING_OPERATOR_DESC::DimensionCount">
+    <summary>The size of the arrays pointed to by <i>StartPadding</i> and <i>EndPadding</i>. This value must be the same value as the dimension count of <i>InputTensor</i> and <i>OutputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_PADDING_OPERATOR_DESC::StartPadding">
+    <summary>The sizes of the padding regions to add at the beginning of each dimension. For each dimension <c>i</c>, <c>StartPadding[i] = OutputTensor.Sizes[i] - InputTensor.Sizes[i] - EndPadding[i]</c>.</summary>
+  </comment>
+  <comment id="DML_PADDING_OPERATOR_DESC::EndPadding">
+    <summary>The sizes of the padding regions to add at the end of each dimension. For each dimension <c>i</c>, <c>EndPadding[i] = OutputTensor.Sizes[i] - InputTensor.Sizes[i] - StartPadding[i]</c>.</summary>
+  </comment>
+  <comment id="DML_CREATE_DEVICE_FLAGS">
+    <summary>
+      <para>Supplies additional device creation options to DMLCreateDevice. Values can be bitwise OR'd together.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_create_device_flags" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_CREATE_DEVICE_FLAGS::DML_CREATE_DEVICE_FLAG_NONE">
+    <summary>No creation options are specified.</summary>
+  </comment>
+  <comment id="DML_CREATE_DEVICE_FLAGS::DML_CREATE_DEVICE_FLAG_DEBUG">
+    <summary>Enables the DirectML debug layers. To use the debug layers, developer mode must be enabled, and the DirectML debug layers must be installed. If the <b>DML_CREATE_DEVICE_FLAG_DEBUG</b> flag is specified and either condition is not met, then <a href="https://docs.microsoft.com/windows/win32/api/directml/nf-directml-dmlcreatedevice">DMLCreateDevice</a> returns <b>DXGI_ERROR_SDK_COMPONENT_MISSING</b>.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MEAN_OPERATOR_DESC">
+    <summary>
+      <para>Averages each pair of corresponding elements of the input tensors, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_mean_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MEAN_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MEAN_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MEAN_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC">
+    <summary>
+      <para>Performs a parametric softplus activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_parametric_softplus_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC::Alpha">
+    <summary>The alpha coefficient.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC::Beta">
+    <summary>The beta coefficient.</summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC">
+    <summary>
+      <para>Computes updated weights (parameters) using the supplied gradients, based on the Adam (<b>ADA</b>ptive <b>M</b>oment estimation) algorithm. This operator is an optimizer, and is typically used in the weight update step of a training loop to perform gradient descent.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_adam_optimizer_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC::InputParametersTensor">
+    <summary>A tensor containing the parameters (weights) to apply this optimizer to. The gradient, first, and second moment estimates, current training step, as well as hyperparameters <i>LearningRate</i>, <i>Beta1</i>, and <i>Beta2</i>, are used by this operator to perform gradient descent on the weight values supplied in this tensor.</summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC::InputFirstMomentTensor">
+    <summary>A tensor containing the first moment estimate of the gradient for each weight value. These values are typically obtained as the result of a previous execution of this operator, via the <i>OutputFirstMomentTensor</i>.
+
+When applying this optimizer to a set of weights for the first time (for example, during the initial training step) the values of this tensor should typically be initialized to zero. Subsequent executions should use the values returned in <i>OutputFirstMomentTensor</i>.
+
+The <i>Sizes</i> and <i>DataType</i> of this tensor must exactly match those of the <i>InputParametersTensor</i>.</summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC::InputSecondMomentTensor">
+    <summary>A tensor containing the second moment estimate of the gradient for each weight value. These values are typically obtained as the result of a previous execution of this operator, via the <i>OutputSecondMomentTensor</i>.
+
+When applying this optimizer to a set of weights for the first time (for example, during the initial training step) the values of this tensor should typically be initialized to zero. Subsequent executions should use the values returned in <i>OutputSecondMomentTensor</i>.
+
+The <i>Sizes</i> and <i>DataType</i> of this tensor must exactly match those of the <i>InputParametersTensor</i>.</summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC::GradientTensor">
+    <summary>The gradients to apply to the input parameters (weights) for gradient descent. Gradients are typically obtained in a backpropagation pass during training.
+
+The <i>Sizes</i> and <i>DataType</i> of this tensor must exactly match those of the <i>InputParametersTensor</i>.</summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC::TrainingStepTensor">
+    <summary>A scalar tensor containing a single integer value representing the current training step count. This value along with <i>Beta1</i> and <i>Beta2</i> is used to compute the exponential decay of the first and second moment estimate tensors.
+
+Typically the training step value starts at 0 at the beginning of training, and is incremented by 1 on each successive training step. This operator doesn't update the training step value; you should do that manually, for example using <a href="https://docs.microsoft.com./DML_ELEMENT_WISE_ADD_OPERATOR_DESC.md">DML_OPERATOR_ELEMENT_WISE_ADD</a>.
+
+This tensor must be a scalar (that is, all <i>Sizes</i> equal to 1) and have data type [<b>DML_TENSOR_DATA_TYPE_UINT32</b>](/windows/win32/api/directml/ne-directml-dml_tensor_data_type).</summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC::OutputParametersTensor">
+    <summary>An output tensor that holds the updated parameter (weight) values after gradient descent is applied.
+
+During binding, this tensor is permitted to alias an eligible input tensor, which can be used to perform an in-place update of this tensor. See the <a href="https://docs.microsoft.com#remarks">Remarks</a> section for more details.
+
+The <i>Sizes</i> and <i>DataType</i> of this tensor must exactly match those of the <i>InputParametersTensor</i>.</summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC::OutputFirstMomentTensor">
+    <summary>An output tensor containing updated first moment estimates. You should store the values of this tensor, and supply them in <i>InputFirstMomentTensor</i> during the subsequent training step.
+
+During binding, this tensor is permitted to alias an eligible input tensor, which can be used to perform an in-place update of this tensor. See the <a href="https://docs.microsoft.com#remarks">Remarks</a> section for more details.
+
+The <i>Sizes</i> and <i>DataType</i> of this tensor must exactly match those of the <i>InputParametersTensor</i>.</summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC::OutputSecondMomentTensor">
+    <summary>An output tensor containing updated second moment estimates. You should store the values of this tensor and supply them in <i>InputSecondMomentTensor</i> during the subsequent training step.
+
+During binding, this tensor is permitted to alias an eligible input tensor, which can be used to perform an in-place update of this tensor. See the <a href="https://docs.microsoft.com#remarks">Remarks</a> section for more details.
+
+The <i>Sizes</i> and <i>DataType</i> of this tensor must exactly match those of the <i>InputParametersTensor</i>.</summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC::LearningRate">
+    <summary>The learning rate, also commonly referred to as the <i>step size</i>. The learning rate is a hyperparameter that determines the magnitude of the weight update along the gradient vector on each training step.</summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC::Beta1">
+    <summary>A hyperparameter representing the exponential decay rate of the gradient's first moment estimate. This value should be between 0.0 and 1.0. A value of 0.9f is typical.</summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC::Beta2">
+    <summary>A hyperparameter representing the exponential decay rate of the gradient's second moment estimate. This value should be between 0.0 and 1.0. A value of 0.999f is typical.</summary>
+  </comment>
+  <comment id="DML_ADAM_OPTIMIZER_OPERATOR_DESC::Epsilon">
+    <summary>A small value used to help numerical stability by preventing division-by-zero. For 32-bit floating-point inputs, typical values include 1e-8 or <c>FLT_EPSILON</c>.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_CELU_OPERATOR_DESC">
+    <summary>
+      <para>Performs the continuously differentiable exponential linear unit (CELU) activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_celu_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_CELU_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_CELU_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_CELU_OPERATOR_DESC::Alpha">
+    <summary>The alpha coefficient. A typical default for this value is 1.0.</summary>
+  </comment>
+  <comment id="DML_FEATURE_LEVEL">
+    <summary>
+      <para>Defines constants that specify a DirectML <i>feature level</i>. A feature level defines a broad umbrella of functionality supported by DirectML.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_feature_level" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_FEATURE_LEVEL::DML_FEATURE_LEVEL_1_0">
+    <summary>Specifies feature level 1_0.</summary>
+  </comment>
+  <comment id="DML_FEATURE_LEVEL::DML_FEATURE_LEVEL_2_0">
+    <summary>Specifies feature level 2_0.</summary>
+  </comment>
+  <comment id="DML_FEATURE_LEVEL::DML_FEATURE_LEVEL_2_1">
+    <summary>Specifies feature level 2_1.</summary>
+  </comment>
+  <comment id="DML_FEATURE_LEVEL::DML_FEATURE_LEVEL_3_0">
+    <summary>Specifies feature level 3_0.</summary>
+  </comment>
+  <comment id="DML_FEATURE_LEVEL::DML_FEATURE_LEVEL_3_1">
+    <summary>Specifies feature level 3_1.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ADD1_OPERATOR_DESC">
+    <summary>
+      <para>Adds every element in <i>ATensor</i> to its corresponding element in <i>BTensor</i> and places the result into the corresponding element of <i>OutputTensor</i>, with the option for fused activation.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_add1_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ADD1_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ADD1_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ADD1_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ADD1_OPERATOR_DESC::FusedActivation">
+    <summary>An optional fused activation layer to apply after the addition.
+
+Fused activation may be used only when the output datatype is <b>FLOAT16</b> or <b>FLOAT32</b>.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_HARDMAX_OPERATOR_DESC">
+    <summary>
+      <para>Performs a hardmax function on each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_hardmax_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_HARDMAX_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from for the input. This tensor must have an <i>effective rank</i> no greater than 2. The effective rank of a tensor is the <i>DimensionCount</i> of the tensor, excluding leftmost dimensions of size 1. For example a tensor size of <c>{ 1, 1, BatchCount, Width }</c> is valid, and is equivalent to a tensor of sizes <c>{ BatchCount, Width }</c>.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_HARDMAX_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="IDMLOperator">
+    <summary>
+      <para>Represents a DirectML operator.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nn-directml-idmloperator" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SIN_OPERATOR_DESC">
+    <summary>
+      <para>Computes the trigonometric sine of each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_sin_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SIN_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SIN_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SIN_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE">
+    <summary>
+      <para>Defines the type of an operator description.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_operator_type" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_INVALID">
+    <summary>Indicates an unknown operator type, and is never valid. Using this value results in an error.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_IDENTITY">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_identity_operator_desc">DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_ABS">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_abs_operator_desc">DML_ELEMENT_WISE_ABS_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_ACOS">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_acos_operator_desc">DML_ELEMENT_WISE_ACOS_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_ADD">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_add_operator_desc">DML_ELEMENT_WISE_ADD_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_ASIN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_asin_operator_desc">DML_ELEMENT_WISE_ASIN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_ATAN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_atan_operator_desc">DML_ELEMENT_WISE_ATAN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_CEIL">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_ceil_operator_desc">DML_ELEMENT_WISE_CEIL_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_CLIP">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_clip_operator_desc">DML_ELEMENT_WISE_CLIP_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_COS">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_cos_operator_desc">DML_ELEMENT_WISE_COS_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_DIVIDE">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_divide_operator_desc">DML_ELEMENT_WISE_DIVIDE_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_EXP">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_exp_operator_desc">DML_ELEMENT_WISE_EXP_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_FLOOR">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_floor_operator_desc">DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_LOG">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_log_operator_desc">DML_ELEMENT_WISE_LOG_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_LOGICAL_AND">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_logical_and_operator_desc">DML_ELEMENT_WISE_LOGICAL_AND_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_LOGICAL_EQUALS">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_logical_equals_operator_desc">DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_LOGICAL_GREATER_THAN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_logical_greater_than_operator_desc">DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_LOGICAL_LESS_THAN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_logical_less_than_operator_desc">DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_LOGICAL_NOT">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_logical_not_operator_desc">DML_ELEMENT_WISE_LOGICAL_NOT_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_LOGICAL_OR">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_logical_or_operator_desc">DML_ELEMENT_WISE_LOGICAL_OR_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_LOGICAL_XOR">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_logical_xor_operator_desc">DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_MAX">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_max_operator_desc">DML_ELEMENT_WISE_MAX_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_MEAN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_mean_operator_desc">DML_ELEMENT_WISE_MEAN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_MIN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_min_operator_desc">DML_ELEMENT_WISE_MIN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_MULTIPLY">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_multiply_operator_desc">DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_POW">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_pow_operator_desc">DML_ELEMENT_WISE_POW_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_CONSTANT_POW">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_constant_pow_operator_desc">DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_RECIP">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_recip_operator_desc">DML_ELEMENT_WISE_RECIP_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_SIN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_sin_operator_desc">DML_ELEMENT_WISE_SIN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_SQRT">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_sqrt_operator_desc">DML_ELEMENT_WISE_SQRT_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_SUBTRACT">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_subtract_operator_desc">DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_TAN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_tan_operator_desc">DML_ELEMENT_WISE_TAN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_THRESHOLD">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_threshold_operator_desc">DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_QUANTIZE_LINEAR">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_quantize_linear_operator_desc">DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_DEQUANTIZE_LINEAR">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_dequantize_linear_operator_desc">DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_ELU">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_elu_operator_desc">DML_ACTIVATION_ELU_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_HARDMAX">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_hardmax_operator_desc">DML_ACTIVATION_HARDMAX_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_HARD_SIGMOID">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_hard_sigmoid_operator_desc">DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_IDENTITY">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_identity_operator_desc">DML_ACTIVATION_IDENTITY_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_LEAKY_RELU">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_leaky_relu_operator_desc">DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_LINEAR">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_linear_operator_desc">DML_ACTIVATION_LINEAR_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_LOG_SOFTMAX">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_log_softmax_operator_desc">DML_ACTIVATION_LOG_SOFTMAX_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_PARAMETERIZED_RELU">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_parameterized_relu_operator_desc">DML_ACTIVATION_PARAMETERIZED_RELU_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_PARAMETRIC_SOFTPLUS">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_parametric_softplus_operator_desc">DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_RELU">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_relu_operator_desc">DML_ACTIVATION_RELU_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_SCALED_ELU">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_scaled_elu_operator_desc">DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_SCALED_TANH">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_scaled_tanh_operator_desc">DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_SIGMOID">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_sigmoid_operator_desc">DML_ACTIVATION_SIGMOID_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_SOFTMAX">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_softmax_operator_desc">DML_ACTIVATION_SOFTMAX_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_SOFTPLUS">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_softplus_operator_desc">DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_SOFTSIGN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_softsign_operator_desc">DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_TANH">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_tanh_operator_desc">DML_ACTIVATION_TANH_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_THRESHOLDED_RELU">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_thresholded_relu_operator_desc">DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_CONVOLUTION">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_convolution_operator_desc">DML_CONVOLUTION_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_GEMM">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_gemm_operator_desc">DML_GEMM_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_REDUCE">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_reduce_operator_desc">DML_REDUCE_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_AVERAGE_POOLING">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_average_pooling_operator_desc">DML_AVERAGE_POOLING_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_LP_POOLING">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_lp_pooling_operator_desc">DML_LP_POOLING_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_MAX_POOLING">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling_operator_desc">DML_MAX_POOLING_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ROI_POOLING">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_roi_pooling_operator_desc">DML_ROI_POOLING_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_SLICE">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_slice_operator_desc">DML_SLICE_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_CAST">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_cast_operator_desc">DML_CAST_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_SPLIT">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_split_operator_desc">DML_SPLIT_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_JOIN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_join_operator_desc">DML_JOIN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_PADDING">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_padding_operator_desc">DML_PADDING_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_VALUE_SCALE_2D">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_value_scale_2d_operator_desc">DML_VALUE_SCALE_2D_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_UPSAMPLE_2D">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_upsample_2d_operator_desc">DML_UPSAMPLE_2D_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_GATHER">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_gather_operator_desc">DML_GATHER_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_SPACE_TO_DEPTH">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_space_to_depth_operator_desc">DML_SPACE_TO_DEPTH_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_DEPTH_TO_SPACE">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_depth_to_space_operator_desc">DML_DEPTH_TO_SPACE_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_TILE">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_tile_operator_desc">DML_TILE_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_TOP_K">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_top_k_operator_desc">DML_TOP_K_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_BATCH_NORMALIZATION">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_batch_normalization_operator_desc">DML_BATCH_NORMALIZATION_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_MEAN_VARIANCE_NORMALIZATION">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_mean_variance_normalization_operator_desc">DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_LOCAL_RESPONSE_NORMALIZATION">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_local_response_normalization_operator_desc">DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_LP_NORMALIZATION">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_lp_normalization_operator_desc">DML_LP_NORMALIZATION_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_RNN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_rnn_operator_desc">DML_RNN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_LSTM">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_lstm_operator_desc">DML_LSTM_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_GRU">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_gru_operator_desc">DML_GRU_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_SIGN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_sign_operator_desc">DML_ELEMENT_WISE_SIGN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_IS_NAN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_is_nan_operator_desc">DML_ELEMENT_WISE_IS_NAN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_ERF">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_erf_operator_desc">DML_ELEMENT_WISE_ERF_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_SINH">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_sinh_operator_desc">DML_ELEMENT_WISE_SINH_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_COSH">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_cosh_operator_desc">DML_ELEMENT_WISE_COSH_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_TANH">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_tanh_operator_desc">DML_ELEMENT_WISE_TANH_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_ASINH">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_asinh_operator_desc">DML_ELEMENT_WISE_ASINH_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_ACOSH">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_acosh_operator_desc">DML_ELEMENT_WISE_ACOSH_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_ATANH">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_atanh_operator_desc">DML_ELEMENT_WISE_ATANH_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_IF">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_if_operator_desc">DML_ELEMENT_WISE_IF_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_ADD1">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_add1_operator_desc">DML_ELEMENT_WISE_ADD1_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_SHRINK">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_shrink_operator_desc">DML_ACTIVATION_SHRINK_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_MAX_POOLING1">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling1_operator_desc">DML_MAX_POOLING1_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_MAX_UNPOOLING">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_unpooling_operator_desc">DML_MAX_UNPOOLING_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_DIAGONAL_MATRIX">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_diagonal_matrix_operator_desc">DML_DIAGONAL_MATRIX_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_SCATTER">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_scatter_operator_desc">DML_SCATTER_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ONE_HOT">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_one_hot_operator_desc">DML_ONE_HOT_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_RESAMPLE">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_resample_operator_desc">DML_RESAMPLE_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_CELU">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_celu_operator_desc">DML_ACTIVATION_CELU_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_RELU_GRAD">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_relu_grad_operator_desc">DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ADAM_OPTIMIZER">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_adam_optimizer_operator_desc">DML_ADAM_OPTIMIZER_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ARGMAX">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_argmax_operator_desc">DML_ARGMAX_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ARGMIN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_argmin_operator_desc">DML_ARGMIN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_AVERAGE_POOLING_GRAD">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_average_pooling_grad_operator_desc">DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_CONVOLUTION_INTEGER">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_convolution_integer_operator_desc">DML_CONVOLUTION_INTEGER_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_CUMULATIVE_SUMMATION">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_cumulative_summation_operator_desc">DML_CUMULATIVE_SUMMATION_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_DEPTH_TO_SPACE1">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_depth_to_space1_operator_desc">DML_DEPTH_TO_SPACE1_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_BIT_AND">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_bit_and_operator_desc">DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_BIT_COUNT">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_bit_count_operator_desc">DML_ELEMENT_WISE_BIT_COUNT_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_BIT_NOT">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_bit_not_operator_desc">DML_ELEMENT_WISE_BIT_NOT_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_BIT_OR">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_bit_or_operator_desc">DML_ELEMENT_WISE_BIT_OR_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_BIT_SHIFT_LEFT">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_bit_shift_left_operator_desc">DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_BIT_SHIFT_RIGHT">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_bit_shift_right_operator_desc">DML_ELEMENT_WISE_BIT_SHIFT_RIGHT_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_BIT_XOR">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_bit_xor_operator_desc">DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_IS_INFINITY">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_is_infinity_operator_desc">DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_logical_greater_than_or_equal_operator_desc">DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_logical_less_than_or_equal_operator_desc">DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_MODULUS_FLOOR">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_modulus_floor_operator_desc">DML_ELEMENT_WISE_MODULUS_FLOOR_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_MODULUS_TRUNCATE">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_modulus_truncate_operator_desc">DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_ROUND">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_element_wise_round_operator_desc">DML_ELEMENT_WISE_ROUND_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_FILL_VALUE_CONSTANT">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_fill_value_constant_operator_desc">DML_FILL_VALUE_CONSTANT_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_FILL_VALUE_SEQUENCE">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_fill_value_sequence_operator_desc">DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_GATHER_ELEMENTS">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_gather_elements_operator_desc">DML_GATHER_ELEMENTS_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_GATHER_ND">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_gather_nd_operator_desc">DML_GATHER_ND_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_GATHER_ND1">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_gather_nd1_operator_desc">DML_GATHER_ND1_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_MATRIX_MULTIPLY_INTEGER">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_matrix_multiply_integer_operator_desc">DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_MAX_POOLING_GRAD">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling_grad_operator_desc">DML_MAX_POOLING_GRAD_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_MAX_POOLING2">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_max_pooling2_operator_desc">DML_MAX_POOLING2_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_MEAN_VARIANCE_NORMALIZATION1">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_mean_variance_normalization1_operator_desc">DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_NONZERO_COORDINATES">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_nonzero_coordinates_operator_desc">DML_NONZERO_COORDINATES_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_QUANTIZED_LINEAR_CONVOLUTION">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_quantized_linear_convolution_operator_desc">DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_QUANTIZED_LINEAR_MATRIX_MULTIPLY">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_quantized_linear_matrix_multiply_operator_desc">DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_RANDOM_GENERATOR">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_random_generator_operator_desc">DML_RANDOM_GENERATOR_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_RESAMPLE_GRAD">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_resample_grad_operator_desc">DML_RESAMPLE_GRAD_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_RESAMPLE1">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_resample1_operator_desc">DML_RESAMPLE1_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_REVERSE_SUBSEQUENCES">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_reverse_subsequences_operator_desc">DML_REVERSE_SUBSEQUENCES_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ROI_ALIGN">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_roi_align_operator_desc">DML_ROI_ALIGN_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_SCATTER_ND">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_scatter_nd_operator_desc">DML_SCATTER_ND_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_SLICE_GRAD">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_slice_grad_operator_desc">DML_SLICE_GRAD_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_SLICE1">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_slice1_operator_desc">DML_SLICE1_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_SPACE_TO_DEPTH1">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_space_to_depth1_operator_desc">DML_SPACE_TO_DEPTH1_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_TOP_K1">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_top_k1_operator_desc">DML_TOP_K1_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_BATCH_NORMALIZATION_GRAD">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/direct3d12/directml/ns-directml-dml_batch_normalization_grad_operator_desc">DML_BATCH_NORMALIZATION_GRAD_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_CUMULATIVE_PRODUCT">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/direct3d12/directml/ns-directml-dml_cumulative_product_operator_desc">DML_CUMULATIVE_PRODUCT_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_ATAN_YX">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/direct3d12/directml/ns-directml-dml_element_wise_atan_yx_operator_desc">DML_ELEMENT_WISE_ATAN_YX_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_CLIP_GRAD">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/direct3d12/directml/ns-directml-dml_element_wise_clip_grad_operator_desc">DML_ELEMENT_WISE_CLIP_GRAD_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ELEMENT_WISE_DIFFERENCE_SQUARE">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/direct3d12/directml/ns-directml-dml_element_wise_difference_square_operator_desc">DML_ELEMENT_WISE_DIFFERENCE_SQUARE_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_LOCAL_RESPONSE_NORMALIZATION_GRAD">
+    <summary>Indicates the operator described by the <a href="https://docs.microsoft.com/windows/win32/direct3d12/directml/ns-directml-dml_local_response_normalization_grad_operator_desc">DML_LOCAL_RESPONSE_NORMALIZATION_GRAD_OPERATOR_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC">
+    <summary>
+      <para>Performs the softsign function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_softsign_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DESC">
+    <summary>
+      <para>Performs a logical left shift of each element of <i>ATensor</i> by a number of bits given by the corresponding element of <i>BTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_bit_shift_left_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MODULUS_FLOOR_OPERATOR_DESC">
+    <summary>
+      <para>Computes the modulus, with the same results as the Python modulus, for each pair of corresponding elements from the input tensors, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_modulus_floor_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MODULUS_FLOOR_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MODULUS_FLOOR_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MODULUS_FLOOR_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_SCALE_BIAS">
+    <summary>
+      <para>Contains the values of scale and bias terms supplied to a DirectML operator. Scale and bias have the effect of applying the function g(x) = x * Scale + Bias.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_scale_bias" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SCALE_BIAS::Scale">
+    <summary>The scale term in g(x) = x * <i>Scale</i> + <i>Bias</i>.</summary>
+  </comment>
+  <comment id="DML_SCALE_BIAS::Bias">
+    <summary>The bias term in g(x) = x * <i>Scale</i> + <i>Bias</i>.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_OPERATOR_DESC">
+    <summary>
+      <para>Averages values across the elements within the sliding window over the input tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_average_pooling_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_OPERATOR_DESC::InputTensor">
+    <summary>An input tensor of <i>Sizes</i> <c>{ BatchCount, ChannelCount, Height, Width }</c> for 4D, and <c>{ BatchCount, ChannelCount, Depth, Height, Weight }</c> for 5D.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_OPERATOR_DESC::OutputTensor">
+    <summary>A description of the output tensor. The sizes of the output tensor can be computed as follows.
+
+<code>
+OutputTensor-&gt;Sizes[0] = InputTensor-&gt;Sizes[0];
+OutputTensor-&gt;Sizes[1] = InputTensor-&gt;Sizes[1];
+
+for (UINT i = 0; i &lt; DimensionCount; ++i) {
+    UINT PaddedSize = InputTensor-&gt;Sizes[i + 2] + StartPadding[i] + EndPadding[i];
+    OutputTensor-&gt;Sizes[i + 2] = (PaddedSize - WindowSizes[i]) / Strides[i] + 1;
+}
+</code></summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_OPERATOR_DESC::DimensionCount">
+    <summary>The number of spatial dimensions of the input tensor <i>InputTensor</i>, which also corresponds to the number of dimensions of the sliding window <i>WindowSize</i>. This value also determines the size of the <i>Strides</i>, <i>StartPadding</i>, and <i>EndPadding</i> arrays. It should be set to 2 when <i>InputTensor</i> is 4D, and 3 when it's a 5D tensor.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_OPERATOR_DESC::Strides">
+    <summary>The strides for the sliding window dimensions of sizes <c>{ Height, Width }</c> when the <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_OPERATOR_DESC::WindowSize">
+    <summary>The dimensions of the sliding window in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_OPERATOR_DESC::StartPadding">
+    <summary>The number of padding elements to be applied to the beginning of each spatial dimension of the input tensor <i>InputTensor</i>. The values are in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_OPERATOR_DESC::EndPadding">
+    <summary>The number of padding elements to be applied to the end of each spatial dimension of the input tensor <i>InputTensor</i>. The values are in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_AVERAGE_POOLING_OPERATOR_DESC::IncludePadding">
+    <summary>Indicates whether to include the padding elements around the spatial edges when calculating the average value across all elements within the sliding window. When the value is set to <b>FALSE</b>, the padding elements are not counted as part of the divisor value of the averaging calculation.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DESC">
+    <summary>
+      <para>Performs a logical <i>equals</i> on each pair of corresponding elements of the input tensors, placing the result (1 for true, 0 for false) into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_logical_equals_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_SHIFT_RIGHT_OPERATOR_DESC">
+    <summary>
+      <para>Performs a logical right shift of each element of <i>ATensor</i> by a number of bits given by the corresponding element of <i>BTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_bit_shift_right_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_SHIFT_RIGHT_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_SHIFT_RIGHT_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_SHIFT_RIGHT_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_CAST_OPERATOR_DESC">
+    <summary>
+      <para>Casts each element in the input to the data type of the output tensor, and stores the result in the corresponding element of the output.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_cast_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_CAST_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to write the results to. This tensor's <i>Sizes</i> should match <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_CAST_OPERATOR_DESC::OutputTensor">
+    <summary>A pointer to a constant <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_tensor_desc">DML_TENSOR_DESC</a> containing the description of the tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_GRAPH_DESC">
+    <summary>
+      <para>Describes a graph of DirectML operators used to compile a combined, optimized operator.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_graph_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_GRAPH_DESC::InputCount">
+    <summary>The number of inputs of the overall graph. Each graph input may be connected to a variable number of internal nodes, therefore this may be different from <i>InputEdgeCount</i>.</summary>
+  </comment>
+  <comment id="DML_GRAPH_DESC::OutputCount">
+    <summary>The number of outputs of the overall graph. Each graph output may be connected to a variable number of internal nodes, therefore this may be different from <i>OutputEdgeCount</i>.</summary>
+  </comment>
+  <comment id="DML_GRAPH_DESC::NodeCount">
+    <summary>The number of internal nodes in the graph.</summary>
+  </comment>
+  <comment id="DML_GRAPH_DESC::Nodes">
+    <summary>The internal nodes in the graph.</summary>
+  </comment>
+  <comment id="DML_GRAPH_DESC::InputEdgeCount">
+    <summary>The number of connections between graph inputs and inputs of internal nodes in the graph.</summary>
+  </comment>
+  <comment id="DML_GRAPH_DESC::InputEdges">
+    <summary>An array of connections between graph inputs and inputs of internal nodes in the graph. The <i>Type</i> field within each element should be set to <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_graph_edge_type">DML_GRAPH_EDGE_TYPE_INPUT</a>.</summary>
+  </comment>
+  <comment id="DML_GRAPH_DESC::OutputEdgeCount">
+    <summary>The number of connections between graph outputs and outputs of internal nodes in the graph.</summary>
+  </comment>
+  <comment id="DML_GRAPH_DESC::OutputEdges">
+    <summary>An array of connections between graph outputs and outputs of internal nodes in the graph. The <i>Type</i> field within each element should be set to <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_graph_edge_type">DML_GRAPH_EDGE_TYPE_OUTPUT</a>.</summary>
+  </comment>
+  <comment id="DML_GRAPH_DESC::IntermediateEdgeCount">
+    <summary>The number of internal connections between nodes in the graph.</summary>
+  </comment>
+  <comment id="DML_GRAPH_DESC::IntermediateEdges">
+    <summary>An array of connections between inputs and outputs of internal nodes in the graph. The Type field within each element should be set to <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_graph_edge_type">DML_GRAPH_EDGE_TYPE_INTERMEDIATE</a></summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_MODE">
+    <summary>
+      <para>Defines constants that specify a mode for the DirectML convolution operator (as described by the DML_CONVOLUTION_OPERATOR_DESC structure).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_convolution_mode" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_MODE::DML_CONVOLUTION_MODE_CONVOLUTION">
+    <summary>Specifies the convolution mode.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_MODE::DML_CONVOLUTION_MODE_CROSS_CORRELATION">
+    <summary>Specifies the cross-correlation mode. If in doubt, use this mode—it is appropriate for the vast majority of machine learning (ML) models.</summary>
+  </comment>
+  <comment id="DML_TILE_OPERATOR_DESC">
+    <summary>
+      <para>Constructs an output tensor by tiling the input tensor. The elements in each dimension of the input tensor are repeated by a multiple in the <i>Repeats</i> array.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_tile_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_TILE_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from, which contains the elements to be tiled.</summary>
+  </comment>
+  <comment id="DML_TILE_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write to, which will hold the tiled output. For each dimension <c>i</c> in <c>[0, InputTensor.DimensionCount-1]</c>, the output size is calculated as <c>OutputTensor.Sizes[i] = InputTensor.Sizes[i] * Repeats[i]</c>. This tensor must have the same <i>DimensionCount</i> as the input tensor.</summary>
+  </comment>
+  <comment id="DML_TILE_OPERATOR_DESC::RepeatsCount">
+    <summary>This field determines the size of the <i>Repeats</i> array. This value must be the same as the <i>InputTensor.DimensionCount</i>.</summary>
+  </comment>
+  <comment id="DML_TILE_OPERATOR_DESC::Repeats">
+    <summary>Each value in this array corresponds to one of the input tensor's dimensions (in order). Each value is the number of tiled copies to make of that dimension. Values must be larger than 0.</summary>
+  </comment>
+  <comment id="IDMLObject">
+    <summary>
+      <para>An interface from which IDMLDevice and IDMLDeviceChild inherit directly (and all other interfaces, indirectly).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nn-directml-idmlobject" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_TENSOR_DATA_TYPE">
+    <summary>
+      <para>Specifies the data type of the values in a tensor. DirectML operators may not support all data types; see the documentation for each specific operator to find which data types it supports.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_tensor_data_type" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_TENSOR_DATA_TYPE::DML_TENSOR_DATA_TYPE_UNKNOWN">
+    <summary>Indicates an unknown data type. This value is never valid.</summary>
+  </comment>
+  <comment id="DML_TENSOR_DATA_TYPE::DML_TENSOR_DATA_TYPE_FLOAT32">
+    <summary>Indicates a 32-bit floating-point data type.</summary>
+  </comment>
+  <comment id="DML_TENSOR_DATA_TYPE::DML_TENSOR_DATA_TYPE_FLOAT16">
+    <summary>Indicates a 16-bit floating-point data type.</summary>
+  </comment>
+  <comment id="DML_TENSOR_DATA_TYPE::DML_TENSOR_DATA_TYPE_UINT32">
+    <summary>Indicates a 32-bit unsigned integer data type.</summary>
+  </comment>
+  <comment id="DML_TENSOR_DATA_TYPE::DML_TENSOR_DATA_TYPE_UINT16">
+    <summary>Indicates a 16-bit unsigned integer data type.</summary>
+  </comment>
+  <comment id="DML_TENSOR_DATA_TYPE::DML_TENSOR_DATA_TYPE_UINT8">
+    <summary>Indicates a 8-bit unsigned integer data type.</summary>
+  </comment>
+  <comment id="DML_TENSOR_DATA_TYPE::DML_TENSOR_DATA_TYPE_INT32">
+    <summary>Indicates a 32-bit signed integer data type.</summary>
+  </comment>
+  <comment id="DML_TENSOR_DATA_TYPE::DML_TENSOR_DATA_TYPE_INT16">
+    <summary>Indicates a 16-bit signed integer data type.</summary>
+  </comment>
+  <comment id="DML_TENSOR_DATA_TYPE::DML_TENSOR_DATA_TYPE_INT8">
+    <summary>Indicates a 8-bit signed integer data type.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC">
+    <summary>
+      <para>Computes the bitwise AND between each corresponding element of the input tensors, and writes the result into the output tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_bit_and_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ROI_ALIGN_OPERATOR_DESC">
+    <summary>
+      <para>Performs an ROI Align operation, as described in the [Mask R-CNN paper](https://arxiv.org/abs/1703.06870). In summary, the operation extracts crops from the input image tensor and resizes them to a common output size specified by the last 2 dimensions of <i>OutputTensor</i> using the specified <i>InterpolationMode</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_roi_align_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ROI_ALIGN_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the input data with dimensions <c>{ BatchCount, ChannelCount, InputHeight, InputWidth }</c>.</summary>
+  </comment>
+  <comment id="DML_ROI_ALIGN_OPERATOR_DESC::ROITensor">
+    <summary>A tensor containing the regions of interest (ROI) data. The allowed dimensions of <c>ROITensor</c> are <c>{ NumROIs, 4 }</c>, <c>{ 1, NumROIs, 4 }</c>, or <c>{ 1, 1, NumROIs, 4 }</c>. For each ROI, the values will be the coordinates of its top-left and bottom-right corners in the order <c>[x1, y1, x2, y2]</c>.</summary>
+  </comment>
+  <comment id="DML_ROI_ALIGN_OPERATOR_DESC::BatchIndicesTensor">
+    <summary>A tensor containing the batch indices to extract the ROIs from. The allowed dimensions of <c>BatchIndicesTensor</c> are <c>{ NumROIs }</c>, <c>{ 1, NumROIs }</c>, <c>{ 1, 1, NumROIs }</c>, or <c>{ 1, 1, 1, NumROIs }</c>. Each value is the index of a batch from <i>InputTensor</i>. The behavior is undefined if the values are not in the range [0, BatchCount).</summary>
+  </comment>
+  <comment id="DML_ROI_ALIGN_OPERATOR_DESC::OutputTensor">
+    <summary>A tensor containing the output data. The expected dimensions of <i>OutputTensor</i> are <c>{ NumROIs, ChannelCount, OutputHeight, OutputWidth }</c>.</summary>
+  </comment>
+  <comment id="DML_ROI_ALIGN_OPERATOR_DESC::ReductionFunction">
+    <summary>The reduction function to use when reducing across all input samples that contribute to an output element (<a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_reduce_function">DML_REDUCE_FUNCTION_AVERAGE</a> or <b>DML_REDUCE_FUNCTION_MAX</b>). The number of input samples to reduce across is bounded by <i>MinimumSamplesPerOutput</i> and <i>MaximumSamplesPerOutput</i>.</summary>
+  </comment>
+  <comment id="DML_ROI_ALIGN_OPERATOR_DESC::InterpolationMode">
+    <summary>The interpolation mode to use when resizing the regions.
+
+- <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_interpolation_mode">DML_INTERPOLATION_MODE_NEAREST_NEIGHBOR</a>. Uses the <i>Nearest Neighbor</i> algorithm, which chooses the input element nearest to the corresponding pixel center for each output element.
+- <b>DML_INTERPOLATION_MODE_LINEAR</b>. Uses the <i>Bilinear</i> algorithm, which computes the output element by doing the weighted average of the 2 nearest neighboring input elements per dimension. Since only 2 dimensions are resized, the weighted average is computed on a total of 4 input elements for each output element.</summary>
+  </comment>
+  <comment id="DML_ROI_ALIGN_OPERATOR_DESC::SpatialScaleX">
+    <summary>The X (or width) component of the scaling factor to multiply the <i>ROITensor</i> coordinates by in order to make them proportionate to <i>InputHeight</i> and <i>InputWidth</i>. For example, if <i>ROITensor</i> contains normalized coordinates (values in the range [0..1]), then <i>SpatialScaleX</i> would usually have the same value as <i>InputWidth</i>.</summary>
+  </comment>
+  <comment id="DML_ROI_ALIGN_OPERATOR_DESC::SpatialScaleY">
+    <summary>The Y (or height) component of the scaling factor to multiply the <i>ROITensor</i> coordinates by in order to make them proportionate to <i>InputHeight</i> and <i>InputWidth</i>. For example, if <i>ROITensor</i> contains normalized coordinates (values in the range [0..1]), <i>SpatialScaleY</i> would usually have the same value as <i>InputHeight</i>.</summary>
+  </comment>
+  <comment id="DML_ROI_ALIGN_OPERATOR_DESC::OutOfBoundsInputValue">
+    <summary>The value to read from <i>InputTensor</i> when the ROIs are outside the bounds of <i>InputTensor</i>. This can happen when the values obtained after scaling <i>ROITensor</i> by <i>SpatialScaleX</i> and <i>SpatialScaleY</i> are bigger than <i>InputWidth</i> and <i>InputHeight</i>.</summary>
+  </comment>
+  <comment id="DML_ROI_ALIGN_OPERATOR_DESC::MinimumSamplesPerOutput">
+    <summary>The minimum number of input samples to use for every output element. The operator will calculate the number of input samples by doing <c>ScaledCropSize / OutputSize</c>, and then clamp it to <i>MinimumSamplesPerOutput</i> and <i>MaximumSamplesPerOutput</i>.</summary>
+  </comment>
+  <comment id="DML_ROI_ALIGN_OPERATOR_DESC::MaximumSamplesPerOutput">
+    <summary>The maximum number of input samples to use for every output element. The operator will calculate the number of input samples by doing <c>ScaledCropSize / OutputSize</c>, and then clamp it to <i>MinimumSamplesPerOutput</i> and <i>MaximumSamplesPerOutput</i>.</summary>
+  </comment>
+  <comment id="DML_BINDING_TYPE">
+    <summary>
+      <para>Defines constants that specify the nature of the resource(s) referred to by a binding description (a DML_BINDING_DESC structure).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_binding_type" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_BINDING_TYPE::DML_BINDING_TYPE_NONE">
+    <summary>Indicates that no resources are to be bound.</summary>
+  </comment>
+  <comment id="DML_BINDING_TYPE::DML_BINDING_TYPE_BUFFER">
+    <summary>Specifies a binding that binds a single buffer to the binding table. The corresponding binding desc type is <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_buffer_binding">DML_BUFFER_BINDING</a>.</summary>
+  </comment>
+  <comment id="DML_BINDING_TYPE::DML_BINDING_TYPE_BUFFER_ARRAY">
+    <summary>Specifies a binding that binds an array of buffers to the binding table. The corresponding binding desc type is <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_buffer_array_binding">DML_BUFFER_ARRAY_BINDING</a>.</summary>
+  </comment>
+  <comment id="IDMLBindingTable::BindPersistentResource">
+    <summary>
+      <para>Binds a buffer as a persistent resource. You can determine the required size of this buffer range by calling IDMLDispatchable::GetBindingProperties.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmlbindingtable-bindpersistentresource" /></para>
+      <param name="binding">An optional pointer to a <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_binding_desc">DML_BINDING_DESC</a> containing the description of a tensor resource to bind.</param>
+    </summary>
+  </comment>
+  <comment id="DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC">
+    <summary>
+      <para>Fills a tensor with a sequence.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_fill_value_sequence_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. This tensor may have any size.</summary>
+  </comment>
+  <comment id="DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC::ValueDataType">
+    <summary>The data type of <i>Value</i> field, which must match <i>OutputTensor.DataType</i>.</summary>
+  </comment>
+  <comment id="DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC::ValueStart">
+    <summary>The initial value to fill the first element in the output, with <i>ValueDataType</i> determining how to interpret the field.</summary>
+  </comment>
+  <comment id="DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC::ValueDelta">
+    <summary>A step to add to the value for each element written, with <i>ValueDataType</i> determining how to interpret the field.</summary>
+  </comment>
+  <comment id="DML_ARGMAX_OPERATOR_DESC">
+    <summary>
+      <para>Outputs the indices of the maximum-valued elements within one or more dimensions of the input tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_argmax_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ARGMAX_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ARGMAX_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. Each output element is the result of an <i>argmax</i> reduction on a subset of elements from the <i>InputTensor</i>. 
+
+- <i>DimensionCount</i> must match <i>InputTensor.DimensionCount</i> (the rank of the input tensor is preserved).
+- <i>Sizes</i> must match <i>InputTensor.Sizes</i>, except for dimensions included in the reduced <i>Axes</i>, which must be size 1.</summary>
+  </comment>
+  <comment id="DML_ARGMAX_OPERATOR_DESC::AxisCount">
+    <summary>The number of axes to reduce. This field determines the size of the <i>Axes</i> array.</summary>
+  </comment>
+  <comment id="DML_ARGMAX_OPERATOR_DESC::Axes">
+    <summary>The axes along which to reduce. Values must be in the range <c>[0, InputTensor.DimensionCount - 1]</c>.</summary>
+  </comment>
+  <comment id="DML_ARGMAX_OPERATOR_DESC::AxisDirection">
+    <summary>Determines which index to select when multiple input elements have the same value.
+- <b>DML_AXIS_DIRECTION_INCREASING</b> returns the index of the first maximum-valued element (for example, <c>argmax({3,2,1,2,3}) = 0</c>)
+- <b>DML_AXIS_DIRECTION_DECREASING</b> returns the index of the last maximum-valued element (for example, <c>argmax({3,2,1,2,3}) = 4</c>)</summary>
+  </comment>
+  <comment id="IDMLDevice::CheckFeatureSupport">
+    <summary>
+      <para>Gets information about the optional features and capabilities that are supported by the DirectML device.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldevice-checkfeaturesupport" /></para>
+      <param name="feature">A constant from the <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_feature">DML_FEATURE</a> enumeration describing the feature(s) that you want to query for support.</param>
+      <param name="featureQueryDataSize">The size of the structure pointed to by the <i>featureQueryData</i> parameter, if provided, otherwise 0.</param>
+      <param name="featureQueryData">An optional pointer to a query structure that corresponds to the value of the <i>feature</i> parameter. To determine the corresponding query type for each constant, see <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_feature">DML_FEATURE</a>.</param>
+      <param name="featureSupportDataSize">The size of the structure pointed to by the <i>featureSupportData</i> parameter.</param>
+      <param name="featureSupportData">A pointer to a support data structure that corresponds to the value of the <i>feature</i> parameter. To determine the corresponding support data type for each constant, see <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_feature">DML_FEATURE</a>.</param>
+    </summary>
+  </comment>
+  <comment id="DML_TOP_K_OPERATOR_DESC">
+    <summary>
+      <para>Selects the largest <i>K</i> elements from each sequence along an axis of the <i>InputTensor</i>, and returns the values and indices of those elements in the <i>OutputValueTensor</i> and <i>OutputIndexTensor</i>, respectively.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_top_k_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_TOP_K_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor containing elements to select.</summary>
+  </comment>
+  <comment id="DML_TOP_K_OPERATOR_DESC::OutputValueTensor">
+    <summary>The output tensor to write the values of the top <i>K</i> elements to. This tensor must have sizes equal to the <i>InputTensor</i>, <i>except</i> for the dimension specified by the <i>Axis</i> parameter, which must have a size equal to <i>K</i>.
+
+The <i>K</i> values selected from each input sequence are guaranteed to be sorted descending (largest to smallest).</summary>
+  </comment>
+  <comment id="DML_TOP_K_OPERATOR_DESC::OutputIndexTensor">
+    <summary>The output tensor to write the indices of the top <i>K</i> elements to. This tensor must have sizes equal to the <i>InputTensor</i>, <i>except</i> for the dimension specified by the <i>Axis</i> parameter, which must have a size equal to <i>K</i>.
+
+The indices returned in this tensor are measured relative to the beginning of their sequence (as opposed to the beginning of the tensor). For example, an index of 0 always refers to the first element for all sequences in an axis.
+
+In cases where two or more elements in the top-K have the same value (that is, when there is a tie), the indices of both elements are included, and are guaranteed to be ordered by ascending element index.</summary>
+  </comment>
+  <comment id="DML_TOP_K_OPERATOR_DESC::Axis">
+    <summary>The index of the dimension to select elements across. This value must be less than the <i>DimensionCount</i> of the <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_TOP_K_OPERATOR_DESC::K">
+    <summary>The number of elements to select. <i>K</i> must be greater than 0, but less than the number of elements in the <i>InputTensor</i> along the dimension specified by <i>Axis</i>.</summary>
+  </comment>
+  <comment id="DML_FEATURE_DATA_FEATURE_LEVELS">
+    <summary>
+      <para>Provides detail about the feature levels supported by a DirectML device.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_feature_data_feature_levels" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_FEATURE_DATA_FEATURE_LEVELS::MaxSupportedFeatureLevel">
+    <summary>The highest feature level supplied in the query structure's <i>RequestedFeatureLevels</i> (see <a href="https://docs.microsoft.com/windows/win32/direct3d12/ns-directml-dml_feature_data_feature_levels">DML_FEATURE_DATA_FEATURE_LEVELS</a>) that is supported by this device.
+
+> [!NOTE]
+> Because this feature query only ever returns one of the values supplied in <i>RequestedFeatureLevels</i>, it's possible that the device supports an even higher feature level than the one returned by this query.
+
+For example, DirectML version <c>1.4.0</c> supports a feature level of <c>DML_FEATURE_LEVEL_3_0</c>. If the <i>RequestedFeatureLevels</i> array contained only <c>DML_FEATURE_LEVEL_1_0</c> and <c>DML_FEATURE_LEVEL_2_0</c>, then this query would return <c>DML_FEATURE_LEVEL_2_0</c>, which is lower than the true feature level (3_0) supported by the device.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_DESC">
+    <summary>
+      <para>A generic container for an operator description. You construct DirectML operators using the parameters specified in this struct. See IDMLDevice::CreateOperator for additional details.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_OPERATOR_DESC::Type">
+    <summary>The type of the operator description. See <a href="https://msdn.microsoft.com/2D66A3DB-FE61-4EC2-B626-DD008FF14802">DML_OPERATOR_TYPE</a> for the available types.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_DESC::Desc">
+    <summary>A pointer to the operator description. The type of the pointed-to struct must match the value specified in <i>Type.</i></summary>
+  </comment>
+  <comment id="DMLCreateDevice1">
+    <summary>
+      <para>Creates a DirectML device for a given Direct3D 12 device.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-dmlcreatedevice1" /></para>
+      <param name="d3d12Device">A pointer to an <a href="https://docs.microsoft.com/windows/win32/api/d3d12/nn-d3d12-id3d12device">ID3D12Device</a> representing the Direct3D 12 device to create the DirectML device over. DirectML supports any D3D feature level, and Direct3D 12 devices created on any adapter, including WARP. However, not all features in DirectML may be available depending on the capabilities of the Direct3D 12 device. See [IDMLDevice::CheckFeatureSupport](/windows/win32/api/directml/nf-directml-idmldevice-checkfeaturesupport) for more info.
+
+If the call to <b>DMLCreateDevice1</b> is successful, then the DirectML device maintains a strong reference to the supplied Direct3D 12 device.</param>
+      <param name="flags">A <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_create_device_flags">DML_CREATE_DEVICE_FLAGS</a> value specifying additional device creation options.</param>
+      <param name="minimumFeatureLevel">A <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_feature_level">DML_FEATURE_LEVEL</a> value specifying the minimum feature level support required.
+
+This parameter can be useful for callers that require a specific version of DirectML, but who may find themselves calling into an older version of DirectML. This can happen, for example, when the user runs your application on an older version of Windows 10.
+
+Applications that explicitly depend on functionality introduced in a particular feature level can specify it as a <i>minimumFeatureLevel</i>. This will guarantee that <b>DMLCreateDevice1</b> won't succeed unless the underlying implementation is <i>at least</i> as capable as this requested minimum feature level.
+
+Note that as this parameter specifies a <i>minimum</i> feature level, the underlying DirectML device may in fact support a higher feature level than the requested minimum. Once device creation succeeds, you can query all of the feature levels supported by this device using [IDMLDevice::CheckFeatureSupport](/windows/win32/api/directml/nf-directml-idmldevice-checkfeaturesupport).</param>
+      <param name="riid">A reference to the globally unique identifier (GUID) of the interface that you wish to be returned in <i>device</i>. This is expected to be the GUID of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmldevice">IDMLDevice</a>.</param>
+      <param name="ppv">A pointer to a memory block that receives a pointer to the device. This is the address of a pointer to an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmldevice">IDMLDevice</a>, representing  the DirectML device created.</param>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SQRT_OPERATOR_DESC">
+    <summary>
+      <para>Computes the square root of each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_sqrt_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SQRT_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SQRT_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SQRT_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ROI_POOLING_OPERATOR_DESC">
+    <summary>
+      <para>Performs a MaxPool function across the input tensor (according to regions of interest, or ROIs).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_roi_pooling_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ROI_POOLING_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the input data with dimensions <c>{ BatchCount, ChannelCount, InputHeight, InputWidth }</c>.</summary>
+  </comment>
+  <comment id="DML_ROI_POOLING_OPERATOR_DESC::ROITensor">
+    <summary>A tensor containing the regions of interest (ROI) data. The expected dimensions of <c>ROITensor</c> are <c>{ 1, 1, NumROIs, 5 }</c> and the data for each ROI is <c>[BatchID, x1, y1, x2, y2]</c>. x1, y1, x2, y2 are the inclusive coordinates of the corners of each ROI and x2 &gt;= x1, y2 &gt;= y1.</summary>
+  </comment>
+  <comment id="DML_ROI_POOLING_OPERATOR_DESC::OutputTensor">
+    <summary>A tensor containing the output data. The expected dimensions of <i>OutputTensor</i> are <c>{ NumROIs, InputChannelCount, PooledSize.Height, PooledSize.Width }</c>.</summary>
+  </comment>
+  <comment id="DML_ROI_POOLING_OPERATOR_DESC::SpatialScale">
+    <summary>Multiplicative spatial scale factor used to translate the ROI coordinates from their input scale to the scale used when pooling.</summary>
+  </comment>
+  <comment id="DML_ROI_POOLING_OPERATOR_DESC::PooledSize">
+    <summary>The ROI pool output size (height, width), which must match the last 2 dimensions of <i>OutputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_GATHER_ND1_OPERATOR_DESC">
+    <summary>
+      <para>Gathers elements from the input tensor, using the indices tensor to remap indices to entire subblocks of the input.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_gather_nd1_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_GATHER_ND1_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from.</summary>
+  </comment>
+  <comment id="DML_GATHER_ND1_OPERATOR_DESC::IndicesTensor">
+    <summary>The tensor containing the indices. The <i>DimensionCount</i> of this tensor must match <i>InputTensor.DimensionCount</i>. The last dimension of the <i>IndicesTensor</i> is actually the number of coordinates per index tuple, and it cannot exceed <i>InputTensor.DimensionCount</i>. For example, an indices tensor of <i>Sizes</i> <c>{1,4,5,2}</c> with <i>IndicesDimensionCount</i> = 3 means a 4x5 array of 2-coordinate tuples that index into <i>InputTensor</i>.
+
+Starting with <c>DML_FEATURE_LEVEL_3_0</c>, this operator supports negative index values when using a signed integral type with this tensor. Negative indices are interpreted as being relative to the end of the respective dimension. For example, an index of -1 refers to the last element along that dimension.</summary>
+  </comment>
+  <comment id="DML_GATHER_ND1_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. The <i>DimensionCount</i> and <i>DataType</i> of this tensor must match <i>InputTensor.DimensionCount</i>. The expected <i>OutputTensor.Sizes</i> are the concatenation of the <i>IndicesTensor.Sizes</i> leading segments and <i>InputTensor.Sizes</i> trailing segment, which yields the following.
+
+<code>
+indexTupleSize = IndicesTensor.Sizes[IndicesTensor.DimensionCount - 1]
+OutputTensor.Sizes = {
+    1...,
+    IndicesTensor.Sizes[(IndicesTensor.DimensionCount - IndicesDimensionCount) .. (IndicesTensor.DimensionCount - 1)],
+    InputTensor.Sizes[(InputTensor.DimensionCount - indexTupleSize) .. InputTensor.DimensionCount]
+}
+</code>
+
+The dimensions are right-aligned, with leading 1 values prepended if needed to satisfy <i>OutputTensor.DimensionCount</i>.
+
+Here's an example.
+
+<code>
+InputTensor.Sizes = {3,4,5,6,7}
+InputDimensionCount = 5
+IndicesTensor.Sizes = {1,1, 1,2,3}
+IndicesDimensionCount = 3 // can be thought of as a {1,2} array of 3-coordinate tuples
+
+// The {1,2} comes from the indices tensor (ignoring last dimension which is the tuple size),
+// and the {6,7} comes from input tensor, ignoring the first 3 dimensions
+// since the index tuples are 3 elements (from the indices tensor last dimension).
+OutputTensor.Sizes = {1, 1,2,6,7}
+</code></summary>
+  </comment>
+  <comment id="DML_GATHER_ND1_OPERATOR_DESC::InputDimensionCount">
+    <summary>The number of actual input dimensions within the <i>InputTensor</i> after ignoring any irrelevant leading ones, ranging <c>[1, <i>InputTensor.DimensionCount</i>]</c>. For example, given <i>InputTensor.Sizes</i> = <c>{1,1,4,6}</c> and <c>InputDimensionCount</c> = 3, the actual meaningful indices are <c>{1,4,6}</c>.</summary>
+  </comment>
+  <comment id="DML_GATHER_ND1_OPERATOR_DESC::IndicesDimensionCount">
+    <summary>The number of actual index dimensions within the <i>IndicesTensor</i> after ignoring any irrelevant leading ones, ranging [1, <i>IndicesTensor.DimensionCount</i>]. For example, given <i>IndicesTensor.Sizes</i> = <c>{1,1,4,6}</c>, and <i>IndicesDimensionCount</i> = 3, the actual meaningful indices are <c>{1,4,6}</c>.</summary>
+  </comment>
+  <comment id="DML_GATHER_ND1_OPERATOR_DESC::BatchDimensionCount">
+    <summary>The number of dimensions within each tensor (<i>InputTensor</i>, <i>IndicesTensor</i>, <i>OutputTensor</i>) that are considered independent batches, ranging within both [0, <i>InputTensor.DimensionCount</i>) and [0, <i>IndicesTensor.DimensionCount</i>). The batch count can be 0, implying a single batch. For example, given <i>IndicesTensor.Sizes</i> = <c>{1,3,4,5,6,7}</c>, and <i>IndicesDimensionCount</i> = 5 and <c>BatchDimensionCount</c> = 2, there are batches <c>{3,4}</c> and meaningful indices <c>{5,6,7}</c>.</summary>
+  </comment>
+  <comment id="DML_MATRIX_TRANSFORM">
+    <summary>
+      <para>Defines constants that specify a matrix transform to be applied to a DirectML tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_matrix_transform" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_MATRIX_TRANSFORM::DML_MATRIX_TRANSFORM_NONE">
+    <summary>Specifies that no transform is to be applied.</summary>
+  </comment>
+  <comment id="DML_MATRIX_TRANSFORM::DML_MATRIX_TRANSFORM_TRANSPOSE">
+    <summary>Specifies that a transpose transform is to be applied.</summary>
+  </comment>
+  <comment id="DML_DIAGONAL_MATRIX_OPERATOR_DESC">
+    <summary>
+      <para>Generates an identity-like matrix with ones (or other explicit value) on the major diagonal, and zeros everywhere else.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_diagonal_matrix_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_DIAGONAL_MATRIX_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. The dimensions are <c>{ Batch1, Batch2, OutputHeight, OutputWidth }</c>. The height and width don't need to be square.</summary>
+  </comment>
+  <comment id="DML_DIAGONAL_MATRIX_OPERATOR_DESC::Offset">
+    <summary>An offset to shift the diagonal lines of <i>Value</i>, with positive offsets shifting the written value to the right/up (viewing the output as a matrix with the top left as 0,0), and negative offsets to the left/down.</summary>
+  </comment>
+  <comment id="DML_DIAGONAL_MATRIX_OPERATOR_DESC::Value">
+    <summary>A value to fill along the 2D diagonal. The standard value is 1.0. Note that if the <i>DataType</i> of the tensors is not <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_tensor_data_type">DML_TENSOR_DATA_TYPE_FLOAT16</a> or <b>DML_TENSOR_DATA_TYPE_FLOAT32</b>, then the value might be truncated (for example, 10.6 will become 10).</summary>
+  </comment>
+  <comment id="DML_TENSOR_FLAGS">
+    <summary>
+      <para>Specifies additional options in a tensor description. Values can be bitwise OR'd together.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_tensor_flags" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_TENSOR_FLAGS::DML_TENSOR_FLAG_NONE">
+    <summary>No options are specified.</summary>
+  </comment>
+  <comment id="DML_TENSOR_FLAGS::DML_TENSOR_FLAG_OWNED_BY_DML">
+    <summary>Indicates that the tensor data should be owned and managed by DirectML. The effect of this flag is that DirectML makes a copy of the tensor data during initialization of an operator, storing it in the persistent resource. This allows DirectML to perform reformatting of the tensor data into other, more efficient forms. Setting this flag may increase performance, but is typically only useful for tensors whose data doesn't change for the lifetime of the operator (for example, weight tensors).
+      
+This flag can only be used on input tensors.
+
+When this flag is set on a particular tensor description, the corresponding tensor must be bound to the binding table during operator initialization, and not during execution. Attempting to bind the tensor during execution while this flag is set results in an error. This is the opposite of the default behavior (the behavior without the <b>DML_TENSOR_FLAG_OWNED_BY_DML</b> flag), where the tensor is expected to be bound during execution, and not during initialization.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_TANH_OPERATOR_DESC">
+    <summary>
+      <para>Performs a hyperbolic tangent activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_tanh_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_TANH_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_TANH_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="IDMLBindingTable::BindInputs">
+    <summary>
+      <para>Binds a set of resources as input tensors.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmlbindingtable-bindinputs" /></para>
+      <param name="bindingCount">This parameter determines the size of the <i>bindings</i> array (if provided).</param>
+      <param name="bindings">An optional pointer to a constant array of <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_binding_desc">DML_BINDING_DESC</a> containing descriptions of the tensor resources to bind.</param>
+    </summary>
+  </comment>
+  <comment id="DML_BUFFER_ARRAY_BINDING">
+    <summary>
+      <para>Specifies a resource binding that is an array of individual buffer bindings.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_buffer_array_binding" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_BUFFER_ARRAY_BINDING::BindingCount">
+    <summary>The number of individual buffer ranges to bind to this slot. This field determines the size of the <i>Bindings</i> array.</summary>
+  </comment>
+  <comment id="DML_BUFFER_ARRAY_BINDING::Bindings">
+    <summary>The individual buffer ranges to bind.</summary>
+  </comment>
+  <comment id="DML_SCATTER_OPERATOR_DESC">
+    <summary>
+      <para>Copies the whole input tensor to the output, then overwrites selected indices with corresponding values from the updates tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_scatter_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SCATTER_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from.</summary>
+  </comment>
+  <comment id="DML_SCATTER_OPERATOR_DESC::IndicesTensor">
+    <summary>A tensor containing the indices into the output tensor. The <i>Sizes</i> must match <i>InputTensor.Sizes</i> for every dimension except <i>Axis</i>.
+
+Starting with <c>DML_FEATURE_LEVEL_3_0</c>, this operator supports negative index values when using a signed integral type with this tensor. Negative indices are interpreted as being relative to the end of the axis dimension. For example, an index of -1 refers to the last element along that dimension.</summary>
+  </comment>
+  <comment id="DML_SCATTER_OPERATOR_DESC::UpdatesTensor">
+    <summary>A tensor containing the new values to replace the existing input values at the corresponding indices. The <i>Sizes</i> of this tensor must match <i>IndicesTensor.Sizes</i>. The <i>DataType</i> must match <i>InputTensor.DataType</i>.</summary>
+  </comment>
+  <comment id="DML_SCATTER_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. The <i>Sizes</i> and <i>DataType</i> of this tensor must match <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_SCATTER_OPERATOR_DESC::Axis">
+    <summary>The axis dimension to use for indexing in <i>OutputTensor</i>, ranging <c>[0, OutputTensor.DimensionCount)</c>.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC">
+    <summary>
+      <para>Subtracts each element of <i>BTensor</i> from the corresponding element of <i>ATensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_subtract_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ARGMIN_OPERATOR_DESC">
+    <summary>
+      <para>Outputs the indices of the minimum-valued elements within one or more dimensions of the input tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_argmin_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ARGMIN_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ARGMIN_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. Each output element is the result of an <i>argmin</i> reduction on a subset of elements from the <i>InputTensor</i>.
+
+- <i>DimensionCount</i> must match <i>InputTensor.DimensionCount</i> (the rank of the input tensor is preserved).
+- <i>Sizes</i> must match <i>InputTensor.Sizes</i>, except for dimensions included in the reduced <i>Axes</i>, which must be size 1.</summary>
+  </comment>
+  <comment id="DML_ARGMIN_OPERATOR_DESC::AxisCount">
+    <summary>The number of axes to reduce. This field determines the size of the <i>Axes</i> array.</summary>
+  </comment>
+  <comment id="DML_ARGMIN_OPERATOR_DESC::Axes">
+    <summary>The axes along which to reduce. Values must be in the range <c>[0, InputTensor.DimensionCount - 1]</c>.</summary>
+  </comment>
+  <comment id="DML_ARGMIN_OPERATOR_DESC::AxisDirection">
+    <summary>DML_AXIS_DIRECTION AxisDirection;
+
+Type: <b><a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_axis_direction">DML_AXIS_DIRECTION</a></b>
+
+Determines which index to select when multiple input elements have the same value.
+- <b>DML_AXIS_DIRECTION_INCREASING</b> returns the index of the first minimum-valued element (for example, <c>argmin({1,2,3,2,1}) = 0</c>)
+- <b>DML_AXIS_DIRECTION_DECREASING</b> returns the index of the last minimum-valued element (for example, <c>argmin({1,2,3,2,1}) = 4</c>)</summary>
+  </comment>
+  <comment id="DML_FEATURE_QUERY_TENSOR_DATA_TYPE_SUPPORT">
+    <summary>
+      <para>Used to query a DirectML device for its support for a particular data type within tensors.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_feature_query_tensor_data_type_support" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_FEATURE_QUERY_TENSOR_DATA_TYPE_SUPPORT::DataType">
+    <summary>The data type about which you're querying for support.</summary>
+  </comment>
+  <comment id="DML_SPACE_TO_DEPTH1_OPERATOR_DESC">
+    <summary>
+      <para>Rearranges blocks of spatial data into depth. The operator outputs a copy of the input tensor where values from the height and width dimensions are moved to the depth dimension.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_space_to_depth1_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SPACE_TO_DEPTH1_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from. The input tensor's dimensions are <c>{ Batch, Channels, Height, Width }</c>.</summary>
+  </comment>
+  <comment id="DML_SPACE_TO_DEPTH1_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. The output tensor's dimensions are <c>{ Batch, Channels / (BlockSize * BlockSize), Height * BlockSize, Width * BlockSize }</c>.</summary>
+  </comment>
+  <comment id="DML_SPACE_TO_DEPTH1_OPERATOR_DESC::BlockSize">
+    <summary>The width and height of the Blocks that are moved.</summary>
+  </comment>
+  <comment id="DML_SPACE_TO_DEPTH1_OPERATOR_DESC::Order">
+    <summary>See <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_depth_space_order">DML_DEPTH_SPACE_ORDER</a>.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_LOG_SOFTMAX_OPERATOR_DESC">
+    <summary>
+      <para>Performs a (natural) log-of-softmax activation function on each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_log_softmax_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_LOG_SOFTMAX_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from. This tensor must have an <i>effective rank</i> no greater than 2. The effective rank of a tensor is the <i>DimensionCount</i> of the tensor, excluding leftmost dimensions of size 1. For example a tensor size of <c>{ 1, 1, BatchCount, Width }</c> is valid, and is equivalent to a tensor of sizes <c>{ BatchCount, Width }</c>.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_LOG_SOFTMAX_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_AXIS_DIRECTION">
+    <summary>
+      <para>Defines constants that specify the direction of an operation along the given axis for the operator (for example, summation, selecting the top-k elements, selecting the minimum element).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_axis_direction" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_AXIS_DIRECTION::DML_AXIS_DIRECTION_INCREASING">
+    <summary>Specifies increasing order (from the low index to the high index).</summary>
+  </comment>
+  <comment id="DML_AXIS_DIRECTION::DML_AXIS_DIRECTION_DECREASING">
+    <summary>Specifies decreasing order (from the high index to the low index).</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC">
+    <summary>
+      <para>Performs a scaled hyperbolic tangent activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_scaled_tanh_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC::Alpha">
+    <summary>The value of alpha. A typical default for this value is 1.0.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC::Beta">
+    <summary>The value of beta. A typical default for this value is 0.5.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ACOS_OPERATOR_DESC">
+    <summary>
+      <para>Computes the arccosine for each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_acos_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ACOS_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ACOS_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ACOS_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC">
+    <summary>
+      <para>Computes the identity for each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_identity_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_BINDING_TABLE_DESC">
+    <summary>
+      <para>Specifies parameters to IDMLDevice::CreateBindingTable and IDMLBindingTable::Reset.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_binding_table_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_BINDING_TABLE_DESC::Dispatchable">
+    <summary>A pointer to an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmldispatchable">IDMLDispatchable</a> interface representing the dispatchable object (an operator initializer, or a compiled operator) for which this binding table will represent the bindings—either an
+        <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlcompiledoperator">IDMLCompiledOperator</a> or an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmloperatorinitializer">IDMLOperatorInitializer</a>. The binding table maintains a strong reference to this
+        interface pointer. This value may not be null.</summary>
+  </comment>
+  <comment id="DML_BINDING_TABLE_DESC::CPUDescriptorHandle">
+    <summary>A valid CPU descriptor handle representing the start of a range into a constant buffer view (CBV)/shader resource view (SRV)/ unordered access view (UAV) descriptor heap into which
+        DirectML may write descriptors.</summary>
+  </comment>
+  <comment id="DML_BINDING_TABLE_DESC::GPUDescriptorHandle">
+    <summary>A valid GPU descriptor handle representing the start of a range into a constant buffer view (CBV)/shader resource view (SRV)/ unordered access view (UAV) descriptor heap that DirectML may use to bind resources to the pipeline.</summary>
+  </comment>
+  <comment id="DML_BINDING_TABLE_DESC::SizeInDescriptors">
+    <summary>The size of the binding table, in descriptors. This is the maximum number of descriptors that DirectML is
+        permitted to write, from the start of both the supplied CPU and GPU descriptor handles. Call
+        [IDMLDispatchable::GetBindingProperties](/windows/win32/api/directml/nf-directml-idmldispatchable-getbindingproperties) to determine the number of descriptors required to execute a
+        dispatchable object.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ROUND_OPERATOR_DESC">
+    <summary>
+      <para>Rounds each element of <i>InputTensor</i> to an integer value, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_round_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ROUND_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ROUND_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ROUND_OPERATOR_DESC::RoundingMode">
+    <summary>A <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_rounding_mode">DML_ROUNDING_MODE</a> determining the direction to round towards.
+
+* If <b>DML_ROUNDING_MODE_HALVES_TO_NEAREST_EVEN</b>: values are rounded to the nearest integer, with halfway values (for example, 0.5) being rounded toward the nearest even integer.
+* If <b>DML_ROUNDING_MODE_TOWARD_ZERO</b>: values are rounded toward zero. This effectively truncates the fractional part.
+* If <b>DML_ROUNDING_MODE_TOWARD_INFINITY</b>: values are rounded to the nearest integer, with halfway values (for example, 0.5) being rounded away from zero (toward positive or negative infinity, depending on the sign of the value).</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC">
+    <summary>
+      <para>Performs a one-layer long short term memory (LSTM) function on the input. This operator uses multiple gates to perform this layer. These gates are performed multiple times in a loop, dictated by the sequence length dimension and the <i>SequenceLengthsTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_lstm_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the input data, X. Packed (and potentially padded) into one 4-D tensor with the sizes of <c>{ 1, seq_length, batch_size, input_size }</c>. seq_length is the dimension that is mapped to the index, t.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::WeightTensor">
+    <summary>A tensor containing the weight data, W. Concatenation of W_[iofc] and W_B[iofc] (if bidirectional). The tensor has sizes <c>{ 1, num_directions, 4 * hidden_size, input_size }</c>.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::RecurrenceTensor">
+    <summary>A tensor containing the recurrence data, R. Concatenation of R_[iofc] and R_B[iofc] (if bidirectional). This tensor has sizes <c>{ 1, num_directions, 4 * hidden_size, hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::BiasTensor">
+    <summary>An optional tensor containing the bias data, B. Concatenation of <c>{ W_b[iofc], R_b[iofc] }</c>, and <c>{ W_Bb[iofc], R_Bb[iofc] }</c> (if bidirectional). This tensor has sizes <c>{ 1, 1, num_directions, 8 * hidden_size }</c>. If not specified, then defaults to 0 bias.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::HiddenInitTensor">
+    <summary>An optional tensor containing the hidden node initializer data, H_(t-1). Contents of this tensor are only used on the first loop index t. If not specified, then defaults to 0. This tensor has sizes <c>{ 1, num_directions, batch_size, hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::CellMemInitTensor">
+    <summary>An optional tensor containing the cell initializer data, C_(t-1). Contents of this tensor are only used on the first loop index t. If not specified, then defaults to 0. This tensor has sizes <c>{ 1, num_directions, batch_size, hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::SequenceLengthsTensor">
+    <summary>An optional tensor containing an independent seq_length for each element in the batch. If not specified, then all sequences in the batch have length seq_length. This tensor has sizes <c>{ 1, 1, 1, batch_size }</c>.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::PeepholeTensor">
+    <summary>An optional tensor containing the weight data for peepholes, P. If not specified, then defaults to 0. Concatenation of P_[iof] and P_B[iof] (if bidirectional). This tensor has sizes <c>{ 1, 1, num_directions, 3 * hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::OutputSequenceTensor">
+    <summary>An optional tensor with which to write the concatenation of all the intermediate output values of the hidden nodes, H_t. This tensor has sizes <c>{ seq_length, num_directions, batch_size, hidden_size }</c>. seq_length is mapped to the loop index t.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::OutputSingleTensor">
+    <summary>An optional tensor with which to write the last output value of the hidden nodes, H_t. This tensor has sizes <c>{ 1, num_directions, batch_size, hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::OutputCellSingleTensor">
+    <summary>An optional tensor with which to write the last output value of the cell, C_t. This tensor has sizes <c>{ 1, num_directions, batch_size, hidden_size }</c>.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::ActivationDescCount">
+    <summary>This field determines the size of the <i>ActivationDescs</i> array.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::ActivationDescs">
+    <summary>An array of <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_operator_desc">DML_OPERATOR_DESC</a> containing the descriptions of the activation operators f(), g(), and h(). f(), g(), and h() are defined independently of direction, meaning that if <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_recurrent_network_direction">DML_RECURRENT_NETWORK_DIRECTION_FORWARD</a> or <b>DML_RECURRENT_NETWORK_DIRECTION_BACKWARD</b> are supplied in <i>Direction</i>, then three activations must be provided. If <b>DML_RECURRENT_NETWORK_DIRECTION_BIDIRECTIONAL</b> is defined, then six activations must be provided. For bidirectional, activations must be provided f(), g(), and h() for forward followed by f(), g(), and h() for backwards.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::Direction">
+    <summary>The direction of the operator: forward, backward, or bidirectional.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::ClipThreshold">
+    <summary>The cell clip threshold. Clipping bounds the elements of a tensor in the range of [-<c>ClipThreshold</c>, +<c>ClipThreshold</c>], and is applied to the input of activations.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::UseClipThreshold">
+    <summary><b>TRUE</b> if <i>ClipThreshold</i> should be used. Otherwise, <b>FALSE</b>.</summary>
+  </comment>
+  <comment id="DML_LSTM_OPERATOR_DESC::CoupleInputForget">
+    <summary><b>TRUE</b> if the input and forget gates should be coupled. Otherwise, <b>FALSE</b>.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC">
+    <summary>
+      <para>Raises each element of <i>InputTensor</i> to the power of <i>Exponent</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_constant_pow_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC::Exponent">
+    <summary>The exponent that all inputs will be raised to.</summary>
+  </comment>
+  <comment id="DML_PADDING_MODE">
+    <summary>
+      <para>Defines constants that specify a mode for the DirectML pad operator (as described by the DML_PADDING_OPERATOR_DESC structure).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_padding_mode" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_PADDING_MODE::DML_PADDING_MODE_CONSTANT">
+    <summary>Indicates padding with a constant.</summary>
+  </comment>
+  <comment id="DML_PADDING_MODE::DML_PADDING_MODE_EDGE">
+    <summary>Indicates edge mode for padding.</summary>
+  </comment>
+  <comment id="DML_PADDING_MODE::DML_PADDING_MODE_REFLECTION">
+    <summary>Indicates reflection mode for padding.</summary>
+  </comment>
+  <comment id="DML_GRAPH_EDGE_TYPE">
+    <summary>
+      <para>Defines constants that specify a type of graph edge. See <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_graph_edge_desc">DML_GRAPH_EDGE_DESC</a> for the usage of this enumeration.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_graph_edge_type" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_GRAPH_EDGE_TYPE::DML_GRAPH_EDGE_TYPE_INVALID">
+    <summary>Specifies an unknown graph edge type, and is never valid. Using this value results in an error.</summary>
+  </comment>
+  <comment id="DML_GRAPH_EDGE_TYPE::DML_GRAPH_EDGE_TYPE_INPUT">
+    <summary>Specifies that the graph edge is described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_input_graph_edge_desc">DML_INPUT_GRAPH_EDGE_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_GRAPH_EDGE_TYPE::DML_GRAPH_EDGE_TYPE_OUTPUT">
+    <summary>Specifies that the graph edge is described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_output_graph_edge_desc">DML_OUTPUT_GRAPH_EDGE_DESC</a> structure.</summary>
+  </comment>
+  <comment id="DML_GRAPH_EDGE_TYPE::DML_GRAPH_EDGE_TYPE_INTERMEDIATE">
+    <summary>Specifies that the graph edge is described by the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_intermediate_graph_edge_desc">DML_INTERMEDIATE_GRAPH_EDGE_DESC</a> structure.</summary>
+  </comment>
+  <comment id="IDMLDevice::CreateBindingTable">
+    <summary>
+      <para>Creates a binding table, which is an object that can be used to bind resources (such as tensors) to the pipeline.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldevice-createbindingtable" /></para>
+      <param name="desc">An optional pointer to a <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_binding_table_desc">DML_BINDING_TABLE_DESC</a> containing the binding table parameters. This may be <b>nullptr</b>, indicating an empty binding table.</param>
+      <param name="riid">A reference to the globally unique identifier (GUID) of the interface that you wish to be returned in <i>ppv</i>. This is expected to be the GUID of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlbindingtable">IDMLBindingTable</a>.</param>
+      <param name="ppv">A pointer to a memory block that receives a pointer to the binding table. This is the address of a pointer to an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlbindingtable">IDMLBindingTable</a>, representing  the binding table created.</param>
+    </summary>
+  </comment>
+  <comment id="IDMLDevice::MakeResident">
+    <summary>
+      <para>Causes one or more pageable objects to become resident in GPU memory. Also see IDMLDevice::Evict.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldevice-makeresident" /></para>
+      <param name="count">This parameter determines the number of elements in the array passed in the  <i>ppObjects</i> parameter.</param>
+      <param name="ppObjects">A pointer to a constant array of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlpageable">IDMLPageable</a> pointers containing the pageable objects to make resident in GPU memory.</param>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC">
+    <summary>
+      <para>Performs a thresholded rectified linear unit (ReLU) activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_thresholded_relu_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC::Alpha">
+    <summary>The threshold for the function. A typical default for this value is 1.0.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC">
+    <summary>
+      <para>Performs a leaky rectified linear unit (ReLU) activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_leaky_relu_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC::Alpha">
+    <summary>The alpha coefficient. A typical default for this value is 0.01.</summary>
+  </comment>
+  <comment id="DML_DEPTH_SPACE_ORDER">
+    <summary>
+      <para>Defines constants controlling the transform applied in the DirectML operators <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_operator_type">DML_OPERATOR_DEPTH_TO_SPACE1</a> and <b>DML_OPERATOR_SPACE_TO_DEPTH1</b>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_depth_space_order" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_DEPTH_SPACE_ORDER::DML_DEPTH_SPACE_ORDER_DEPTH_COLUMN_ROW">
+    <summary>Causes tensors used in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_depth_to_space1_operator_desc">DML_DEPTH_TO_SPACE1_OPERATOR_DESC</a> and <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_space_to_depth1_operator_desc">DML_SPACE_TO_DEPTH1_OPERATOR_DESC</a> to be interpreted with the following layouts, where dimensions in parenthesis are flattened together.
+
+- <b>Depth version</b>: [Batch, (BlockHeight, BlockWidth, Channels), Height, Width]
+- <b>Space version</b>: [Batch, Channels, (Height, BlockHeight), (Width, BlockWidth)]</summary>
+  </comment>
+  <comment id="DML_DEPTH_SPACE_ORDER::DML_DEPTH_SPACE_ORDER_COLUMN_ROW_DEPTH">
+    <summary>Causes tensors used in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_depth_to_space1_operator_desc">DML_DEPTH_TO_SPACE1_OPERATOR_DESC</a> and <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_space_to_depth1_operator_desc">DML_SPACE_TO_DEPTH1_OPERATOR_DESC</a> to be interpreted with the following layouts, where dimensions in parenthesis are flattened together.
+
+- <b>Depth version</b>: [Batch, (Channels, BlockHeight, BlockWidth), Height, Width]
+- <b>Space version</b>: [Batch, Channels, (Height, BlockHeight), (Width, BlockWidth)]</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_TANH_OPERATOR_DESC">
+    <summary>
+      <para>Computes the hyperbolic tangent of element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_tanh_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_TANH_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_TANH_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_TANH_OPERATOR_DESC::ScaleBias">
+    <summary />
+  </comment>
+  <comment id="IDMLDebugDevice">
+    <summary>
+      <para>Controls the DirectML debug layers.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nn-directml-idmldebugdevice" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_GATHER_OPERATOR_DESC">
+    <summary>
+      <para>Gathers elements from the input tensor along <b>Axis</b>, using <b>IndicesTensor</b> to remap indices.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_gather_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_GATHER_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from.</summary>
+  </comment>
+  <comment id="DML_GATHER_OPERATOR_DESC::IndicesTensor">
+    <summary>A tensor containing the indices. The <i>DimensionCount</i> of this tensor must match <i>InputTensor.DimensionCount</i>.
+
+Starting with <c>DML_FEATURE_LEVEL_3_0</c>, this operator supports negative index values when using a signed integral type with this tensor. Negative indices are interpreted as being relative to the end of the axis dimension. For example, an index of -1 refers to the last element along that dimension.</summary>
+  </comment>
+  <comment id="DML_GATHER_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. The <i>DimensionCount</i> and <i>DataType</i> of this tensor must match <i>InputTensor.DimensionCount</i>. The expected <i>OutputTensor.Sizes</i> are the concatenation of the <i>InputTensor.Sizes</i> leading and trailing segments split at the current <i>Axis</i> with the <i>IndicesTensor.Sizes</i> inserted between.
+
+<code>
+OutputTensor.Sizes = {
+    InputTensor.Sizes[0..Axis],
+    IndicesTensor.Sizes[(IndicesTensor.DimensionCount - IndexDimensions) .. IndicesTensor.DimensionCount],
+    InputTensor.Sizes[(Axis+1) .. InputTensor.DimensionCount]
+}
+</code>
+
+The dimensions are right-aligned such that any leading 1 values from the input sizes are cropped which would otherwise overflow the output <i>DimensionCount</i>.
+
+The number of relevant dimensions in this tensor depends on <i>IndexDimensions</i> and the <i>original rank</i> of <i>InputTensor</i>. The original rank is the number of dimensions prior to any padding with leading ones. The number of relevant dimensions in the output can be computed by the <i>original rank</i> of <i>InputTensor</i> + <i>IndexDimensions</i> - 1. This value must be less than or equal to the <i>DimensionCount</i> of <i>OutputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_GATHER_OPERATOR_DESC::Axis">
+    <summary>The axis dimension of <i>InputTensor</i> to gather on, ranging <c>[0, <i>InputTensor.DimensionCount</i>)</c>.</summary>
+  </comment>
+  <comment id="DML_GATHER_OPERATOR_DESC::IndexDimensions">
+    <summary>The number of actual index dimensions within the <c>IndicesTensor</c> after ignoring any irrelevant leading ones, ranging [0, <c>IndicesTensor.DimensionCount</c>). For example, given <c>IndicesTensor.Sizes</c> = <c>{ 1, 1, 4, 6 }</c> and <c>IndexDimensions</c> = 3, the actual meaningful indices are <c>{ 1, 4, 6 }</c>.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_TAN_OPERATOR_DESC">
+    <summary>
+      <para>Computes the trigonometric tangent of each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_tan_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_TAN_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_TAN_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_TAN_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ATAN_OPERATOR_DESC">
+    <summary>
+      <para>Computes the arctangent for each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_atan_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ATAN_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ATAN_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ATAN_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_BATCH_NORMALIZATION_OPERATOR_DESC">
+    <summary>
+      <para>Performs a batch normalization on the input.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_batch_normalization_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_BATCH_NORMALIZATION_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the Input data.</summary>
+  </comment>
+  <comment id="DML_BATCH_NORMALIZATION_OPERATOR_DESC::MeanTensor">
+    <summary>A tensor containing the Mean data.
+
+If <b>DML_FEATURE_LEVEL</b> is less than <b>DML_FEATURE_LEVEL_4_0</b>, then this tensor's dimensions should be <c>{ MeanBatchCount, ChannelCount, MeanHeight, MeanWidth }</c>. The dimensions MeanBatchCount, MeanHeight, and MeanWidth should either match <i>InputTensor</i>, or be set to 1 to automatically broadcast those dimensions across the input.
+
+If <b>DML_FEATURE_LEVEL</b> is greater than or equal to <b>DML_FEATURE_LEVEL_4_0</b>, then any dimension can be set to 1, and be automatically broadcast to match <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_BATCH_NORMALIZATION_OPERATOR_DESC::VarianceTensor">
+    <summary>A tensor containing the Variance data.
+
+If <b>DML_FEATURE_LEVEL</b> is less than <b>DML_FEATURE_LEVEL_4_0</b>, then this tensor's dimensions should be <c>{ VarianceBatchCount, ChannelCount, VarianceHeight, VarianceWidth }</c>. The dimensions VarianceBatchCount, VarianceHeight, and VarianceWidth should either match <i>InputTensor</i>, or be set to 1 to automatically broadcast those dimensions across the input.
+
+If <b>DML_FEATURE_LEVEL</b> is greater than or equal to <b>DML_FEATURE_LEVEL_4_0</b>, then any dimension can be set to 1, and be automatically broadcast to match <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_BATCH_NORMALIZATION_OPERATOR_DESC::ScaleTensor">
+    <summary>A tensor containing the Scale data.
+
+If <b>DML_FEATURE_LEVEL</b> is less than <b>DML_FEATURE_LEVEL_4_0</b>, then this tensor's dimensions should be <c>{ ScaleBatchCount, ChannelCount, ScaleHeight, ScaleWidth }</c>. The dimensions ScaleBatchCount, ScaleHeight, and ScaleWidth should either match <i>InputTensor</i>, or be set to 1 to automatically broadcast those dimensions across the input.
+
+If <b>DML_FEATURE_LEVEL</b> is greater than or equal to <b>DML_FEATURE_LEVEL_4_0</b>, then any dimension can be set to 1 and be automatically broadcast to match <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_BATCH_NORMALIZATION_OPERATOR_DESC::BiasTensor">
+    <summary>A tensor containing the Bias data.
+
+If <b>DML_FEATURE_LEVEL</b> is less than <b>DML_FEATURE_LEVEL_4_0</b>, then this tensor's dimensions should be <c>{ BiasBatchCount, ChannelCount, BiasHeight, BiasWidth }</c>. The dimensions BiasBatchCount, BiasHeight, and BiasWidth should either match <i>InputTensor</i>, or be set to 1 to automatically broadcast those dimensions across the input.
+
+If <b>DML_FEATURE_LEVEL</b> is greater than or equal to <b>DML_FEATURE_LEVEL_4_0</b>, then any dimension can be set to 1 and be automatically broadcast to match <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_BATCH_NORMALIZATION_OPERATOR_DESC::OutputTensor">
+    <summary>A tensor to write the results to. This tensor's dimensions should match <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_BATCH_NORMALIZATION_OPERATOR_DESC::Spatial">
+    <summary><b>TRUE</b> to specify that locations are spatial, otherwise <b>FALSE</b>. Setting this to <b>FALSE</b> will require the Width and Height dimensions of <i>MeanTensor</i> and <i>VarianceTensor</i> to not be broadcast. This parameter was deprecated in <b>DML_FEATURE_LEVEL_4_0</b>, and has no effect.</summary>
+  </comment>
+  <comment id="DML_BATCH_NORMALIZATION_OPERATOR_DESC::Epsilon">
+    <summary>The epsilon value to use to avoid division by zero.</summary>
+  </comment>
+  <comment id="DML_BATCH_NORMALIZATION_OPERATOR_DESC::FusedActivation">
+    <summary>An optional fused activation layer to apply after the normalization.</summary>
+  </comment>
+  <comment id="IDMLBindingTable::BindOutputs">
+    <summary>
+      <para>Binds a set of resources as output tensors.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmlbindingtable-bindoutputs" /></para>
+      <param name="bindingCount">This parameter determines the size of the <i>bindings</i> array (if provided).</param>
+      <param name="bindings">An optional pointer to a constant array of <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_binding_desc">DML_BINDING_DESC</a> containing descriptions of the tensor resources to bind.</param>
+    </summary>
+  </comment>
+  <comment id="DML_FEATURE_QUERY_FEATURE_LEVELS">
+    <summary>
+      <para>Used to query a DirectML device for its support for one or more feature levels.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_feature_query_feature_levels" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_FEATURE_QUERY_FEATURE_LEVELS::RequestedFeatureLevelCount">
+    <summary>The number of elements in the <i>RequestedFeatureLevels</i> array.</summary>
+  </comment>
+  <comment id="DML_FEATURE_QUERY_FEATURE_LEVELS::RequestedFeatureLevels">
+    <summary>An array of feature levels to query support for. When [IDMLDevice::CheckFeatureSupport](/windows/win32/api/directml/nf-directml-idmldevice-checkfeaturesupport) returns, the <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_feature_data_feature_levels">DML_FEATURE_DATA_FEATURE_LEVELS</a> struct contains the highest feature level in this array that is supported by the device.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_RELU_OPERATOR_DESC">
+    <summary>
+      <para>Performs a rectified linear unit (ReLU) activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_relu_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_RELU_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_RELU_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="IDMLPageable">
+    <summary>
+      <para>Implemented by objects that can be evicted from GPU memory, and hence that can be supplied to IDMLDevice::Evict and IDMLDevice::MakeResident.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nn-directml-idmlpageable" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION">
+    <summary>
+      <para>Defines constants that specify the specific reduction algorithm to use for the DirectML reduce operator (as described by the DML_REDUCE_OPERATOR_DESC structure).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_reduce_function" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION::DML_REDUCE_FUNCTION_ARGMAX">
+    <summary>Indicates a reduction function that computes the indices of the max elements of the input tensor's elements along the specified axis, int32 {i j k ..} = maxindex(X Y Z …).</summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION::DML_REDUCE_FUNCTION_ARGMIN">
+    <summary>Indicates a reduction function that computes the indices of the min elements of the input tensor's elements along the specified axis, int32 {i j k ..} = minindex(X Y Z …).</summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION::DML_REDUCE_FUNCTION_AVERAGE">
+    <summary>Indicates a reduction function that computes the mean of the input tensor's elements along the specified axes, x = (x1 + x2 + ... + xn) / n.</summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION::DML_REDUCE_FUNCTION_L1">
+    <summary>Indicates a reduction function that computes the L1 norm of the input tensor's elements along the specified axes, x = \|x1\| + \|x2\| + ... + \|xn\|.</summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION::DML_REDUCE_FUNCTION_L2">
+    <summary>Indicates a reduction function that computes the L2 norm of the input tensor's elements along the specified axes, x = sqrt(x1^2 + x2^2 + ... + xn^2).</summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION::DML_REDUCE_FUNCTION_LOG_SUM">
+    <summary>Indicates a reduction function that computes the log sum of the input tensor's elements along the specified axes, x = log(x1 + x2 + ... + xn).</summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION::DML_REDUCE_FUNCTION_LOG_SUM_EXP">
+    <summary>Indicates a reduction function that computes the log sum exponent of the input tensor's elements along the specified axes, x = log(exp(x1) + exp(x2) + ... + exp(xn)).</summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION::DML_REDUCE_FUNCTION_MAX">
+    <summary>Indicates a reduction function that computes the max of the input tensor's elements along the specified axes, x = max(max(max(x1, x2), x3), ..., xn).</summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION::DML_REDUCE_FUNCTION_MIN">
+    <summary>Indicates a reduction function that computes the min of the input tensor's elements along the specified axes, x = min(min(min(x1, x2), x3), ..., xn).</summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION::DML_REDUCE_FUNCTION_MULTIPLY">
+    <summary>Indicates a reduction function that computes the product of the input tensor's elements along the specified axes, x = (x1 * x2 * ... * xn).</summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION::DML_REDUCE_FUNCTION_SUM">
+    <summary>Indicates a reduction function that computes the sum  of the input tensor's elements along the specified axes, x = (x1 + x2 + ... + xn).</summary>
+  </comment>
+  <comment id="DML_REDUCE_FUNCTION::DML_REDUCE_FUNCTION_SUM_SQUARE">
+    <summary>Indicates a reduction function that computes the sum square of the input tensor's elements along the specified axes, x = x1^2 + x2^2 + ... + xn^2.</summary>
+  </comment>
+  <comment id="IDMLDevice::GetDeviceRemovedReason">
+    <summary>
+      <para>Retrieves the reason that the DirectML device was removed.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldevice-getdeviceremovedreason" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_NOT_OPERATOR_DESC">
+    <summary>
+      <para>Performs a logical NOT on each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_logical_not_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_NOT_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_LOGICAL_NOT_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_COS_OPERATOR_DESC">
+    <summary>
+      <para>Computes the trigonometric cosine of each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_cos_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_COS_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_COS_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_COS_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC">
+    <summary>
+      <para>Computes the product of each pair of corresponding elements of the input tensors, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_multiply_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_OPERATOR_DESC">
+    <summary>
+      <para>Computes the maximum value across the elements within the sliding window over the input tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_max_pooling_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_OPERATOR_DESC::InputTensor">
+    <summary>An input tensor of <i>Sizes</i> <c>{ BatchCount, ChannelCount, Height, Width }</c> if <i>InputTensor.DimensionCount</i> is 4, and <c>{ BatchCount, ChannelCount, Depth, Height, Weight }</c> if <i>InputTensor.DimensionCount</i> is 5.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_OPERATOR_DESC::OutputTensor">
+    <summary>An output tensor to write the results to. The sizes of the output tensor can be computed as follows.
+
+<code>
+OutputTensor-&gt;Sizes[0] = InputTensor-&gt;Sizes[0];
+OutputTensor-&gt;Sizes[1] = InputTensor-&gt;Sizes[1];
+
+for (UINT i = 0; i &lt; DimensionCount; ++i) {
+  UINT PaddedSize = InputTensor-&gt;Sizes[i + 2] + StartPadding[i] + EndPadding[i];
+  OutputTensor-&gt;Sizes[i + 2] = (PaddedSize - WindowSizes[i]) / Strides[i] + 1;
+}
+</code></summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_OPERATOR_DESC::DimensionCount">
+    <summary>The number of spatial dimensions of the input tensor <i>InputTensor</i>, which also corresponds to the number of dimensions of the sliding window <i>WindowSize</i>. This value also determines the size of the <i>Strides</i>, <i>StartPadding</i>, and <i>EndPadding</i> arrays. It should be set to 2 when <i>InputTensor</i> is 4D, and 3 when it's a 5D tensor.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_OPERATOR_DESC::Strides">
+    <summary>The strides for the sliding window dimensions of sizes <c>{ Height, Width }</c> when the <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_OPERATOR_DESC::WindowSize">
+    <summary>The dimensions of the sliding window in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_OPERATOR_DESC::StartPadding">
+    <summary>The number of padding elements to be applied to the beginning of each spatial dimension of the input tensor <i>InputTensor</i>. The values are in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING_OPERATOR_DESC::EndPadding">
+    <summary>The number of padding elements to be applied to the end of each spatial dimension of the input tensor <i>InputTensor</i>. The values are in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_JOIN_OPERATOR_DESC">
+    <summary>
+      <para>Concatenates an array of input tensors along a specified axis.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_join_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_JOIN_OPERATOR_DESC::InputCount">
+    <summary>This field determines the size of the <i>InputTensors</i> array. This value must be greater than 0.</summary>
+  </comment>
+  <comment id="DML_JOIN_OPERATOR_DESC::InputTensors">
+    <summary>An array containing the descriptions of the tensors to join into a single output tensor. All input tensors in this array must have the same sizes except for the join axis, which may have any non-zero value.</summary>
+  </comment>
+  <comment id="DML_JOIN_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the joined input tensors into. The output sizes must have the same sizes as all input tensors except for the join axis, which must be equal to the sum of all inputs' join axis size.</summary>
+  </comment>
+  <comment id="DML_JOIN_OPERATOR_DESC::Axis">
+    <summary>The index of the dimension of the input tensors to join. All input and output tensors must have identical sizes in all dimensions except for this axis. This value must be in the range <c>[0, OutputTensor.DimensionCount - 1]</c>.</summary>
+  </comment>
+  <comment id="DML_RECURRENT_NETWORK_DIRECTION">
+    <summary>
+      <para>Defines constants that specify a direction for a recurrent DirectML operator.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_recurrent_network_direction" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_RECURRENT_NETWORK_DIRECTION::DML_RECURRENT_NETWORK_DIRECTION_FORWARD">
+    <summary>Indicates the forward pass.</summary>
+  </comment>
+  <comment id="DML_RECURRENT_NETWORK_DIRECTION::DML_RECURRENT_NETWORK_DIRECTION_BACKWARD">
+    <summary>Indicates the backward pass.</summary>
+  </comment>
+  <comment id="DML_RECURRENT_NETWORK_DIRECTION::DML_RECURRENT_NETWORK_DIRECTION_BIDIRECTIONAL">
+    <summary>Indicates both passes.</summary>
+  </comment>
+  <comment id="DML_SCALAR_UNION">
+    <summary>
+      <para>A union of scalar types.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_scalar_union" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SCALAR_UNION::Bytes">
+    <summary>An 8-byte array.</summary>
+  </comment>
+  <comment id="DML_SCALAR_UNION::Int8">
+    <summary>An 8-bit signed integer.</summary>
+  </comment>
+  <comment id="DML_SCALAR_UNION::UInt8">
+    <summary>An 8-bit unsigned integer.</summary>
+  </comment>
+  <comment id="DML_SCALAR_UNION::Int16">
+    <summary>A 16-bit signed integer.</summary>
+  </comment>
+  <comment id="DML_SCALAR_UNION::UInt16">
+    <summary>A 16-bit unsigned integer.</summary>
+  </comment>
+  <comment id="DML_SCALAR_UNION::Int32">
+    <summary>A 32-bit signed integer.</summary>
+  </comment>
+  <comment id="DML_SCALAR_UNION::UInt32">
+    <summary>A 32-bit unsigned integer.</summary>
+  </comment>
+  <comment id="DML_SCALAR_UNION::Int64">
+    <summary>A 64-bit signed integer.</summary>
+  </comment>
+  <comment id="DML_SCALAR_UNION::UInt64">
+    <summary>A 64-bit unsigned integer.</summary>
+  </comment>
+  <comment id="DML_SCALAR_UNION::Float32">
+    <summary>A single precision floating-point number.</summary>
+  </comment>
+  <comment id="DML_SCALAR_UNION::Float64">
+    <summary>A double precision floating-point number.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE_OPERATOR_DESC">
+    <summary>
+      <para>Resamples elements from the source to the destination tensor, using the scale factors to compute the destination tensor size. You can use a linear or nearest-neighbor interpolation mode.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_resample_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_RESAMPLE_OPERATOR_DESC::InputTensor">
+    <summary>The tensor containing the input data.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the output data to.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE_OPERATOR_DESC::InterpolationMode">
+    <summary>This field determines the kind of interpolation used to choose output pixels.
+
+- <b>DML_INTERPOLATION_MODE_NEAREST_NEIGHBOR</b>. Uses the <i>Nearest Neighbor</i> algorithm, which chooses the input element nearest to the corresponding pixel center for each output element.
+
+- <b>DML_INTERPOLATION_MODE_LINEAR</b>. Uses the <i>Quadrilinear</i> algorithm, which computes the output element by doing the weighted average of the 2 nearest neighboring input elements per dimension. Since all 4 dimensions can be resampled, the weighted average is computed on a total of 16 input elements for each output element.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE_OPERATOR_DESC::ScaleCount">
+    <summary>The number of values in the array <i>Scales</i> points to. This value must match the dimension count of <i>InputTensor</i> and <i>OutputTensor</i>, which has to be 4.</summary>
+  </comment>
+  <comment id="DML_RESAMPLE_OPERATOR_DESC::Scales">
+    <summary>The scales to apply when resampling the input, where scales &gt; 1 scale up the image and scales &lt; 1 scale down the image for that dimension. Note that the scales don't need to be exactly <c>OutputSize / InputSize</c>. If the input after scaling is larger than the output bound, then we crop it to the output size. On the other hand, if the input after scaling is smaller than the output bound, the output edges are clamped.</summary>
+  </comment>
+  <comment id="DML_GRAPH_EDGE_DESC">
+    <summary>
+      <para>A generic container for a connection within a graph of DirectML operators defined by <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_graph_desc">DML_GRAPH_DESC</a> and passed to [IDMLDevice1::CompileGraph](/windows/desktop/api/directml/nf-directml-idmldevice1-compilegraph).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_graph_edge_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_GRAPH_EDGE_DESC::Type">
+    <summary>The type of graph edge. See <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_graph_edge_type">DML_GRAPH_EDGE_TYPE</a> for available types, and <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_graph_desc">DML_GRAPH_DESC</a> for where to use each type.</summary>
+  </comment>
+  <comment id="DML_GRAPH_EDGE_DESC::Desc">
+    <summary>A pointer to the graph edge description. The type of the pointed-to struct must match the value specified in <i>Type</i>.</summary>
+  </comment>
+  <comment id="IDMLDevice::GetParentDevice">
+    <summary>
+      <para>Retrieves the Direct3D 12 device that was used to create this DirectML device.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldevice-getparentdevice" /></para>
+      <param name="riid">A reference to the globally unique identifier (GUID) of the interface that you wish to be returned in <i>ppv</i>. This is expected to be the GUID of <a href="https://docs.microsoft.com/windows/win32/api/d3d12/nn-d3d12-id3d12device">ID3D12Device</a>.</param>
+      <param name="ppv">A pointer to a memory block that receives a pointer to the device. This is the address of a pointer to an <a href="https://docs.microsoft.com/windows/win32/api/d3d12/nn-d3d12-id3d12device">ID3D12Device</a>, representing  the device.</param>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ACOSH_OPERATOR_DESC">
+    <summary>
+      <para>Computes the hyperbolic arccosine for each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_acosh_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ACOSH_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ACOSH_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ACOSH_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_CUMULATIVE_SUMMATION_OPERATOR_DESC">
+    <summary>
+      <para>Sums the elements of a tensor along an axis, writing the running tally of the summation into the output tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_cumulative_summation_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_CUMULATIVE_SUMMATION_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor containing elements to be summed.</summary>
+  </comment>
+  <comment id="DML_CUMULATIVE_SUMMATION_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the resulting cumulative summations to. This tensor must have the same sizes and data type as the <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_CUMULATIVE_SUMMATION_OPERATOR_DESC::Axis">
+    <summary>The index of the dimension to sum elements over. This value must be less than the <i>DimensionCount</i> of the <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_CUMULATIVE_SUMMATION_OPERATOR_DESC::AxisDirection">
+    <summary>One of the values of the <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_axis_direction">DML_AXIS_DIRECTION</a> enumeration. If set to <b>DML_AXIS_DIRECTION_INCREASING</b>, then the summation occurs by traversing the tensor along the specified axis by ascending element index. If set to <b>DML_AXIS_DIRECTION_DECREASING</b>, the reverse is true, and the summation occurs by traversing elements by descending index.</summary>
+  </comment>
+  <comment id="DML_CUMULATIVE_SUMMATION_OPERATOR_DESC::HasExclusiveSum">
+    <summary>If <b>TRUE</b>, then the value of the current element is excluded when writing the running tally to the output tensor. If <b>FALSE</b>, then the value of the current element is included in the running tally.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC">
+    <summary>
+      <para>Performs a convolution of the <i>FilterTensor</i> with the <i>InputTensor</i>. This operator supports a number of standard convolution configurations.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_convolution_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the input data. The expected dimensions of the <i>InputTensor</i> are <c>{ BatchCount, InputChannelCount, InputHeight, InputWidth }</c> for 4D, and <c>{ BatchCount, InputChannelCount, InputDepth, InputHeight, InputWidth }</c> for 5D.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::FilterTensor">
+    <summary>A tensor containing the filter data. The expected dimensions of the <i>FilterTensor</i> are <c>{ FilterBatchCount, FilterChannelCount, FilterHeight, FilterWidth }</c> for 4D, and <c>{ FilterBatchCount, FilterChannelCount, FilterDepth, FilterHeight, FilterWidth }</c> for 5D.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::BiasTensor">
+    <summary>An optional tensor containing the bias data—one value for each output channel. Assuming the <i>OutputTensor</i> has sizes of <c>{ BatchCount, OutputChannelCount, OutputHeight, OutputWidth }</c>, the expected dimensions of the <i>BiasTensor</i> are <c>{ 1, OutputChannelCount, 1, 1 }</c> for 4D, and <c>{ 1, OutputChannelCount, 1, 1, 1 }</c> for 5D.
+
+For each output channel, the single bias value for that channel is added to every element in that channel of the <i>OutputTensor</i>. That is, the <i>BiasTensor</i> is broadcasted to the size of the <i>OutputTensor</i>, and what the operator returns is the summation of this broadcasted <i>BiasTensor</i> with the result from convolution.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::OutputTensor">
+    <summary>A tensor to write the results to. The expected dimensions of the <i>OutputTensor</i> are <c>{ BatchCount, OutputChannelCount, OutputHeight, OutputWidth }</c> for 4D, and <c>{ BatchCount, OutputChannelCount, OutputDepth, OutputHeight, OutputWidth }</c> for 5D.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::Mode">
+    <summary>The mode to use for the convolution operation. <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_convolution_mode">DML_CONVOLUTION_MODE_CROSS_CORRELATION</a> is the behavior for required for typical inference scenarios. In contrast, <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_convolution_mode">DML_CONVOLUTION_MODE_CONVOLUTION</a> flips the order of elements in each filter kernel along each spatial dimension.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::Direction">
+    <summary>The direction of the convolution operation. <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_convolution_direction">DML_CONVOLUTION_DIRECTION_FORWARD</a> is the primary form of convolution used for inference where a combination of <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_convolution_direction">DML_CONVOLUTION_DIRECTION_FORWARD</a> and <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_convolution_direction">DML_CONVOLUTION_DIRECTION_BACKWARD</a> are used during training.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::DimensionCount">
+    <summary>The number of spatial dimensions for the convolution operation. Spatial dimensions are the lower dimensions of the convolution <i>FilterTensor</i>. For example, the width and height dimension are spatial dimensions of a 4D convolution filter tensor. This value also determines the size of the <i>Strides</i>, <i>Dilations</i>, <i>StartPadding</i>, <i>EndPadding</i>, and <i>OutputPadding</i> arrays. It should be set to 2 when <i>InputTensor.DimensionCount</i> is 4, and 3 when <i>InputTensor.DimensionCount</i> is 5.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::Strides">
+    <summary>An array containing the strides of the convolution operation. These strides are applied to the convolution filter. They are separate from the tensor strides included in <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_tensor_desc">DML_TENSOR_DESC</a>.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::Dilations">
+    <summary>An array containing the dilations of the convolution operation. Dilations are strides applied to the elements of the filter kernel. This has the effect of simulating a larger filter kernel by padding the internal filter kernel elements with zeros.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::StartPadding">
+    <summary>An array containing the padding values to be applied to the beginning of each spatial dimension of the filter and input tensor of the convolution operation. The start padding values are interpreted according to the <i>Direction</i> field.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::EndPadding">
+    <summary>An array containing the padding values to be applied to the end of each spatial dimension of the filter and input tensor of the convolution operation. The end padding values are interpreted according to the <i>Direction</i> field.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::OutputPadding">
+    <summary>An array containing the output padding of the convolution operation. <i>OutputPadding</i> applies a zero padding to the result of the convolution. This padding is applied to the end of each spatial dimension of the output tensor.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::GroupCount">
+    <summary>The number of groups which to divide the convolution operation up into. This can be used to achieve depth-wise convolution by setting <i>GroupCount</i> equal to the input channel count, and <i>Direction</i> equal to <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_convolution_direction">DML_CONVOLUTION_DIRECTION_FORWARD</a>. This divides the convolution up into a separate convolution per input channel.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_OPERATOR_DESC::FusedActivation">
+    <summary>An optional fused activation layer to apply after the convolution.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC">
+    <summary>
+      <para>Performs a mean variance normalization function on the input tensor. This operator will calculate the mean and variance of the input tensor to perform normalization.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_mean_variance_normalization1_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC::InputTensor">
+    <summary>A tensor containing the Input data. This tensor's dimensions should be <c>{ BatchCount, ChannelCount, Height, Width }</c>.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC::ScaleTensor">
+    <summary>An optional tensor containing the Scale data.
+
+If <b>DML_FEATURE_LEVEL</b> is less than <b>DML_FEATURE_LEVEL_4_0</b>, then this tensor's dimensions should be <c>{ ScaleBatchCount, ChannelCount, ScaleHeight, ScaleWidth }</c>. The dimensions ScaleBatchCount, ScaleHeight, and ScaleWidth should either match <i>InputTensor</i>, or be set to 1 to automatically broadcast those dimensions across the input.
+
+If <b>DML_FEATURE_LEVEL</b> is greater than or equal to <b>DML_FEATURE_LEVEL_4_0</b>, then any dimension can be set to 1, and be automatically broadcast to match <i>InputTensor</i>.
+
+This tensor is required if the <i>BiasTensor</i> is used.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC::BiasTensor">
+    <summary>An optional tensor containing the Bias data.
+
+If <b>DML_FEATURE_LEVEL</b> is less than <b>DML_FEATURE_LEVEL_4_0</b>, then this tensor's dimensions should be <c>{ BiasBatchCount, ChannelCount, BiasHeight, BiasWidth }</c>. The dimensions BiasBatchCount, BiasHeight, and BiasWidth should either match <i>InputTensor</i>, or be set to 1 to automatically broadcast those dimensions across the input.
+
+If <b>DML_FEATURE_LEVEL</b> is greater than or equal to <b>DML_FEATURE_LEVEL_4_0</b>, then any dimension can be set to 1, and be automatically broadcast to match <i>InputTensor</i>.
+
+This tensor is required if the <i>ScaleTensor</i> is used.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC::OutputTensor">
+    <summary>A tensor to write the results to. This tensor's dimensions are <c>{ BatchCount, ChannelCount, Height, Width }</c>.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC::AxisCount">
+    <summary>The number of axes. This field determines the size of the <i>Axes</i> array.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC::Axes">
+    <summary>The axes along which to calculate the Mean and Variance.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC::NormalizeVariance">
+    <summary><b>TRUE</b> if the Normalization layer includes Variance in the normalization calculation. Otherwise, <b>FALSE</b>. If <b>FALSE</b>, then normalization equation is <c>Output = FusedActivation(Scale * (Input - Mean) + Bias)</c>.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC::Epsilon">
+    <summary>The epsilon value to use to avoid division by zero. A value of 0.00001 is recommended as default.</summary>
+  </comment>
+  <comment id="DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC::FusedActivation">
+    <summary>An optional fused activation layer to apply after the normalization.</summary>
+  </comment>
+  <comment id="DML_FEATURE">
+    <summary>
+      <para>Defines a set of optional features and capabilities that can be queried from the DirectML device.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_feature" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_FEATURE::DML_FEATURE_TENSOR_DATA_TYPE_SUPPORT">
+    <summary>Allows querying for tensor data type support. The query type is <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_feature_query_tensor_data_type_support">DML_FEATURE_QUERY_TENSOR_DATA_TYPE_SUPPORT</a>, and the support data type is <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_feature_data_tensor_data_type_support">DML_FEATURE_DATA_TENSOR_DATA_TYPE_SUPPORT</a>.</summary>
+  </comment>
+  <comment id="DML_FEATURE::DML_FEATURE_FEATURE_LEVELS">
+    <summary>Allows querying for the feature levels supported by the device. The query type is <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_feature_query_feature_levels">DML_FEATURE_QUERY_FEATURE_LEVELS</a>, and the support data type is <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_feature_data_feature_levels">DML_FEATURE_DATA_FEATURE_LEVELS</a>.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR_DESC">
+    <summary>
+      <para>Performs the following linear dequantization function on every element in <i>InputTensor</i> with respect to its corresponding element in <i>ScaleTensor</i> and <c>ZeroPointTensor</c>, placing the results in the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_dequantize_linear_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR_DESC::InputTensor">
+    <summary>The tensor containing the inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR_DESC::ScaleTensor">
+    <summary>The tensor containing the scales.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR_DESC::ZeroPointTensor">
+    <summary>The tensor containing the zero point that was used for quantization.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IS_NAN_OPERATOR_DESC">
+    <summary>
+      <para>For each element of the input tensor, returns 1 if the input is NaN (as defined by IEEE-754), and 0 otherwise. The result is placed into the corresponding element of the output tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_is_nan_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IS_NAN_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IS_NAN_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="IDMLDebugDevice::SetMuteDebugOutput">
+    <summary>
+      <para>Determine whether to mute DirectML from sending messages to the ID3D12InfoQueue.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldebugdevice-setmutedebugoutput" /></para>
+      <param name="mute">If <b>TRUE</b>, DirectML is muted, and it will not send messages to the <a href="https://docs.microsoft.com/windows/win32/api/d3d12sdklayers/nn-d3d12sdklayers-id3d12infoqueue">ID3D12InfoQueue</a>. If <b>FALSE</b>, DirectML is not muted, and it will send messages to the <b>ID3D12InfoQueue</b>. The default value is <b>FALSE</b>.</param>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC">
+    <summary>
+      <para>Computes backpropagation gradients for a rectified linear unit (ReLU).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_activation_relu_grad_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC::InputTensor">
+    <summary>The input (feature) tensor. This is typically the same input as was provided during the forward pass (see <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_activation_relu_operator_desc">DML_ACTIVATION_RELU_OPERATOR_DESC</a>).</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC::InputGradientTensor">
+    <summary>The incoming gradient tensor. This is typically obtained from the output of backpropagation of a preceding layer. The <i>Sizes</i> and <i>DataType</i> of this tensor must exactly match those of the <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC::OutputTensor">
+    <summary>An output tensor containing the backpropagated gradients. The <i>Sizes</i> and <i>DataType</i> of this tensor must exactly match those of the <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="IDMLDevice::CreateCommandRecorder">
+    <summary>
+      <para>Creates a DirectML command recorder.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldevice-createcommandrecorder" /></para>
+      <param name="riid">A reference to the globally unique identifier (GUID) of the interface that you wish to be returned in <i>ppv</i>. This is expected to be the GUID of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlcommandrecorder">IDMLCommandRecorder</a>.</param>
+      <param name="ppv">A pointer to a memory block that receives a pointer to the command recorder. This is the address of a pointer to an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmlcommandrecorder">IDMLCommandRecorder</a>, representing  the command recorder created.</param>
+    </summary>
+  </comment>
+  <comment id="DMLCreateDevice">
+    <summary>
+      <para>Creates a DirectML device for a given Direct3D 12 device.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-dmlcreatedevice" /></para>
+      <param name="d3d12Device">A pointer to an <a href="https://docs.microsoft.com/windows/win32/api/d3d12/nn-d3d12-id3d12device">ID3D12Device</a> representing the Direct3D 12 device to create the DirectML device over. DirectML supports any D3D feature level, and Direct3D 12 devices created on any adapter, including WARP. However, not all features in DirectML may be available depending on the capabilities of the Direct3D 12 device. See [IDMLDevice::CheckFeatureSupport](/windows/win32/api/directml/nf-directml-idmldevice-checkfeaturesupport) for more info.
+
+If the call to <b>DMLCreateDevice</b> is successful, then the DirectML device maintains a strong reference to the supplied Direct3D 12 device.</param>
+      <param name="flags">A <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_create_device_flags">DML_CREATE_DEVICE_FLAGS</a> value specifying additional device creation options.</param>
+      <param name="riid">A reference to the globally unique identifier (GUID) of the interface that you wish to be returned in <i>device</i>. This is expected to be the GUID of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmldevice">IDMLDevice</a>.</param>
+      <param name="ppv">A pointer to a memory block that receives a pointer to the device. This is the address of a pointer to an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmldevice">IDMLDevice</a>, representing  the DirectML device created.</param>
+    </summary>
+  </comment>
+  <comment id="DML_FEATURE_DATA_TENSOR_DATA_TYPE_SUPPORT">
+    <summary>
+      <para>Provides detail about whether a DirectML device supports a particular data type within tensors.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_feature_data_tensor_data_type_support" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_FEATURE_DATA_TENSOR_DATA_TYPE_SUPPORT::IsSupported">
+    <summary><b>TRUE</b> if the tensor data type is supported within tensors by the DirectML device. Otherwise, <b>FALSE</b>.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC">
+    <summary>
+      <para>Computes the bitwise XOR (eXclusive OR) between each corresponding element of the input tensors, and writes the result into the output tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_bit_xor_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_BINDING_DESC">
+    <summary>
+      <para>Contains the description of a binding so that you can add it to the binding table via a call to one of the IDMLBindingTable methods.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_binding_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_BINDING_DESC::Type">
+    <summary>A <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_binding_type">DML_BINDING_TYPE</a> specifying the type of the binding; whether it refers to a single buffer, or to an array of buffers.</summary>
+  </comment>
+  <comment id="DML_BINDING_DESC::Desc">
+    <summary>A pointer to a constant structure whose type depends on the value <i>Type</i>. If <i>Type</i> is <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_binding_type">DML_BINDING_TYPE_BUFFER</a>, then <i>Desc</i> should point to a <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_buffer_binding">DML_BUFFER_BINDING</a>. If <i>Type</i> is <a href="https://docs.microsoft.com/windows/win32/api/directml/ne-directml-dml_binding_type">DML_BINDING_TYPE_BUFFER_ARRAY</a>, then <i>Desc</i> should point to a <a href="https://docs.microsoft.com/windows/win32/api/directml/ns-directml-dml_buffer_array_binding">DML_BUFFER_ARRAY_BINDING</a>.</summary>
+  </comment>
+  <comment id="DML_SLICE1_OPERATOR_DESC">
+    <summary>
+      <para>Extracts a single subregion (a "slice") of an input tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_slice1_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_SLICE1_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to extract slices from.</summary>
+  </comment>
+  <comment id="DML_SLICE1_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the sliced data results to.</summary>
+  </comment>
+  <comment id="DML_SLICE1_OPERATOR_DESC::DimensionCount">
+    <summary>The number of dimensions. This field determines the size of the <i>InputWindowOffsets</i>, <i>InputWindowSizes</i>, and <i>InputWindowStrides</i> arrays. This value must match the <i>DimensionCount</i> of the input and output tensors. This value must be between 1 and 8, inclusively, starting from <c>DML_FEATURE_LEVEL_3_0</c>; earlier feature levels require a value of either 4 or 5.</summary>
+  </comment>
+  <comment id="DML_SLICE1_OPERATOR_DESC::InputWindowOffsets">
+    <summary>An array containing the beginning (in elements) of the input window in each dimension. Values in the array must satisfy the constraint <c>InputWindowOffsets[i] + InputWindowSizes[i] &lt;= InputTensor.Sizes[i]</c></summary>
+  </comment>
+  <comment id="DML_SLICE1_OPERATOR_DESC::InputWindowSizes">
+    <summary>An array containing the extent (in elements) of the input window in each dimension. Values in the array must satisfy the constraint <c>InputWindowOffsets[i] + InputWindowSizes[i] &lt;= InputTensor.Sizes[i]</c></summary>
+  </comment>
+  <comment id="DML_SLICE1_OPERATOR_DESC::InputWindowStrides">
+    <summary>An array containing the slice's stride along each dimension of the input tensor, in elements. The magnitude of the stride indicates how many elements to advance when copying within the input window. The sign of the stride determines if elements are copied starting at the beginning of the window (positive stride) or end of the window (negative stride). Strides may not be 0.</summary>
+  </comment>
+  <comment id="IDMLDispatchable::GetBindingProperties">
+    <summary>
+      <para>Retrieves the binding properties for a dispatchable object (an operator initializer, or a compiled operator).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldispatchable-getbindingproperties" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_REDUCE_OPERATOR_DESC">
+    <summary>
+      <para>Outputs the reduction of elements (sum, product, minimum, and so on) within one or more dimensions of the input tensor.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_reduce_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_REDUCE_OPERATOR_DESC::Function">
+    <summary>Specifies the reduction function to apply to the input.</summary>
+  </comment>
+  <comment id="DML_REDUCE_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from.</summary>
+  </comment>
+  <comment id="DML_REDUCE_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. Each output element is the result of a reduction on a subset of elements from the <i>InputTensor</i>.
+
+- <i>DimensionCount</i> must match <i>InputTensor.DimensionCount</i> (the rank of the input tensor is preserved).
+- <i>Sizes</i> must match <i>InputTensor.Sizes</i>, except for dimensions included in the reduced <i>Axes</i>, which must be size 1.</summary>
+  </comment>
+  <comment id="DML_REDUCE_OPERATOR_DESC::AxisCount">
+    <summary>The number of axes to reduce. This field determines the size of the <i>Axes</i> array.</summary>
+  </comment>
+  <comment id="DML_REDUCE_OPERATOR_DESC::Axes">
+    <summary>The axes along which to reduce. Values must be in the range <c>[0, InputTensor.DimensionCount - 1]</c>.</summary>
+  </comment>
+  <comment id="IDMLObject::SetName">
+    <summary>
+      <para>Associates a name with the DirectML device object. This name is for use in debug diagnostics and tools.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmlobject-setname" /></para>
+      <param name="name">A <b>NULL</b>-terminated <b>UNICODE</b> string that contains the name to associate with the DirectML device object.</param>
+    </summary>
+  </comment>
+  <comment id="DML_OPERATOR_GRAPH_NODE_DESC">
+    <summary>
+      <para>Decribes a node within a graph of DirectML operators defined by <a href="https://docs.microsoft.com/windows/desktop/api/directml/ns-directml-dml_graph_desc">DML_GRAPH_DESC</a> and passed to [IDMLDevice1::CompileGraph](/windows/desktop/api/directml/nf-directml-idmldevice1-compilegraph).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_operator_graph_node_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_OPERATOR_GRAPH_NODE_DESC::Operator">
+    <summary>A DirectML operator defining the behavior of the node.</summary>
+  </comment>
+  <comment id="DML_OPERATOR_GRAPH_NODE_DESC::Name">
+    <summary>An optional name for the graph connection. If provided, this might be used within certain error messages emitted by the DirectML debug layer.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ABS_OPERATOR_DESC">
+    <summary>
+      <para>Computes the absolute value for each element of <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_abs_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ABS_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ABS_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_ABS_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC">
+    <summary>
+      <para>Replaces all elements of <i>InputTensor</i> below the given threshold, <i>Min</i>, with <i>Min</i>. Results are placed into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_threshold_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC::ScaleBias">
+    <summary>An optional scale and bias to apply to the input. If present, this has the effect of applying the function <c>g(x) = x * scale + bias</c> to each <i>input</i> element prior to computing this operator.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC::Min">
+    <summary>The minimum value, below which the operator replaces the value with <i>Min</i>.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING1_OPERATOR_DESC">
+    <summary>
+      <para>Computes the maximum value across the elements within the sliding window over the input tensor, and optionally returns the indices of the maximum values selected.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_max_pooling1_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_MAX_POOLING1_OPERATOR_DESC::InputTensor">
+    <summary>An input tensor of <i>Sizes</i> <c>{ BatchCount, ChannelCount, Height, Width }</c> if <i>InputTensor.DimensionCount</i> is 4, and <c>{ BatchCount, ChannelCount, Depth, Height, Weight } </c>if <i>InputTensor.DimensionCount</i> is 5.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING1_OPERATOR_DESC::OutputTensor">
+    <summary>An output tensor to write the results to. The sizes of the output tensor can be computed as follows.
+
+<code>
+OutputTensor-&gt;Sizes[0] = InputTensor-&gt;Sizes[0];
+OutputTensor-&gt;Sizes[1] = InputTensor-&gt;Sizes[1];
+
+for (UINT i = 0; i &lt; DimensionCount; ++i) {
+  UINT PaddedSize = InputTensor-&gt;Sizes[i + 2] + StartPadding[i] + EndPadding[i];
+  OutputTensor-&gt;Sizes[i + 2] = (PaddedSize - WindowSizes[i]) / Strides[i] + 1;
+}
+</code></summary>
+  </comment>
+  <comment id="DML_MAX_POOLING1_OPERATOR_DESC::OutputIndicesTensor">
+    <summary>An optional output tensor of indices to the input tensor <i>InputTensor</i> of the maximum values produced and stored in the <i>OutputTensor</i>. These index values are zero-based and treat the input tensor as a contiguous one-dimensional array. When multiple elements within the sliding window have the same value, the later equal values are ignored and the index points to the first value encountered. Both the <i>OutputTensor</i> and <i>OutputIndicesTensor</i> have the same tensor sizes.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING1_OPERATOR_DESC::DimensionCount">
+    <summary>The number of spatial dimensions of the input tensor <i>InputTensor</i>, which also corresponds to the number of dimensions of the sliding window <i>WindowSize</i>. This value also determines the size of the <i>Strides</i>, <i>StartPadding</i>, and <i>EndPadding</i> arrays. It should be set to 2 when <i>InputTensor</i> is 4D, and 3 when it's a 5D tensor.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING1_OPERATOR_DESC::Strides">
+    <summary>The strides for the sliding window dimensions of sizes <c>{ Height, Width }</c> when the <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING1_OPERATOR_DESC::WindowSize">
+    <summary>The dimensions of the sliding window in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING1_OPERATOR_DESC::StartPadding">
+    <summary>The number of padding elements to be applied to the beginning of each spatial dimension of the input tensor <i>InputTensor</i>. The values are in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING1_OPERATOR_DESC::EndPadding">
+    <summary>The number of padding elements to be applied to the end of each spatial dimension of the input tensor <i>InputTensor</i>. The values are in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="IDMLObject::SetPrivateData">
+    <summary>
+      <para>Sets application-defined data to a DirectML device object, and associates that data with an application-defined GUID.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmlobject-setprivatedata" /></para>
+      <param name="guid">The <b>GUID</b> to associate with the data.</param>
+      <param name="dataSize">The size in bytes of the data.</param>
+      <param name="data">A pointer to a memory block that contains the data to be stored with this DirectML device object. If <i>data</i> is <b>NULL</b>, then <i>dataSize</i> must be 0, and any data that was previously associated with the <b>GUID</b> specified in <i>guid</i> will be destroyed.</param>
+    </summary>
+  </comment>
+  <comment id="DML_MAX_POOLING2_OPERATOR_DESC">
+    <summary>
+      <para>Computes the maximum value across the elements within the sliding window over the input tensor, and optionally returns the indices of the maximum values selected.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_max_pooling2_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_MAX_POOLING2_OPERATOR_DESC::InputTensor">
+    <summary>An input tensor of <i>Sizes</i> <c>{ BatchCount, ChannelCount, Height, Width }</c> if <i>InputTensor.DimensionCount</i> is 4, and <c>{ BatchCount, ChannelCount, Depth, Height, Weight } </c>if <i>InputTensor.DimensionCount</i> is 5.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING2_OPERATOR_DESC::OutputTensor">
+    <summary>An output tensor to write the results to. The sizes of the output tensor can be computed as follows.
+
+<code>
+OutputTensor-&gt;Sizes[0] = InputTensor-&gt;Sizes[0];
+OutputTensor-&gt;Sizes[1] = InputTensor-&gt;Sizes[1];
+
+for (UINT i = 0; i &lt; DimensionCount; ++i) {
+  UINT PaddedSize = InputTensor-&gt;Sizes[i + 2] + StartPadding[i] + EndPadding[i];
+  OutputTensor-&gt;Sizes[i + 2] = (PaddedSize - WindowSizes[i]) / Strides[i] + 1;
+}
+</code></summary>
+  </comment>
+  <comment id="DML_MAX_POOLING2_OPERATOR_DESC::OutputIndicesTensor">
+    <summary>An optional output tensor of indices to the input tensor <i>InputTensor</i> of the maximum values produced and stored in the <i>OutputTensor</i>. These index values are zero-based and treat the input tensor as a contiguous one-dimensional array. When multiple elements within the sliding window have the same value, the later equal values are ignored and the index points to the first value encountered. Both the <i>OutputTensor</i> and <i>OutputIndicesTensor</i> have the same tensor sizes.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING2_OPERATOR_DESC::DimensionCount">
+    <summary>The number of spatial dimensions of the input tensor <i>InputTensor</i>, which also corresponds to the number of dimensions of the sliding window <i>WindowSize</i>. This value also determines the size of the <i>Strides</i>, <i>StartPadding</i>, and <i>EndPadding</i> arrays. It should be set to 2 when <i>InputTensor</i> is 4D, and 3 when it's a 5D tensor.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING2_OPERATOR_DESC::Strides">
+    <summary>The strides for the sliding window dimensions of sizes <c>{ Height, Width }</c> when the <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING2_OPERATOR_DESC::WindowSize">
+    <summary>The dimensions of the sliding window in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING2_OPERATOR_DESC::StartPadding">
+    <summary>The number of padding elements to be applied to the beginning of each spatial dimension of the input tensor <i>InputTensor</i>. The values are in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING2_OPERATOR_DESC::EndPadding">
+    <summary>The number of padding elements to be applied to the end of each spatial dimension of the input tensor <i>InputTensor</i>. The values are in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_MAX_POOLING2_OPERATOR_DESC::Dilations">
+    <summary>The values for each spatial dimension of the input tensor <i>InputTensor</i> by which an element within the sliding window is selected for every elements of that value. The values are in <c>{ Height, Width }</c> when <i>DimensionCount</i> is set to 2, or <c>{ Depth, Height, Width }</c> when set to 3.</summary>
+  </comment>
+  <comment id="DML_DEPTH_TO_SPACE_OPERATOR_DESC">
+    <summary>
+      <para>Rearranges (permutes) data from depth into blocks of spatial data. The operator outputs a copy of the input tensor where values from the depth dimension are moved in spatial blocks to the height and width dimensions.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_depth_to_space_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_DEPTH_TO_SPACE_OPERATOR_DESC::InputTensor">
+    <summary>The tensor to read from. The input tensor's dimensions are <c>{ BatchCount, InputChannelCount, InputHeight, InputWidth }</c>.</summary>
+  </comment>
+  <comment id="DML_DEPTH_TO_SPACE_OPERATOR_DESC::OutputTensor">
+    <summary>The tensor to write the results to. The output tensor's dimensions are <c>{ BatchCount, OutputChannelCount, OutputHeight, OutputWidth }</c>, where:
+
+* OutputChannelCount is computed as InputChannelCount / (<i>BlockSize</i> * <i>BlockSize</i>).
+* OutputHeight is computed as InputHeight * <i>BlockSize</i>.
+* OutputWidth is computed as InputWidth * <i>BlockSize</i>.</summary>
+  </comment>
+  <comment id="DML_DEPTH_TO_SPACE_OPERATOR_DESC::BlockSize">
+    <summary>The width and height of the blocks that are moved.</summary>
+  </comment>
+  <comment id="IDMLDeviceChild::GetDevice">
+    <summary>
+      <para>Retrieves the DirectML device that was used to create this object.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/nf-directml-idmldevicechild-getdevice" /></para>
+      <param name="riid">A reference to the globally unique identifier (GUID) of the interface that you wish to be returned in <i>ppv</i>. This is expected to be the GUID of <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmldevice">IDMLDevice</a>.</param>
+      <param name="ppv">A pointer to a memory block that receives a pointer to the DirectML device. This is the address of a pointer to an <a href="https://docs.microsoft.com/windows/win32/api/directml/nn-directml-idmldevice">IDMLDevice</a>, representing  the DirectML device.</param>
+    </summary>
+  </comment>
+  <comment id="DML_BINDING_PROPERTIES">
+    <summary>
+      <para>Contains information about the binding requirements of a particular compiled operator, or operator initializer. This struct is retrieved from IDMLDispatchable::GetBindingProperties.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_binding_properties" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_BINDING_PROPERTIES::RequiredDescriptorCount">
+    <summary>The minimum size, in descriptors, of the binding table required for a particular dispatchable object (an operator initializer, or a compiled operator).</summary>
+  </comment>
+  <comment id="DML_BINDING_PROPERTIES::TemporaryResourceSize">
+    <summary>The minimum size in bytes of the temporary resource that must be bound to the binding table for a particular dispatchable
+      object. A value of zero means that a temporary resource is not required.</summary>
+  </comment>
+  <comment id="DML_BINDING_PROPERTIES::PersistentResourceSize">
+    <summary>The minimum size in bytes of the persistent resource that must be bound to the binding table for a particular
+      dispatchable object. Persistent resources must be supplied during initialization of a compiled operator (where it
+      is bound as an output of the operator initializer) as well as during execution. A value of zero means that a
+      persistent resource is not required. Only compiled operators have persistent resources—operator initializers
+      always return a value of 0 for this member.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MIN_OPERATOR_DESC">
+    <summary>
+      <para>Takes the lesser of two corresponding elements from the input tensors, and places the result into the corresponding element of <i>OutputTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_min_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MIN_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MIN_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_MIN_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_DIRECTION">
+    <summary>
+      <para>Defines constants that specify a direction for the DirectML convolution operator (as described by the DML_CONVOLUTION_OPERATOR_DESC structure).</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ne-directml-dml_convolution_direction" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_DIRECTION::DML_CONVOLUTION_DIRECTION_FORWARD">
+    <summary>Indicates a forward convolution.</summary>
+  </comment>
+  <comment id="DML_CONVOLUTION_DIRECTION::DML_CONVOLUTION_DIRECTION_BACKWARD">
+    <summary>Indicates a backward convolution. Backward convolution is also known as <em>transposed</em> convolution.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IF_OPERATOR_DESC">
+    <summary>
+      <para>Selects elements either from <i>ATensor</i> or <i>BTensor</i>, depending on the value of the corresponding element in <i>ConditionTensor</i>. Non-zero elements of <i>ConditionTensor</i> select from <i>ATensor</i>, while zero-valued elements select from <i>BTensor</i>.</para>
+      <para>Microsoft Docs: <see href="https://docs.microsoft.com/windows/win32/api//directml/ns-directml-dml_element_wise_if_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IF_OPERATOR_DESC::ConditionTensor">
+    <summary>The condition tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IF_OPERATOR_DESC::ATensor">
+    <summary>A tensor containing the left-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IF_OPERATOR_DESC::BTensor">
+    <summary>A tensor containing the right-hand side inputs.</summary>
+  </comment>
+  <comment id="DML_ELEMENT_WISE_IF_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
 </comments>

--- a/src/Vortice.DirectML/DynamicQuantizeLinearOperatorDescription.cs
+++ b/src/Vortice.DirectML/DynamicQuantizeLinearOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_DYNAMIC_QUANTIZE_LINEAR_OPERATOR_DESC']/*" />
 public partial struct DynamicQuantizeLinearOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseAbsOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAbsOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_ABS_OPERATOR_DESC']/*" />
 public partial struct ElementWiseAbsOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseAcosOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAcosOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_ACOS_OPERATOR_DESC']/*" />
 public partial struct ElementWiseAcosOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseAcoshOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAcoshOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_ACOSH_OPERATOR_DESC']/*" />
 public partial struct ElementWiseAcoshOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseAdd1OperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAdd1OperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_ADD1_OPERATOR_DESC']/*" />
 public partial struct ElementWiseAdd1OperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseAddOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAddOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_ADD_OPERATOR_DESC']/*" />
 public partial struct ElementWiseAddOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseAsinOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAsinOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_ASIN_OPERATOR_DESC']/*" />
 public partial struct ElementWiseAsinOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseAsinhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAsinhOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_ASINH_OPERATOR_DESC']/*" />
 public partial struct ElementWiseAsinhOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseAtanOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAtanOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_ATAN_OPERATOR_DESC']/*" />
 public partial struct ElementWiseAtanOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseAtanYxOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAtanYxOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_ATAN_YX_OPERATOR_DESC']/*" />
 public partial struct ElementWiseAtanYxOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseAtanhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAtanhOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_ATANH_OPERATOR_DESC']/*" />
 public partial struct ElementWiseAtanhOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseBitAndOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitAndOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC']/*" />
 public partial struct ElementWiseBitAndOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseBitCountOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitCountOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_BIT_COUNT_OPERATOR_DESC']/*" />
 public partial struct ElementWiseBitCountOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseBitNotOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitNotOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_BIT_NOT_OPERATOR_DESC']/*" />
 public partial struct ElementWiseBitNotOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseBitOrOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitOrOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_BIT_OR_OPERATOR_DESC']/*" />
 public partial struct ElementWiseBitOrOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseBitShiftLeftOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitShiftLeftOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DESC']/*" />
 public partial struct ElementWiseBitShiftLeftOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseBitShiftRightOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitShiftRightOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_BIT_SHIFT_RIGHT_OPERATOR_DESC']/*" />
 public partial struct ElementWiseBitShiftRightOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseBitXorOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitXorOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC']/*" />
 public partial struct ElementWiseBitXorOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseCeilOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseCeilOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_CEIL_OPERATOR_DESC']/*" />
 public partial struct ElementWiseCeilOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseClipGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseClipGradOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_CLIP_GRAD_OPERATOR_DESC']/*" />
 public partial struct ElementWiseClipGradOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseClipOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseClipOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_CLIP_OPERATOR_DESC']/*" />
 public partial struct ElementWiseClipOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseConstantPowOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseConstantPowOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC']/*" />
 public partial struct ElementWiseConstantPowOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseCosOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseCosOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_COS_OPERATOR_DESC']/*" />
 public partial struct ElementWiseCosOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseCoshOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseCoshOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_COSH_OPERATOR_DESC']/*" />
 public partial struct ElementWiseCoshOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseDequantizeLinearOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseDequantizeLinearOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR_DESC']/*" />
 public partial struct ElementWiseDequantizeLinearOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseDifferenceSquareOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseDifferenceSquareOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_DIFFERENCE_SQUARE_OPERATOR_DESC']/*" />
 public partial struct ElementWiseDifferenceSquareOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseDivideOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseDivideOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_DIVIDE_OPERATOR_DESC']/*" />
 public partial struct ElementWiseDivideOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseErfOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseErfOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_ERF_OPERATOR_DESC']/*" />
 public partial struct ElementWiseErfOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseExpOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseExpOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_EXP_OPERATOR_DESC']/*" />
 public partial struct ElementWiseExpOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseFloorOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseFloorOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC']/*" />
 public partial struct ElementWiseFloorOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseIdentityOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseIdentityOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC']/*" />
 public partial struct ElementWiseIdentityOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseIfOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseIfOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_IF_OPERATOR_DESC']/*" />
 public partial struct ElementWiseIfOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseIsInfinityOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseIsInfinityOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC']/*" />
 public partial struct ElementWiseIsInfinityOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseIsNanOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseIsNanOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_IS_NAN_OPERATOR_DESC']/*" />
 public partial struct ElementWiseIsNanOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseLogOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_LOG_OPERATOR_DESC']/*" />
 public partial struct ElementWiseLogOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseLogicalAndOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalAndOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_LOGICAL_AND_OPERATOR_DESC']/*" />
 public partial struct ElementWiseLogicalAndOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseLogicalEqualsOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalEqualsOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DESC']/*" />
 public partial struct ElementWiseLogicalEqualsOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseLogicalGreaterThanOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalGreaterThanOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OPERATOR_DESC']/*" />
 public partial struct ElementWiseLogicalGreaterThanOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseLogicalGreaterThanOrEqualOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalGreaterThanOrEqualOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL_OPERATOR_DESC']/*" />
 public partial struct ElementWiseLogicalGreaterThanOrEqualOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseLogicalLessThanOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalLessThanOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OPERATOR_DESC']/*" />
 public partial struct ElementWiseLogicalLessThanOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseLogicalLessThanOrEqualOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalLessThanOrEqualOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL_OPERATOR_DESC']/*" />
 public partial struct ElementWiseLogicalLessThanOrEqualOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseLogicalNotOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalNotOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_LOGICAL_NOT_OPERATOR_DESC']/*" />
 public partial struct ElementWiseLogicalNotOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseLogicalOrOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalOrOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_LOGICAL_OR_OPERATOR_DESC']/*" />
 public partial struct ElementWiseLogicalOrOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseLogicalXorOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalXorOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC']/*" />
 public partial struct ElementWiseLogicalXorOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseMaxOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseMaxOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_MAX_OPERATOR_DESC']/*" />
 public partial struct ElementWiseMaxOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseMeanOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseMeanOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_MEAN_OPERATOR_DESC']/*" />
 public partial struct ElementWiseMeanOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseMinOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseMinOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_MIN_OPERATOR_DESC']/*" />
 public partial struct ElementWiseMinOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseModulusFloorOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseModulusFloorOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_MODULUS_FLOOR_OPERATOR_DESC']/*" />
 public partial struct ElementWiseModulusFloorOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseModulusTruncateOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseModulusTruncateOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_DESC']/*" />
 public partial struct ElementWiseModulusTruncateOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseMultiplyOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseMultiplyOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC']/*" />
 public partial struct ElementWiseMultiplyOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWisePowOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWisePowOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_POW_OPERATOR_DESC']/*" />
 public partial struct ElementWisePowOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseQuantizeLinearOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseQuantizeLinearOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC']/*" />
 public partial struct ElementWiseQuantizeLinearOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseQuantizedLinearAddOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseQuantizedLinearAddOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_QUANTIZED_LINEAR_ADD_OPERATOR_DESC']/*" />
 public partial struct ElementWiseQuantizedLinearAddOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseRecipOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseRecipOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_RECIP_OPERATOR_DESC']/*" />
 public partial struct ElementWiseRecipOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseRoundOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseRoundOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_ROUND_OPERATOR_DESC']/*" />
 public partial struct ElementWiseRoundOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseSignOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseSignOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_SIGN_OPERATOR_DESC']/*" />
 public partial struct ElementWiseSignOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseSinOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseSinOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_SIN_OPERATOR_DESC']/*" />
 public partial struct ElementWiseSinOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseSinhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseSinhOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_SINH_OPERATOR_DESC']/*" />
 public partial struct ElementWiseSinhOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseSqrtOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseSqrtOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_SQRT_OPERATOR_DESC']/*" />
 public partial struct ElementWiseSqrtOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseSubtractOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseSubtractOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC']/*" />
 public partial struct ElementWiseSubtractOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseTanOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseTanOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_TAN_OPERATOR_DESC']/*" />
 public partial struct ElementWiseTanOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseTanhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseTanhOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_TANH_OPERATOR_DESC']/*" />
 public partial struct ElementWiseTanhOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ElementWiseThresholdOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseThresholdOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC']/*" />
 public partial struct ElementWiseThresholdOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/FillValueConstantOperatorDescription.cs
+++ b/src/Vortice.DirectML/FillValueConstantOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_FILL_VALUE_CONSTANT_OPERATOR_DESC']/*" />
 public partial struct FillValueConstantOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/FillValueSequenceOperatorDescription.cs
+++ b/src/Vortice.DirectML/FillValueSequenceOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC']/*" />
 public partial struct FillValueSequenceOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/GatherElementsOperatorDescription.cs
+++ b/src/Vortice.DirectML/GatherElementsOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_GATHER_ELEMENTS_OPERATOR_DESC']/*" />
 public partial struct GatherElementsOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/GatherNd1OperatorDescription.cs
+++ b/src/Vortice.DirectML/GatherNd1OperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_GATHER_ND1_OPERATOR_DESC']/*" />
 public partial struct GatherNd1OperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/GatherNdOperatorDescription.cs
+++ b/src/Vortice.DirectML/GatherNdOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_GATHER_ND_OPERATOR_DESC']/*" />
 public partial struct GatherNdOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/GatherOperatorDescription.cs
+++ b/src/Vortice.DirectML/GatherOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_GATHER_OPERATOR_DESC']/*" />
 public partial struct GatherOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/GeneralMatrixMultiplyOperatorDescription.cs
+++ b/src/Vortice.DirectML/GeneralMatrixMultiplyOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_GEMM_OPERATOR_DESC']/*" />
 public partial struct GeneralMatrixMultiplyOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/GruOperatorDescription.cs
+++ b/src/Vortice.DirectML/GruOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_GRU_OPERATOR_DESC']/*" />
 public partial struct GruOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/JoinOperatorDescription.cs
+++ b/src/Vortice.DirectML/JoinOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_JOIN_OPERATOR_DESC']/*" />
 public partial struct JoinOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/LocalResponseNormalizationGradientOperatorDescription.cs
+++ b/src/Vortice.DirectML/LocalResponseNormalizationGradientOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_LOCAL_RESPONSE_NORMALIZATION_GRAD_OPERATOR_DESC']/*" />
 public partial struct LocalResponseNormalizationGradientOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/LocalResponseNormalizationOperatorDescription.cs
+++ b/src/Vortice.DirectML/LocalResponseNormalizationOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC']/*" />
 public partial struct LocalResponseNormalizationOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/LpNormalizationOperatorDescription.cs
+++ b/src/Vortice.DirectML/LpNormalizationOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_LP_NORMALIZATION_OPERATOR_DESC']/*" />
 public partial struct LpNormalizationOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/LpPoolingOperatorDescription.cs
+++ b/src/Vortice.DirectML/LpPoolingOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_LP_POOLING_OPERATOR_DESC']/*" />
 public partial struct LpPoolingOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/LstmOperatorDescription.cs
+++ b/src/Vortice.DirectML/LstmOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_LSTM_OPERATOR_DESC']/*" />
 public partial struct LstmOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/MatrixMultiplyIntegerOperatorDescription.cs
+++ b/src/Vortice.DirectML/MatrixMultiplyIntegerOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC']/*" />
 public partial struct MatrixMultiplyIntegerOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/MaxPooling1OperatorDescription.cs
+++ b/src/Vortice.DirectML/MaxPooling1OperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_MAX_POOLING1_OPERATOR_DESC']/*" />
 public partial struct MaxPooling1OperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/MaxPooling2OperatorDescription.cs
+++ b/src/Vortice.DirectML/MaxPooling2OperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_MAX_POOLING2_OPERATOR_DESC']/*" />
 public partial struct MaxPooling2OperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/MaxPoolingGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/MaxPoolingGradOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_MAX_POOLING_GRAD_OPERATOR_DESC']/*" />
 public partial struct MaxPoolingGradOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/MaxPoolingOperatorDescription.cs
+++ b/src/Vortice.DirectML/MaxPoolingOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_MAX_POOLING_OPERATOR_DESC']/*" />
 public partial struct MaxPoolingOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/MaxUnpoolingOperatorDescription.cs
+++ b/src/Vortice.DirectML/MaxUnpoolingOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_MAX_UNPOOLING_OPERATOR_DESC']/*" />
 public partial struct MaxUnpoolingOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/MeanVarianceNormalization1OperatorDescription.cs
+++ b/src/Vortice.DirectML/MeanVarianceNormalization1OperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC']/*" />
 public partial struct MeanVarianceNormalization1OperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/MeanVarianceNormalizationOperatorDescription.cs
+++ b/src/Vortice.DirectML/MeanVarianceNormalizationOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC']/*" />
 public partial struct MeanVarianceNormalizationOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/NonzeroCoordinatesOperatorDescription.cs
+++ b/src/Vortice.DirectML/NonzeroCoordinatesOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_NONZERO_COORDINATES_OPERATOR_DESC']/*" />
 public partial struct NonzeroCoordinatesOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/OneHotOperatorDescription.cs
+++ b/src/Vortice.DirectML/OneHotOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ONE_HOT_OPERATOR_DESC']/*" />
 public partial struct OneHotOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/PaddingOperatorDescription.cs
+++ b/src/Vortice.DirectML/PaddingOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_PADDING_OPERATOR_DESC']/*" />
 public partial struct PaddingOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/QuantizedLinearConvolutionOperatorDescription.cs
+++ b/src/Vortice.DirectML/QuantizedLinearConvolutionOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC']/*" />
 public partial struct QuantizedLinearConvolutionOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/QuantizedLinearMatrixMultiplyOperatorDescription.cs
+++ b/src/Vortice.DirectML/QuantizedLinearMatrixMultiplyOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC']/*" />
 public partial struct QuantizedLinearMatrixMultiplyOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/RandomGeneratorOperatorDescription.cs
+++ b/src/Vortice.DirectML/RandomGeneratorOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_RANDOM_GENERATOR_OPERATOR_DESC']/*" />
 public partial struct RandomGeneratorOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ReduceOperatorDescription.cs
+++ b/src/Vortice.DirectML/ReduceOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_REDUCE_OPERATOR_DESC']/*" />
 public partial struct ReduceOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/Resample1OperatorDescription.cs
+++ b/src/Vortice.DirectML/Resample1OperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_RESAMPLE1_OPERATOR_DESC']/*" />
 public partial struct Resample1OperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ResampleGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/ResampleGradOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_RESAMPLE_GRAD_OPERATOR_DESC']/*" />
 public partial struct ResampleGradOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ResampleOperatorDescription.cs
+++ b/src/Vortice.DirectML/ResampleOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_RESAMPLE_OPERATOR_DESC']/*" />
 public partial struct ResampleOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ReverseSubsequencesOperatorDescription.cs
+++ b/src/Vortice.DirectML/ReverseSubsequencesOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_REVERSE_SUBSEQUENCES_OPERATOR_DESC']/*" />
 public partial struct ReverseSubsequencesOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/RnnOperatorDescription.cs
+++ b/src/Vortice.DirectML/RnnOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_RNN_OPERATOR_DESC']/*" />
 public partial struct RnnOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/RoiAlign1OperatorDescription.cs
+++ b/src/Vortice.DirectML/RoiAlign1OperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ROI_ALIGN1_OPERATOR_DESC']/*" />
 public partial struct RoiAlign1OperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/RoiAlignOperatorDescription.cs
+++ b/src/Vortice.DirectML/RoiAlignOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ROI_ALIGN_OPERATOR_DESC']/*" />
 public partial struct RoiAlignOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/RoiPoolingOperatorDescription.cs
+++ b/src/Vortice.DirectML/RoiPoolingOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_ROI_POOLING_OPERATOR_DESC']/*" />
 public partial struct RoiPoolingOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ScatterNdOperatorDescription.cs
+++ b/src/Vortice.DirectML/ScatterNdOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_SCATTER_ND_OPERATOR_DESC']/*" />
 public partial struct ScatterNdOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ScatterOperatorDescription.cs
+++ b/src/Vortice.DirectML/ScatterOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_SCATTER_OPERATOR_DESC']/*" />
 public partial struct ScatterOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/Slice1OperatorDescription.cs
+++ b/src/Vortice.DirectML/Slice1OperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_SLICE1_OPERATOR_DESC']/*" />
 public partial struct Slice1OperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/SliceGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/SliceGradOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_SLICE_GRAD_OPERATOR_DESC']/*" />
 public partial struct SliceGradOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/SliceOperatorDescription.cs
+++ b/src/Vortice.DirectML/SliceOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_SLICE_OPERATOR_DESC']/*" />
 public partial struct SliceOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/SpaceToDepth1OperatorDescription.cs
+++ b/src/Vortice.DirectML/SpaceToDepth1OperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_SPACE_TO_DEPTH1_OPERATOR_DESC']/*" />
 public partial struct SpaceToDepth1OperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/SpaceToDepthOperatorDescription.cs
+++ b/src/Vortice.DirectML/SpaceToDepthOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_SPACE_TO_DEPTH_OPERATOR_DESC']/*" />
 public partial struct SpaceToDepthOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/SplitOperatorDescription.cs
+++ b/src/Vortice.DirectML/SplitOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_SPLIT_OPERATOR_DESC']/*" />
 public partial struct SplitOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/TileOperatorDescription.cs
+++ b/src/Vortice.DirectML/TileOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_TILE_OPERATOR_DESC']/*" />
 public partial struct TileOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/TopK1OperatorDescription.cs
+++ b/src/Vortice.DirectML/TopK1OperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_TOP_K1_OPERATOR_DESC']/*" />
 public partial struct TopK1OperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/TopKOperatorDescription.cs
+++ b/src/Vortice.DirectML/TopKOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_TOP_K_OPERATOR_DESC']/*" />
 public partial struct TopKOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/Upsample2DOperatorDescription.cs
+++ b/src/Vortice.DirectML/Upsample2DOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_UPSAMPLE_2D_OPERATOR_DESC']/*" />
 public partial struct Upsample2DOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>

--- a/src/Vortice.DirectML/ValueScale2DOperatorDescription.cs
+++ b/src/Vortice.DirectML/ValueScale2DOperatorDescription.cs
@@ -3,7 +3,6 @@
 
 namespace Vortice.DirectML;
 
-/// <include file="Documentation.xml" path="/comments/comment[@id='DML_VALUE_SCALE_2D_OPERATOR_DESC']/*" />
 public partial struct ValueScale2DOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
 {
     /// <summary>


### PR DESCRIPTION
Also strip includes cause they are generated. Will probably continue to improve. However, it requires the sharpgentools fix to fully work and compile without missing whitespace errors.

See documentation in: e4ee34e04968f0ab5a5f21f81b93c6499a12eb81

![image](https://user-images.githubusercontent.com/535918/165860581-fe244e38-2bdc-48dd-900d-f2efeafb1b4e.png)
