### PR TITLE
Fix access violation when setting Name = null

### DIFF
--- a/src/Vortice.Direct3D12/ID3D12Object.cs
+++ b/src/Vortice.Direct3D12/ID3D12Object.cs
@@ -11,7 +11,7 @@ public partial class ID3D12Object
     /// <remarks>
     /// This name is for use in debug diagnostics and tools.
     /// </remarks>
-    public unsafe string? Name
+    public unsafe string Name
     {
         get
         {
@@ -27,7 +27,7 @@ public partial class ID3D12Object
         }
         set
         {
-            SetName(value);
+            SetName(value ?? string.Empty);
         }
     }
 }


### PR DESCRIPTION
The main fix is to make the string non-nullable, but I put a null check in as well just to be safe. Do we still need to check for null if the parameter is non-nullable? I guess yes because not everyone will have nullability enabled.