### PR TITLE
UIAnimation not using utf-8 causing error when open in Windows VS.

### DIFF
--- a/src/Vortice.UIAnimation/IUIAnimationManager.cs
+++ b/src/Vortice.UIAnimation/IUIAnimationManager.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.UIAnimation;

--- a/src/Vortice.UIAnimation/IUIAnimationManager2.cs
+++ b/src/Vortice.UIAnimation/IUIAnimationManager2.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.UIAnimation;

--- a/src/Vortice.UIAnimation/IUIAnimationTimer.cs
+++ b/src/Vortice.UIAnimation/IUIAnimationTimer.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.UIAnimation;

--- a/src/Vortice.UIAnimation/IUIAnimationTransition2.cs
+++ b/src/Vortice.UIAnimation/IUIAnimationTransition2.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.UIAnimation;

--- a/src/Vortice.UIAnimation/IUIAnimationTransitionFactory.cs
+++ b/src/Vortice.UIAnimation/IUIAnimationTransitionFactory.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.UIAnimation;

--- a/src/Vortice.UIAnimation/IUIAnimationTransitionFactory2.cs
+++ b/src/Vortice.UIAnimation/IUIAnimationTransitionFactory2.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.UIAnimation;

--- a/src/Vortice.UIAnimation/IUIAnimationTransitionLibrary.cs
+++ b/src/Vortice.UIAnimation/IUIAnimationTransitionLibrary.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.UIAnimation;

--- a/src/Vortice.UIAnimation/IUIAnimationTransitionLibrary2.cs
+++ b/src/Vortice.UIAnimation/IUIAnimationTransitionLibrary2.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.UIAnimation;

--- a/src/Vortice.UIAnimation/IUIAnimationVariableChangeHandler2.cs
+++ b/src/Vortice.UIAnimation/IUIAnimationVariableChangeHandler2.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.UIAnimation;

--- a/src/Vortice.UIAnimation/IUIAnimationVariableChangeHandler2Vtbl.cs
+++ b/src/Vortice.UIAnimation/IUIAnimationVariableChangeHandler2Vtbl.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.UIAnimation;

--- a/src/Vortice.UIAnimation/IUIAnimationVariableIntegerChangeHandler2.cs
+++ b/src/Vortice.UIAnimation/IUIAnimationVariableIntegerChangeHandler2.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.UIAnimation;

--- a/src/Vortice.UIAnimation/IUIAnimationVariableIntegerChangeHandler2Vtbl.cs
+++ b/src/Vortice.UIAnimation/IUIAnimationVariableIntegerChangeHandler2Vtbl.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.UIAnimation;


### PR DESCRIPTION
This is caused by the `©` sign in first line.

I checked all other code, it's all using `utf-8`, but for reason unknown only this UIAnimation project is using `Western (Mac Roman)`, causing will popup a error(only this UIAnimation project, all other project is good):
![image](https://user-images.githubusercontent.com/1317141/177237773-15521e20-e46a-41bf-942a-45c61e0a0bda.png)
![image](https://user-images.githubusercontent.com/1317141/177237788-05be4319-7e28-4092-bc06-f1b4dabc0e85.png)
