### PR TITLE
Nullability fixes for WriteBufferImmediate() and barriers

### DIFF
--- a/src/Vortice.Direct3D12/ID3D12GraphicsCommandList2.cs
+++ b/src/Vortice.Direct3D12/ID3D12GraphicsCommandList2.cs
@@ -5,16 +5,11 @@ namespace Vortice.Direct3D12;
 
 public partial class ID3D12GraphicsCommandList2
 {
-    public void WriteBufferImmediate(int count, WriteBufferImmediateParameter[] @params, WriteBufferImmediateMode[] modes)
+    public void WriteBufferImmediate(WriteBufferImmediateParameter[] @params, WriteBufferImmediateMode[]? modes = null)
     {
-        WriteBufferImmediate_(count, @params, modes);
-    }
-
-    public void WriteBufferImmediate(WriteBufferImmediateParameter[] @params, WriteBufferImmediateMode[] modes)
-    {
-        if (@params.Length != modes.Length)
+        if (modes != null && @params.Length != modes.Length)
         {
-            throw new InvalidOperationException($"params and modes need to have same length");
+            throw new ArgumentException($"If {nameof(modes)} is not null, it must have the same length as {nameof(@params)}", nameof(modes));
         }
 
         WriteBufferImmediate_(@params.Length, @params, modes);

--- a/src/Vortice.Direct3D12/ResourceBarrier.cs
+++ b/src/Vortice.Direct3D12/ResourceBarrier.cs
@@ -65,7 +65,7 @@ public partial struct ResourceBarrier
     /// <param name="stateAfter">The state after.</param>
     /// <param name="subresource">The subresource.</param>
     /// <param name="flags">The transition flags.</param>
-    /// <returns>New intance of <see cref="ResourceBarrier"/> struct.</returns>
+    /// <returns>New instance of <see cref="ResourceBarrier"/> struct.</returns>
     public static ResourceBarrier BarrierTransition(ID3D12Resource resource, ResourceStates stateBefore, ResourceStates stateAfter,
         int subresource = D3D12.ResourceBarrierAllSubResources, ResourceBarrierFlags flags = ResourceBarrierFlags.None)
     {
@@ -77,8 +77,8 @@ public partial struct ResourceBarrier
     /// </summary>
     /// <param name="resourceBefore">The resource before.</param>
     /// <param name="resourceAfter">The resource after.</param>
-    /// <returns>New intance of <see cref="ResourceBarrier"/> struct.</returns>
-    public static ResourceBarrier BarrierAliasing(ID3D12Resource resourceBefore, ID3D12Resource resourceAfter)
+    /// <returns>New instance of <see cref="ResourceBarrier"/> struct.</returns>
+    public static ResourceBarrier BarrierAliasing(ID3D12Resource? resourceBefore, ID3D12Resource? resourceAfter)
     {
         return new ResourceBarrier(new ResourceAliasingBarrier(resourceBefore, resourceAfter));
     }
@@ -87,8 +87,8 @@ public partial struct ResourceBarrier
     /// Create a new UAV resource barrier instance.
     /// </summary>
     /// <param name="resource">The resource.</param>
-    /// <returns>New intance of <see cref="ResourceBarrier"/> struct.</returns>
-    public static ResourceBarrier BarrierUnorderedAccessView(ID3D12Resource resource)
+    /// <returns>New instance of <see cref="ResourceBarrier"/> struct.</returns>
+    public static ResourceBarrier BarrierUnorderedAccessView(ID3D12Resource? resource)
     {
         return new ResourceBarrier(new ResourceUnorderedAccessViewBarrier(resource));
     }


### PR DESCRIPTION
For WriteBufferImmediate(), the modes parameter is nullable, see [here](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist2-writebufferimmediate). I removed an overload which doesn't seem to be needed but which is a small breaking change; feel free to revert this if you don't like it.

The pResource parameter in the UAV barrier structure is optional, see [here](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_resource_uav_barrier).

Both resource parameters in the aliasing barrier structure are optional, see [here](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_resource_aliasing_barrier).