### PR TITLE
Update AudioBuffer.cs

### DIFF
--- a/src/Vortice.XAudio2/AudioBuffer.cs
+++ b/src/Vortice.XAudio2/AudioBuffer.cs
@@ -75,7 +75,7 @@ public partial class AudioBuffer : IDisposable
     public static unsafe AudioBuffer Create<T>(ReadOnlySpan<T> data, BufferFlags flags = BufferFlags.EndOfStream) where T : unmanaged
     {
         int sizeInBytes = data.Length * sizeof(T);
-        void* dataPtr = MemoryHelpers.AllocateMemory((nuint)data.Length);
+        void* dataPtr = MemoryHelpers.AllocateMemory((nuint)sizeInBytes);
         MemoryHelpers.CopyMemory(dataPtr, data);
         return new AudioBuffer(flags, dataPtr, sizeInBytes, true);
     }


### PR DESCRIPTION
Fixed a bug in the static Create method where memory allocation was being provided data length when it requires size in bytes. Because the data is generic, sizeInBytes is the correct value to provide, and it is already calculated in the method.