### PR TITLE
Move implicit cast to OperatorDescription instead of specializations

### DIFF
--- a/src/Vortice.DirectML/ActivationCeluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationCeluOperatorDescription.cs
@@ -56,9 +56,4 @@ public partial struct ActivationCeluOperatorDescription : IFusableActivationOper
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationCeluOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationEluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationEluOperatorDescription.cs
@@ -56,9 +56,4 @@ public partial struct ActivationEluOperatorDescription : IFusableActivationOpera
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationEluOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationHardSigmoidOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationHardSigmoidOperatorDescription.cs
@@ -61,9 +61,4 @@ public partial struct ActivationHardSigmoidOperatorDescription : IFusableActivat
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationHardSigmoidOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationHardmaxOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationHardmaxOperatorDescription.cs
@@ -44,9 +44,4 @@ public partial struct ActivationHardmaxOperatorDescription : IOperatorDescriptio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationHardmaxOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationIdentityOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationIdentityOperatorDescription.cs
@@ -51,9 +51,4 @@ public partial struct ActivationIdentityOperatorDescription : IFusableActivation
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationIdentityOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationLeakyReluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationLeakyReluOperatorDescription.cs
@@ -56,9 +56,4 @@ public partial struct ActivationLeakyReluOperatorDescription : IFusableActivatio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationLeakyReluOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationLinearOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationLinearOperatorDescription.cs
@@ -61,9 +61,4 @@ public partial struct ActivationLinearOperatorDescription : IFusableActivationOp
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationLinearOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationLogSoftmaxOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationLogSoftmaxOperatorDescription.cs
@@ -44,9 +44,4 @@ public partial struct ActivationLogSoftmaxOperatorDescription : IOperatorDescrip
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationLogSoftmaxOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationParameterizedReluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationParameterizedReluOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ActivationParameterizedReluOperatorDescription : IOperator
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationParameterizedReluOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationParametricSoftplusOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationParametricSoftplusOperatorDescription.cs
@@ -61,9 +61,4 @@ public partial struct ActivationParametricSoftplusOperatorDescription : IFusable
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationParametricSoftplusOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationReluGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationReluGradOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ActivationReluGradOperatorDescription : IOperatorDescripti
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationReluGradOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationReluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationReluOperatorDescription.cs
@@ -51,9 +51,4 @@ public partial struct ActivationReluOperatorDescription : IFusableActivationOper
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationReluOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationScaledEluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationScaledEluOperatorDescription.cs
@@ -61,9 +61,4 @@ public partial struct ActivationScaledEluOperatorDescription : IFusableActivatio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationScaledEluOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationScaledTanhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationScaledTanhOperatorDescription.cs
@@ -61,9 +61,4 @@ public partial struct ActivationScaledTanhOperatorDescription : IFusableActivati
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationScaledTanhOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationShrinkOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationShrinkOperatorDescription.cs
@@ -61,9 +61,4 @@ public partial struct ActivationShrinkOperatorDescription : IFusableActivationOp
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationShrinkOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationSigmoidOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationSigmoidOperatorDescription.cs
@@ -51,9 +51,4 @@ public partial struct ActivationSigmoidOperatorDescription : IFusableActivationO
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationSigmoidOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationSoftmaxOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationSoftmaxOperatorDescription.cs
@@ -44,9 +44,4 @@ public partial struct ActivationSoftmaxOperatorDescription : IOperatorDescriptio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationSoftmaxOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationSoftplusOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationSoftplusOperatorDescription.cs
@@ -56,9 +56,4 @@ public partial struct ActivationSoftplusOperatorDescription : IFusableActivation
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationSoftplusOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationSoftsignOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationSoftsignOperatorDescription.cs
@@ -51,9 +51,4 @@ public partial struct ActivationSoftsignOperatorDescription : IFusableActivation
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationSoftsignOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationTanhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationTanhOperatorDescription.cs
@@ -51,9 +51,4 @@ public partial struct ActivationTanhOperatorDescription : IFusableActivationOper
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationTanhOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ActivationThresholdedReluOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationThresholdedReluOperatorDescription.cs
@@ -56,9 +56,4 @@ public partial struct ActivationThresholdedReluOperatorDescription : IFusableAct
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ActivationThresholdedReluOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/AdamOptimizerOperatorDescription.cs
+++ b/src/Vortice.DirectML/AdamOptimizerOperatorDescription.cs
@@ -100,9 +100,4 @@ public partial struct AdamOptimizerOperatorDescription : IOperatorDescription, I
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(AdamOptimizerOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ArgmaxOperatorDescription.cs
+++ b/src/Vortice.DirectML/ArgmaxOperatorDescription.cs
@@ -57,9 +57,4 @@ public partial struct ArgmaxOperatorDescription : IOperatorDescription, IOperato
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ArgmaxOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ArgminOperatorDescription.cs
+++ b/src/Vortice.DirectML/ArgminOperatorDescription.cs
@@ -57,9 +57,4 @@ public partial struct ArgminOperatorDescription : IOperatorDescription, IOperato
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ArgminOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/AveragePoolingGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/AveragePoolingGradOperatorDescription.cs
@@ -81,9 +81,4 @@ public partial struct AveragePoolingGradOperatorDescription : IOperatorDescripti
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(AveragePoolingGradOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/AveragePoolingOperatorDescription.cs
+++ b/src/Vortice.DirectML/AveragePoolingOperatorDescription.cs
@@ -81,9 +81,4 @@ public partial struct AveragePoolingOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(AveragePoolingOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/BatchNormalizationGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/BatchNormalizationGradOperatorDescription.cs
@@ -85,9 +85,4 @@ public partial struct BatchNormalizationGradOperatorDescription : IOperatorDescr
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(BatchNormalizationGradOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/BatchNormalizationOperatorDescription.cs
+++ b/src/Vortice.DirectML/BatchNormalizationOperatorDescription.cs
@@ -88,9 +88,4 @@ public partial struct BatchNormalizationOperatorDescription : IOperatorDescripti
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(BatchNormalizationOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/BatchNormalizationTrainingGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/BatchNormalizationTrainingGradOperatorDescription.cs
@@ -85,9 +85,4 @@ public partial struct BatchNormalizationTrainingGradOperatorDescription : IOpera
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(BatchNormalizationTrainingGradOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/BatchNormalizationTrainingOperatorDescription.cs
+++ b/src/Vortice.DirectML/BatchNormalizationTrainingOperatorDescription.cs
@@ -94,9 +94,4 @@ public partial struct BatchNormalizationTrainingOperatorDescription : IOperatorD
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(BatchNormalizationTrainingOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/CastOperatorDescription.cs
+++ b/src/Vortice.DirectML/CastOperatorDescription.cs
@@ -44,9 +44,4 @@ public partial struct CastOperatorDescription : IOperatorDescription, IOperatorD
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(CastOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ConvolutionIntegerOperatorDescription.cs
+++ b/src/Vortice.DirectML/ConvolutionIntegerOperatorDescription.cs
@@ -109,9 +109,4 @@ public partial struct ConvolutionIntegerOperatorDescription : IOperatorDescripti
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ConvolutionIntegerOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ConvolutionOperatorDescription.cs
+++ b/src/Vortice.DirectML/ConvolutionOperatorDescription.cs
@@ -125,9 +125,4 @@ public partial struct ConvolutionOperatorDescription : IOperatorDescription, IOp
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ConvolutionOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/CumulativeProductOperatorDescription.cs
+++ b/src/Vortice.DirectML/CumulativeProductOperatorDescription.cs
@@ -59,9 +59,4 @@ public partial struct CumulativeProductOperatorDescription : IOperatorDescriptio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(CumulativeProductOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/CumulativeSummationOperatorDescription.cs
+++ b/src/Vortice.DirectML/CumulativeSummationOperatorDescription.cs
@@ -59,9 +59,4 @@ public partial struct CumulativeSummationOperatorDescription : IOperatorDescript
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(CumulativeSummationOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/DepthToSpace1OperatorDescription.cs
+++ b/src/Vortice.DirectML/DepthToSpace1OperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct DepthToSpace1OperatorDescription : IOperatorDescription, I
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(DepthToSpace1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/DepthToSpaceOperatorDescription.cs
+++ b/src/Vortice.DirectML/DepthToSpaceOperatorDescription.cs
@@ -49,9 +49,4 @@ public partial struct DepthToSpaceOperatorDescription : IOperatorDescription, IO
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(DepthToSpaceOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/DiagonalMatrixOperatorDescription.cs
+++ b/src/Vortice.DirectML/DiagonalMatrixOperatorDescription.cs
@@ -48,9 +48,4 @@ public partial struct DiagonalMatrixOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(DiagonalMatrixOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/DynamicQuantizeLinearOperatorDescription.cs
+++ b/src/Vortice.DirectML/DynamicQuantizeLinearOperatorDescription.cs
@@ -56,9 +56,4 @@ public partial struct DynamicQuantizeLinearOperatorDescription : IOperatorDescri
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(DynamicQuantizeLinearOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseAbsOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAbsOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseAbsOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseAbsOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseAcosOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAcosOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseAcosOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseAcosOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseAcoshOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAcoshOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseAcoshOperatorDescription : IOperatorDescription
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseAcoshOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseAdd1OperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAdd1OperatorDescription.cs
@@ -60,9 +60,4 @@ public partial struct ElementWiseAdd1OperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseAdd1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseAddOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAddOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseAddOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseAddOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseAsinOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAsinOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseAsinOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseAsinOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseAsinhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAsinhOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseAsinhOperatorDescription : IOperatorDescription
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseAsinhOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseAtanOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAtanOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseAtanOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseAtanOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseAtanYXOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAtanYXOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseAtanYXOperatorDescription : IOperatorDescriptio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseAtanYXOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseAtanhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseAtanhOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseAtanhOperatorDescription : IOperatorDescription
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseAtanhOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseBitAndOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitAndOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseBitAndOperatorDescription : IOperatorDescriptio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseBitAndOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseBitCountOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitCountOperatorDescription.cs
@@ -44,9 +44,4 @@ public partial struct ElementWiseBitCountOperatorDescription : IOperatorDescript
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseBitCountOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseBitNotOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitNotOperatorDescription.cs
@@ -44,9 +44,4 @@ public partial struct ElementWiseBitNotOperatorDescription : IOperatorDescriptio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseBitNotOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseBitOrOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitOrOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseBitOrOperatorDescription : IOperatorDescription
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseBitOrOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseBitShiftLeftOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitShiftLeftOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseBitShiftLeftOperatorDescription : IOperatorDesc
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseBitShiftLeftOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseBitShiftRightOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitShiftRightOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseBitShiftRightOperatorDescription : IOperatorDes
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseBitShiftRightOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseBitXorOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseBitXorOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseBitXorOperatorDescription : IOperatorDescriptio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseBitXorOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseCeilOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseCeilOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseCeilOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseCeilOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseClip1OperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseClip1OperatorDescription.cs
@@ -69,9 +69,4 @@ public partial struct ElementWiseClip1OperatorDescription : IOperatorDescription
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseClip1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseClipGrad1OperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseClipGrad1OperatorDescription.cs
@@ -65,9 +65,4 @@ public partial struct ElementWiseClipGrad1OperatorDescription : IOperatorDescrip
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseClipGrad1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseClipGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseClipGradOperatorDescription.cs
@@ -60,9 +60,4 @@ public partial struct ElementWiseClipGradOperatorDescription : IOperatorDescript
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseClipGradOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseClipOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseClipOperatorDescription.cs
@@ -64,9 +64,4 @@ public partial struct ElementWiseClipOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseClipOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseConstantPowOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseConstantPowOperatorDescription.cs
@@ -59,9 +59,4 @@ public partial struct ElementWiseConstantPowOperatorDescription : IOperatorDescr
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseConstantPowOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseCosOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseCosOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseCosOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseCosOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseCoshOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseCoshOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseCoshOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseCoshOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseDequantizeLinearOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseDequantizeLinearOperatorDescription.cs
@@ -56,9 +56,4 @@ public partial struct ElementWiseDequantizeLinearOperatorDescription : IOperator
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseDequantizeLinearOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseDifferenceSquareOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseDifferenceSquareOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseDifferenceSquareOperatorDescription : IOperator
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseDifferenceSquareOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseDivideOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseDivideOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseDivideOperatorDescription : IOperatorDescriptio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseDivideOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseErfOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseErfOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseErfOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseErfOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseExpOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseExpOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseExpOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseExpOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseFloorOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseFloorOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseFloorOperatorDescription : IOperatorDescription
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseFloorOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseIdentityOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseIdentityOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseIdentityOperatorDescription : IOperatorDescript
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseIdentityOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseIfOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseIfOperatorDescription.cs
@@ -56,9 +56,4 @@ public partial struct ElementWiseIfOperatorDescription : IOperatorDescription, I
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseIfOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseIsInfinityOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseIsInfinityOperatorDescription.cs
@@ -49,9 +49,4 @@ public partial struct ElementWiseIsInfinityOperatorDescription : IOperatorDescri
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseIsInfinityOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseIsNanOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseIsNanOperatorDescription.cs
@@ -44,9 +44,4 @@ public partial struct ElementWiseIsNanOperatorDescription : IOperatorDescription
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseIsNanOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseLogOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseLogOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseLogOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseLogicalAndOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalAndOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseLogicalAndOperatorDescription : IOperatorDescri
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseLogicalAndOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseLogicalEqualsOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalEqualsOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseLogicalEqualsOperatorDescription : IOperatorDes
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseLogicalEqualsOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseLogicalGreaterThanOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalGreaterThanOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseLogicalGreaterThanOperatorDescription : IOperat
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseLogicalGreaterThanOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseLogicalGreaterThanOrEqualOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalGreaterThanOrEqualOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseLogicalGreaterThanOrEqualOperatorDescription : 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseLogicalGreaterThanOrEqualOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseLogicalLessThanOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalLessThanOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseLogicalLessThanOperatorDescription : IOperatorD
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseLogicalLessThanOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseLogicalLessThanOrEqualOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalLessThanOrEqualOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseLogicalLessThanOrEqualOperatorDescription : IOp
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseLogicalLessThanOrEqualOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseLogicalNotOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalNotOperatorDescription.cs
@@ -44,9 +44,4 @@ public partial struct ElementWiseLogicalNotOperatorDescription : IOperatorDescri
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseLogicalNotOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseLogicalOrOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalOrOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseLogicalOrOperatorDescription : IOperatorDescrip
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseLogicalOrOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseLogicalXorOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseLogicalXorOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseLogicalXorOperatorDescription : IOperatorDescri
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseLogicalXorOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseMaxOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseMaxOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseMaxOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseMaxOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseMeanOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseMeanOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseMeanOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseMeanOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseMinOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseMinOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseMinOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseMinOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseModulusFloorOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseModulusFloorOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseModulusFloorOperatorDescription : IOperatorDesc
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseModulusFloorOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseModulusTruncateOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseModulusTruncateOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseModulusTruncateOperatorDescription : IOperatorD
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseModulusTruncateOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseMultiplyOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseMultiplyOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseMultiplyOperatorDescription : IOperatorDescript
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseMultiplyOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseNegateOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseNegateOperatorDescription.cs
@@ -44,9 +44,4 @@ public partial struct ElementWiseNegateOperatorDescription : IOperatorDescriptio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseNegateOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWisePowOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWisePowOperatorDescription.cs
@@ -60,9 +60,4 @@ public partial struct ElementWisePowOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWisePowOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseQuantizeLinearOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseQuantizeLinearOperatorDescription.cs
@@ -56,9 +56,4 @@ public partial struct ElementWiseQuantizeLinearOperatorDescription : IOperatorDe
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseQuantizeLinearOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseQuantizedLinearAddOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseQuantizedLinearAddOperatorDescription.cs
@@ -101,9 +101,4 @@ public partial struct ElementWiseQuantizedLinearAddOperatorDescription : IOperat
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseQuantizedLinearAddOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseRecipOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseRecipOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseRecipOperatorDescription : IOperatorDescription
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseRecipOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseRoundOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseRoundOperatorDescription.cs
@@ -49,9 +49,4 @@ public partial struct ElementWiseRoundOperatorDescription : IOperatorDescription
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseRoundOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseSignOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseSignOperatorDescription.cs
@@ -44,9 +44,4 @@ public partial struct ElementWiseSignOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseSignOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseSinOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseSinOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseSinOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseSinOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseSinhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseSinhOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseSinhOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseSinhOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseSqrtOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseSqrtOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseSqrtOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseSqrtOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseSubtractOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseSubtractOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct ElementWiseSubtractOperatorDescription : IOperatorDescript
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseSubtractOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseTanOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseTanOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseTanOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseTanOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseTanhOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseTanhOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct ElementWiseTanhOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseTanhOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ElementWiseThresholdOperatorDescription.cs
+++ b/src/Vortice.DirectML/ElementWiseThresholdOperatorDescription.cs
@@ -59,9 +59,4 @@ public partial struct ElementWiseThresholdOperatorDescription : IOperatorDescrip
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ElementWiseThresholdOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/FillValueConstantOperatorDescription.cs
+++ b/src/Vortice.DirectML/FillValueConstantOperatorDescription.cs
@@ -48,9 +48,4 @@ public partial struct FillValueConstantOperatorDescription : IOperatorDescriptio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(FillValueConstantOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/FillValueSequenceOperatorDescription.cs
+++ b/src/Vortice.DirectML/FillValueSequenceOperatorDescription.cs
@@ -53,9 +53,4 @@ public partial struct FillValueSequenceOperatorDescription : IOperatorDescriptio
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(FillValueSequenceOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/GatherElementsOperatorDescription.cs
+++ b/src/Vortice.DirectML/GatherElementsOperatorDescription.cs
@@ -55,9 +55,4 @@ public partial struct GatherElementsOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(GatherElementsOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/GatherNd1OperatorDescription.cs
+++ b/src/Vortice.DirectML/GatherNd1OperatorDescription.cs
@@ -65,9 +65,4 @@ public partial struct GatherNd1OperatorDescription : IOperatorDescription, IOper
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(GatherNd1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/GatherNdOperatorDescription.cs
+++ b/src/Vortice.DirectML/GatherNdOperatorDescription.cs
@@ -60,9 +60,4 @@ public partial struct GatherNdOperatorDescription : IOperatorDescription, IOpera
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(GatherNdOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/GatherOperatorDescription.cs
+++ b/src/Vortice.DirectML/GatherOperatorDescription.cs
@@ -60,9 +60,4 @@ public partial struct GatherOperatorDescription : IOperatorDescription, IOperato
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(GatherOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/GeneralMatrixMultiplyOperatorDescription.cs
+++ b/src/Vortice.DirectML/GeneralMatrixMultiplyOperatorDescription.cs
@@ -91,9 +91,4 @@ public partial struct GeneralMatrixMultiplyOperatorDescription : IOperatorDescri
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(GeneralMatrixMultiplyOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/GruOperatorDescription.cs
+++ b/src/Vortice.DirectML/GruOperatorDescription.cs
@@ -139,9 +139,4 @@ public partial struct GruOperatorDescription : IOperatorDescription, IOperatorDe
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(GruOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/JoinOperatorDescription.cs
+++ b/src/Vortice.DirectML/JoinOperatorDescription.cs
@@ -72,9 +72,4 @@ public partial struct JoinOperatorDescription : IOperatorDescription, IOperatorD
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(JoinOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/LocalResponseNormalizationGradientOperatorDescription.cs
+++ b/src/Vortice.DirectML/LocalResponseNormalizationGradientOperatorDescription.cs
@@ -75,9 +75,4 @@ public partial struct LocalResponseNormalizationGradientOperatorDescription : IO
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(LocalResponseNormalizationGradientOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/LocalResponseNormalizationOperatorDescription.cs
+++ b/src/Vortice.DirectML/LocalResponseNormalizationOperatorDescription.cs
@@ -69,9 +69,4 @@ public partial struct LocalResponseNormalizationOperatorDescription : IOperatorD
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(LocalResponseNormalizationOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/LpNormalizationOperatorDescription.cs
+++ b/src/Vortice.DirectML/LpNormalizationOperatorDescription.cs
@@ -59,9 +59,4 @@ public partial struct LpNormalizationOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(LpNormalizationOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/LpPoolingOperatorDescription.cs
+++ b/src/Vortice.DirectML/LpPoolingOperatorDescription.cs
@@ -81,9 +81,4 @@ public partial struct LpPoolingOperatorDescription : IOperatorDescription, IOper
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(LpPoolingOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/LstmOperatorDescription.cs
+++ b/src/Vortice.DirectML/LstmOperatorDescription.cs
@@ -179,9 +179,4 @@ public partial struct LstmOperatorDescription : IOperatorDescription, IOperatorD
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(LstmOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/MatrixMultiplyIntegerOperatorDescription.cs
+++ b/src/Vortice.DirectML/MatrixMultiplyIntegerOperatorDescription.cs
@@ -72,9 +72,4 @@ public partial struct MatrixMultiplyIntegerOperatorDescription : IOperatorDescri
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(MatrixMultiplyIntegerOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/MaxPooling1OperatorDescription.cs
+++ b/src/Vortice.DirectML/MaxPooling1OperatorDescription.cs
@@ -87,9 +87,4 @@ public partial struct MaxPooling1OperatorDescription : IOperatorDescription, IOp
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(MaxPooling1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/MaxPooling2OperatorDescription.cs
+++ b/src/Vortice.DirectML/MaxPooling2OperatorDescription.cs
@@ -94,9 +94,4 @@ public partial struct MaxPooling2OperatorDescription : IOperatorDescription, IOp
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(MaxPooling2OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/MaxPoolingGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/MaxPoolingGradOperatorDescription.cs
@@ -89,9 +89,4 @@ public partial struct MaxPoolingGradOperatorDescription : IOperatorDescription, 
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(MaxPoolingGradOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/MaxPoolingOperatorDescription.cs
+++ b/src/Vortice.DirectML/MaxPoolingOperatorDescription.cs
@@ -76,9 +76,4 @@ public partial struct MaxPoolingOperatorDescription : IOperatorDescription, IOpe
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(MaxPoolingOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/MaxUnpoolingOperatorDescription.cs
+++ b/src/Vortice.DirectML/MaxUnpoolingOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct MaxUnpoolingOperatorDescription : IOperatorDescription, IO
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(MaxUnpoolingOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/MeanVarianceNormalization1OperatorDescription.cs
+++ b/src/Vortice.DirectML/MeanVarianceNormalization1OperatorDescription.cs
@@ -93,9 +93,4 @@ public partial struct MeanVarianceNormalization1OperatorDescription : IOperatorD
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(MeanVarianceNormalization1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/MeanVarianceNormalizationOperatorDescription.cs
+++ b/src/Vortice.DirectML/MeanVarianceNormalizationOperatorDescription.cs
@@ -90,9 +90,4 @@ public partial struct MeanVarianceNormalizationOperatorDescription : IOperatorDe
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(MeanVarianceNormalizationOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/NonzeroCoordinatesOperatorDescription.cs
+++ b/src/Vortice.DirectML/NonzeroCoordinatesOperatorDescription.cs
@@ -50,9 +50,4 @@ public partial struct NonzeroCoordinatesOperatorDescription : IOperatorDescripti
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(NonzeroCoordinatesOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/OneHotOperatorDescription.cs
+++ b/src/Vortice.DirectML/OneHotOperatorDescription.cs
@@ -55,9 +55,4 @@ public partial struct OneHotOperatorDescription : IOperatorDescription, IOperato
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(OneHotOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/OperatorDescription.cs
+++ b/src/Vortice.DirectML/OperatorDescription.cs
@@ -13,6 +13,11 @@ public partial struct OperatorDescription
         Description = description;
     }
 
+    public static implicit operator OperatorDescription(IOperatorDescription description)
+    {
+        return new OperatorDescription(description);
+    }
+
     #region Marshal
     [StructLayout(LayoutKind.Sequential, Pack = 0)]
     internal struct __Native

--- a/src/Vortice.DirectML/Padding1OperatorDescription.cs
+++ b/src/Vortice.DirectML/Padding1OperatorDescription.cs
@@ -77,9 +77,4 @@ public partial struct Padding1OperatorDescription : IOperatorDescription, IOpera
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(Padding1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/PaddingOperatorDescription.cs
+++ b/src/Vortice.DirectML/PaddingOperatorDescription.cs
@@ -72,9 +72,4 @@ public partial struct PaddingOperatorDescription : IOperatorDescription, IOperat
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(PaddingOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/QuantizedLinearConvolutionOperatorDescription.cs
+++ b/src/Vortice.DirectML/QuantizedLinearConvolutionOperatorDescription.cs
@@ -148,9 +148,4 @@ public partial struct QuantizedLinearConvolutionOperatorDescription : IOperatorD
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(QuantizedLinearConvolutionOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/QuantizedLinearMatrixMultiplyOperatorDescription.cs
+++ b/src/Vortice.DirectML/QuantizedLinearMatrixMultiplyOperatorDescription.cs
@@ -101,9 +101,4 @@ public partial struct QuantizedLinearMatrixMultiplyOperatorDescription : IOperat
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(QuantizedLinearMatrixMultiplyOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/RandomGeneratorOperatorDescription.cs
+++ b/src/Vortice.DirectML/RandomGeneratorOperatorDescription.cs
@@ -59,9 +59,4 @@ public partial struct RandomGeneratorOperatorDescription : IOperatorDescription,
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(RandomGeneratorOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ReduceOperatorDescription.cs
+++ b/src/Vortice.DirectML/ReduceOperatorDescription.cs
@@ -57,9 +57,4 @@ public partial struct ReduceOperatorDescription : IOperatorDescription, IOperato
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ReduceOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/Resample1OperatorDescription.cs
+++ b/src/Vortice.DirectML/Resample1OperatorDescription.cs
@@ -74,9 +74,4 @@ public partial struct Resample1OperatorDescription : IOperatorDescription, IOper
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(Resample1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ResampleGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/ResampleGradOperatorDescription.cs
@@ -74,9 +74,4 @@ public partial struct ResampleGradOperatorDescription : IOperatorDescription, IO
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ResampleGradOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ResampleOperatorDescription.cs
+++ b/src/Vortice.DirectML/ResampleOperatorDescription.cs
@@ -57,9 +57,4 @@ public partial struct ResampleOperatorDescription : IOperatorDescription, IOpera
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ResampleOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ReverseSubsequencesOperatorDescription.cs
+++ b/src/Vortice.DirectML/ReverseSubsequencesOperatorDescription.cs
@@ -55,9 +55,4 @@ public partial struct ReverseSubsequencesOperatorDescription : IOperatorDescript
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ReverseSubsequencesOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/RnnOperatorDescription.cs
+++ b/src/Vortice.DirectML/RnnOperatorDescription.cs
@@ -134,9 +134,4 @@ public partial struct RnnOperatorDescription : IOperatorDescription, IOperatorDe
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(RnnOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/RoiAlign1OperatorDescription.cs
+++ b/src/Vortice.DirectML/RoiAlign1OperatorDescription.cs
@@ -106,9 +106,4 @@ public partial struct RoiAlign1OperatorDescription : IOperatorDescription, IOper
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(RoiAlign1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/RoiAlignGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/RoiAlignGradOperatorDescription.cs
@@ -125,9 +125,4 @@ public partial struct RoiAlignGradOperatorDescription : IOperatorDescription, IO
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(RoiAlignGradOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/RoiAlignOperatorDescription.cs
+++ b/src/Vortice.DirectML/RoiAlignOperatorDescription.cs
@@ -91,9 +91,4 @@ public partial struct RoiAlignOperatorDescription : IOperatorDescription, IOpera
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(RoiAlignOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/RoiPoolingOperatorDescription.cs
+++ b/src/Vortice.DirectML/RoiPoolingOperatorDescription.cs
@@ -60,9 +60,4 @@ public partial struct RoiPoolingOperatorDescription : IOperatorDescription, IOpe
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(RoiPoolingOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ScatterNdOperatorDescription.cs
+++ b/src/Vortice.DirectML/ScatterNdOperatorDescription.cs
@@ -66,9 +66,4 @@ public partial struct ScatterNdOperatorDescription : IOperatorDescription, IOper
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ScatterNdOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ScatterOperatorDescription.cs
+++ b/src/Vortice.DirectML/ScatterOperatorDescription.cs
@@ -61,9 +61,4 @@ public partial struct ScatterOperatorDescription : IOperatorDescription, IOperat
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ScatterOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/Slice1OperatorDescription.cs
+++ b/src/Vortice.DirectML/Slice1OperatorDescription.cs
@@ -69,9 +69,4 @@ public partial struct Slice1OperatorDescription : IOperatorDescription, IOperato
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(Slice1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/SliceGradOperatorDescription.cs
+++ b/src/Vortice.DirectML/SliceGradOperatorDescription.cs
@@ -69,9 +69,4 @@ public partial struct SliceGradOperatorDescription : IOperatorDescription, IOper
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(SliceGradOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/SliceOperatorDescription.cs
+++ b/src/Vortice.DirectML/SliceOperatorDescription.cs
@@ -69,9 +69,4 @@ public partial struct SliceOperatorDescription : IOperatorDescription, IOperator
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(SliceOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/SpaceToDepth1OperatorDescription.cs
+++ b/src/Vortice.DirectML/SpaceToDepth1OperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct SpaceToDepth1OperatorDescription : IOperatorDescription, I
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(SpaceToDepth1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/SpaceToDepthOperatorDescription.cs
+++ b/src/Vortice.DirectML/SpaceToDepthOperatorDescription.cs
@@ -49,9 +49,4 @@ public partial struct SpaceToDepthOperatorDescription : IOperatorDescription, IO
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(SpaceToDepthOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/SplitOperatorDescription.cs
+++ b/src/Vortice.DirectML/SplitOperatorDescription.cs
@@ -71,9 +71,4 @@ public partial struct SplitOperatorDescription : IOperatorDescription, IOperator
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(SplitOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/TileOperatorDescription.cs
+++ b/src/Vortice.DirectML/TileOperatorDescription.cs
@@ -52,9 +52,4 @@ public partial struct TileOperatorDescription : IOperatorDescription, IOperatorD
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(TileOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/TopK1OperatorDescription.cs
+++ b/src/Vortice.DirectML/TopK1OperatorDescription.cs
@@ -65,9 +65,4 @@ public partial struct TopK1OperatorDescription : IOperatorDescription, IOperator
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(TopK1OperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/TopKOperatorDescription.cs
+++ b/src/Vortice.DirectML/TopKOperatorDescription.cs
@@ -60,9 +60,4 @@ public partial struct TopKOperatorDescription : IOperatorDescription, IOperatorD
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(TopKOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/Upsample2DOperatorDescription.cs
+++ b/src/Vortice.DirectML/Upsample2DOperatorDescription.cs
@@ -54,9 +54,4 @@ public partial struct Upsample2DOperatorDescription : IOperatorDescription, IOpe
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(Upsample2DOperatorDescription description)
-    {
-        return new(description);
-    }
 }

--- a/src/Vortice.DirectML/ValueScale2DOperatorDescription.cs
+++ b/src/Vortice.DirectML/ValueScale2DOperatorDescription.cs
@@ -57,9 +57,4 @@ public partial struct ValueScale2DOperatorDescription : IOperatorDescription, IO
         UnsafeUtilities.Free(@ref);
     }
     #endregion
-
-    public static implicit operator OperatorDescription(ValueScale2DOperatorDescription description)
-    {
-        return new(description);
-    }
 }


### PR DESCRIPTION
More catch all and lower code solution which allows automatic creation from IOperatorDescription or IFusableActivationOperatorDescriptions.

Addition in src/Vortice.DirectML/OperatorDescription.cs

I haven't been able to build this so relying on the presubmits.