### PR TITLE
Make Tensors nullable for eligible fusable activation operatorDescs

### DIFF
--- a/src/Vortice.DirectML/ActivationCeluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationCeluOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationCeluOperatorDescription : IOperatorDescription, 
     public OperatorType OperatorType => OperatorType.ActivationCelu;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_CELU_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_CELU_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_CELU_OPERATOR_DESC::Alpha']/*" />
     public float Alpha { get; set; }
@@ -32,8 +32,8 @@ public partial struct ActivationCeluOperatorDescription : IOperatorDescription, 
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
         @ref->Alpha = Alpha;
 
         return new(@ref);
@@ -43,8 +43,15 @@ public partial struct ActivationCeluOperatorDescription : IOperatorDescription, 
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationEluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationEluOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationEluOperatorDescription : IOperatorDescription, I
     public OperatorType OperatorType => OperatorType.ActivationElu;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_ELU_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_ELU_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_ELU_OPERATOR_DESC::Alpha']/*" />
     public float Alpha { get; set; }
@@ -32,8 +32,8 @@ public partial struct ActivationEluOperatorDescription : IOperatorDescription, I
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
         @ref->Alpha = Alpha;
 
         return new(@ref);
@@ -43,8 +43,15 @@ public partial struct ActivationEluOperatorDescription : IOperatorDescription, I
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationHardSigmoidOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationHardSigmoidOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationHardSigmoidOperatorDescription : IOperatorDescri
     public OperatorType OperatorType => OperatorType.ActivationHardSigmoid;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC::Alpha']/*" />
     public float Alpha { get; set; }
@@ -36,8 +36,8 @@ public partial struct ActivationHardSigmoidOperatorDescription : IOperatorDescri
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
         @ref->Alpha = Alpha;
         @ref->Beta = Beta;
 
@@ -48,8 +48,15 @@ public partial struct ActivationHardSigmoidOperatorDescription : IOperatorDescri
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationIdentityOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationIdentityOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationIdentityOperatorDescription : IOperatorDescripti
     public OperatorType OperatorType => OperatorType.ActivationIdentity;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_IDENTITY_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_IDENTITY_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     #region Marshal
     [StructLayout(LayoutKind.Sequential, Pack = 0)]
@@ -28,8 +28,8 @@ public partial struct ActivationIdentityOperatorDescription : IOperatorDescripti
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
 
         return new(@ref);
     }
@@ -38,8 +38,15 @@ public partial struct ActivationIdentityOperatorDescription : IOperatorDescripti
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationLeakyReluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationLeakyReluOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationLeakyReluOperatorDescription : IOperatorDescript
     public OperatorType OperatorType => OperatorType.ActivationLeakyRelu;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC::Alpha']/*" />
     public float Alpha { get; set; }
@@ -32,8 +32,8 @@ public partial struct ActivationLeakyReluOperatorDescription : IOperatorDescript
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
         @ref->Alpha = Alpha;
 
         return new(@ref);
@@ -43,8 +43,15 @@ public partial struct ActivationLeakyReluOperatorDescription : IOperatorDescript
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationLinearOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationLinearOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationLinearOperatorDescription : IOperatorDescription
     public OperatorType OperatorType => OperatorType.ActivationLinear;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_LINEAR_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_LINEAR_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_LINEAR_OPERATOR_DESC::Alpha']/*" />
     public float Alpha { get; set; }
@@ -36,8 +36,8 @@ public partial struct ActivationLinearOperatorDescription : IOperatorDescription
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
         @ref->Alpha = Alpha;
         @ref->Beta = Beta;
 
@@ -48,8 +48,15 @@ public partial struct ActivationLinearOperatorDescription : IOperatorDescription
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationParametricSoftplusOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationParametricSoftplusOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationParametricSoftplusOperatorDescription : IOperato
     public OperatorType OperatorType => OperatorType.ActivationParametricSoftplus;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC::Alpha']/*" />
     public float Alpha { get; set; }
@@ -36,8 +36,8 @@ public partial struct ActivationParametricSoftplusOperatorDescription : IOperato
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
         @ref->Alpha = Alpha;
         @ref->Beta = Beta;
 
@@ -48,8 +48,15 @@ public partial struct ActivationParametricSoftplusOperatorDescription : IOperato
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationReluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationReluOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationReluOperatorDescription : IOperatorDescription, 
     public OperatorType OperatorType => OperatorType.ActivationRelu;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_RELU_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_RELU_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     #region Marshal
     [StructLayout(LayoutKind.Sequential, Pack = 0)]
@@ -28,8 +28,8 @@ public partial struct ActivationReluOperatorDescription : IOperatorDescription, 
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
 
         return new(@ref);
     }
@@ -38,8 +38,15 @@ public partial struct ActivationReluOperatorDescription : IOperatorDescription, 
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationScaledEluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationScaledEluOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationScaledEluOperatorDescription : IOperatorDescript
     public OperatorType OperatorType => OperatorType.ActivationScaledElu;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC::Alpha']/*" />
     public float Alpha { get; set; }
@@ -36,8 +36,8 @@ public partial struct ActivationScaledEluOperatorDescription : IOperatorDescript
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
         @ref->Alpha = Alpha;
         @ref->Gamma = Gamma;
 
@@ -48,8 +48,15 @@ public partial struct ActivationScaledEluOperatorDescription : IOperatorDescript
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationScaledTanhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationScaledTanhOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationScaledTanhOperatorDescription : IOperatorDescrip
     public OperatorType OperatorType => OperatorType.ActivationScaledTanh;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC::Alpha']/*" />
     public float Alpha { get; set; }
