### PR TITLE
Fix methods in ID3D12Device4 and ID3D12Device7 so they accept base types.

### DIFF
--- a/src/Vortice.Direct3D12/ID3D12Device4.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device4.cs
@@ -6,24 +6,24 @@ namespace Vortice.Direct3D12;
 public partial class ID3D12Device4
 {
     #region CreateCommandList1
-    public T CreateCommandList1<T>(CommandListType type, CommandListFlags commandListFlags = CommandListFlags.None) where T : ID3D12GraphicsCommandList1
+    public T CreateCommandList1<T>(CommandListType type, CommandListFlags commandListFlags = CommandListFlags.None) where T : ID3D12CommandList
     {
         CreateCommandList1(0, type, commandListFlags, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr);
     }
 
-    public T CreateCommandList1<T>(int nodeMask, CommandListType type, CommandListFlags commandListFlags = CommandListFlags.None) where T : ID3D12GraphicsCommandList1
+    public T CreateCommandList1<T>(int nodeMask, CommandListType type, CommandListFlags commandListFlags = CommandListFlags.None) where T : ID3D12CommandList
     {
         CreateCommandList1(nodeMask, type, commandListFlags, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr);
     }
 
-    public Result CreateCommandList1<T>(CommandListType type, CommandListFlags commandListFlags, out T? commandList) where T : ID3D12GraphicsCommandList1
+    public Result CreateCommandList1<T>(CommandListType type, CommandListFlags commandListFlags, out T? commandList) where T : ID3D12CommandList
     {
         return CreateCommandList1<T>(0, type, commandListFlags, out commandList);
     }
 
-    public Result CreateCommandList1<T>(int nodeMask, CommandListType type, CommandListFlags commandListFlags, out T? commandList) where T : ID3D12GraphicsCommandList1
+    public Result CreateCommandList1<T>(int nodeMask, CommandListType type, CommandListFlags commandListFlags, out T? commandList) where T : ID3D12CommandList
     {
         Result result = CreateCommandList1(nodeMask, type, commandListFlags, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -44,7 +44,7 @@ public partial class ID3D12Device4
         ResourceDescription description,
         ResourceStates initialResourceState,
         ID3D12ProtectedResourceSession protectedSession,
-        ClearValue? optimizedClearValue = null) where T : ID3D12Resource1
+        ClearValue? optimizedClearValue = null) where T : ID3D12Resource
     {
         CreateCommittedResource1(ref heapProperties, heapFlags,
             ref description,
@@ -61,7 +61,7 @@ public partial class ID3D12Device4
         ResourceDescription description,
         ResourceStates initialResourceState,
         ID3D12ProtectedResourceSession protectedSession,
-        out T? resource) where T : ID3D12Resource1
+        out T? resource) where T : ID3D12Resource
     {
         Result result = CreateCommittedResource1(ref heapProperties, heapFlags,
             ref description,
@@ -86,7 +86,7 @@ public partial class ID3D12Device4
         ResourceStates initialResourceState,
         ID3D12ProtectedResourceSession protectedSession,
         ClearValue optimizedClearValue,
-        out T? resource) where T : ID3D12Resource1
+        out T? resource) where T : ID3D12Resource
     {
         Result result = CreateCommittedResource1(ref heapProperties, heapFlags,
             ref description,
@@ -106,13 +106,13 @@ public partial class ID3D12Device4
     #endregion
 
     #region CreateHeap1
-    public T CreateHeap1<T>(HeapDescription description, ID3D12ProtectedResourceSession protectedSession) where T : ID3D12Heap1
+    public T CreateHeap1<T>(HeapDescription description, ID3D12ProtectedResourceSession protectedSession) where T : ID3D12Heap
     {
         CreateHeap1(ref description, protectedSession, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr);
     }
 
-    public Result CreateHeap1<T>(HeapDescription description, ID3D12ProtectedResourceSession protectedSession, out T? heap) where T : ID3D12Heap1
+    public Result CreateHeap1<T>(HeapDescription description, ID3D12ProtectedResourceSession protectedSession, out T? heap) where T : ID3D12Heap
     {
         Result result = CreateHeap1(ref description, protectedSession, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -148,13 +148,13 @@ public partial class ID3D12Device4
     #endregion
 
     #region CreateReservedResource1
-    public T CreateReservedResource1<T>(ResourceDescription description, ResourceStates initialState, ClearValue clearValue, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12Resource1
+    public T CreateReservedResource1<T>(ResourceDescription description, ResourceStates initialState, ClearValue clearValue, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12Resource
     {
         CreateReservedResource1(ref description, initialState, clearValue, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr);
     }
 
-    public Result CreateReservedResource1<T>(ResourceDescription description, ResourceStates initialState, ClearValue clearValue, ID3D12ProtectedResourceSession protectedResourceSession, out T? resource) where T : ID3D12Resource1
+    public Result CreateReservedResource1<T>(ResourceDescription description, ResourceStates initialState, ClearValue clearValue, ID3D12ProtectedResourceSession protectedResourceSession, out T? resource) where T : ID3D12Resource
     {
         Result result = CreateReservedResource1(ref description, initialState, clearValue, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -167,13 +167,13 @@ public partial class ID3D12Device4
         return result;
     }
 
-    public T CreateReservedResource1<T>(ResourceDescription description, ResourceStates initialState, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12Resource1
+    public T CreateReservedResource1<T>(ResourceDescription description, ResourceStates initialState, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12Resource
     {
         CreateReservedResource1(ref description, initialState, null, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr);
     }
 
-    public Result CreateReservedResource1<T>(ResourceDescription description, ResourceStates initialState, ID3D12ProtectedResourceSession protectedResourceSession, out T? resource) where T : ID3D12Resource1
+    public Result CreateReservedResource1<T>(ResourceDescription description, ResourceStates initialState, ID3D12ProtectedResourceSession protectedResourceSession, out T? resource) where T : ID3D12Resource
     {
         Result result = CreateReservedResource1(ref description, initialState, null, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/ID3D12Device7.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device7.cs
@@ -24,13 +24,13 @@ public partial class ID3D12Device7
         return result;
     }
 
-    public T CreateProtectedResourceSession1<T>(ProtectedResourceSessionDescription1 description) where T : ID3D12ProtectedResourceSession1
+    public T CreateProtectedResourceSession1<T>(ProtectedResourceSessionDescription1 description) where T : ID3D12ProtectedResourceSession
     {
         CreateProtectedResourceSession1(ref description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr);
     }
 
-    public Result CreateProtectedResourceSession1<T>(ProtectedResourceSessionDescription1 description, out T? session) where T : ID3D12ProtectedResourceSession1
+    public Result CreateProtectedResourceSession1<T>(ProtectedResourceSessionDescription1 description, out T? session) where T : ID3D12ProtectedResourceSession
     {
         Result result = CreateProtectedResourceSession1(ref description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)


### PR DESCRIPTION
The Create() methods in ID3D12Device4 and ID3D12Device7 do accept the GUIDs of base types, and it's often convenient to use the earlier versions of these interfaces.