@@ -36,8 +36,8 @@ public partial struct ActivationScaledTanhOperatorDescription : IOperatorDescrip
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
         @ref->Alpha = Alpha;
         @ref->Beta = Beta;
 
@@ -48,8 +48,15 @@ public partial struct ActivationScaledTanhOperatorDescription : IOperatorDescrip
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationShrinkOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationShrinkOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationShrinkOperatorDescription : IOperatorDescription
     public OperatorType OperatorType => OperatorType.ActivationShrink;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SHRINK_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SHRINK_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SHRINK_OPERATOR_DESC::Bias']/*" />
     public float Bias { get; set; }
@@ -36,8 +36,8 @@ public partial struct ActivationShrinkOperatorDescription : IOperatorDescription
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
         @ref->Bias = Bias;
         @ref->Threshold = Threshold;
 
@@ -48,8 +48,15 @@ public partial struct ActivationShrinkOperatorDescription : IOperatorDescription
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationSigmoidOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationSigmoidOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationSigmoidOperatorDescription : IOperatorDescriptio
     public OperatorType OperatorType => OperatorType.ActivationSigmoid;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SIGMOID_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SIGMOID_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     #region Marshal
     [StructLayout(LayoutKind.Sequential, Pack = 0)]
@@ -28,8 +28,8 @@ public partial struct ActivationSigmoidOperatorDescription : IOperatorDescriptio
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
 
         return new(@ref);
     }
@@ -38,8 +38,15 @@ public partial struct ActivationSigmoidOperatorDescription : IOperatorDescriptio
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationSoftplusOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationSoftplusOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationSoftplusOperatorDescription : IOperatorDescripti
     public OperatorType OperatorType => OperatorType.ActivationSoftplus;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC::Steepness']/*" />
     public float Steepness { get; set; }
@@ -32,8 +32,8 @@ public partial struct ActivationSoftplusOperatorDescription : IOperatorDescripti
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
         @ref->Steepness = Steepness;
 
         return new(@ref);
@@ -43,8 +43,15 @@ public partial struct ActivationSoftplusOperatorDescription : IOperatorDescripti
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationSoftsignOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationSoftsignOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationSoftsignOperatorDescription : IOperatorDescripti
     public OperatorType OperatorType => OperatorType.ActivationSoftsign;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     #region Marshal
     [StructLayout(LayoutKind.Sequential, Pack = 0)]
@@ -28,8 +28,8 @@ public partial struct ActivationSoftsignOperatorDescription : IOperatorDescripti
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
 
         return new(@ref);
     }
@@ -38,8 +38,15 @@ public partial struct ActivationSoftsignOperatorDescription : IOperatorDescripti
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationTanhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationTanhOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationTanhOperatorDescription : IOperatorDescription, 
     public OperatorType OperatorType => OperatorType.ActivationTanh;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_TANH_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_TANH_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     #region Marshal
     [StructLayout(LayoutKind.Sequential, Pack = 0)]
@@ -28,8 +28,8 @@ public partial struct ActivationTanhOperatorDescription : IOperatorDescription, 
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
 
         return new(@ref);
     }
@@ -38,8 +38,15 @@ public partial struct ActivationTanhOperatorDescription : IOperatorDescription, 
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }

--- a/src/Vortice.DirectML/ActivationThresholdedReluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationThresholdedReluOperatorDescription.cs
@@ -11,10 +11,10 @@ public partial struct ActivationThresholdedReluOperatorDescription : IOperatorDe
     public OperatorType OperatorType => OperatorType.ActivationThresholdedRelu;
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC::InputTensor']/*" />
-    public TensorDescription InputTensor { get; set; }
+    public TensorDescription? InputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC::OutputTensor']/*" />
-    public TensorDescription OutputTensor { get; set; }
+    public TensorDescription? OutputTensor { get; set; }
 
     /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC::Alpha']/*" />
     public float Alpha { get; set; }
@@ -32,8 +32,8 @@ public partial struct ActivationThresholdedReluOperatorDescription : IOperatorDe
     {
         __Native* @ref = UnsafeUtilities.Alloc<__Native>();
 
-        @ref->InputTensor = InputTensor.__MarshalAlloc();
-        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->InputTensor = (InputTensor != null) ? InputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
+        @ref->OutputTensor = (OutputTensor != null) ? OutputTensor.Value.__MarshalAlloc() : IntPtr.Zero;
         @ref->Alpha = Alpha;
 
         return new(@ref);
@@ -43,8 +43,15 @@ public partial struct ActivationThresholdedReluOperatorDescription : IOperatorDe
     {
         var @ref = (__Native*)pDesc;
 
-        InputTensor.__MarshalFree(ref @ref->InputTensor);
-        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+        if (InputTensor != null)
+        {
+            InputTensor.Value.__MarshalFree(ref @ref->InputTensor);
+        }
+
+        if (OutputTensor != null)
+        {
+            OutputTensor.Value.__MarshalFree(ref @ref->OutputTensor);
+        }
 
         UnsafeUtilities.Free(@ref);
     }


### PR DESCRIPTION
Listed OperatorDescriptions must have nullable tensorDescs when used as part of fused activations. Not that this is NOT all activation operators. See https://docs.microsoft.com/en-us/windows/ai/directml/dml-fused-activations#:~:text=Fused%20activations%20are%20a%20performance,a%20roundtrip%20to%20graphics%20memory.