### PR TITLE
Fix typo of GetRegisteredEffects

### DIFF
--- a/src/Vortice.Direct2D1/ID2D1Factory1.cs
+++ b/src/Vortice.Direct2D1/ID2D1Factory1.cs
@@ -34,7 +34,7 @@ public partial class ID2D1Factory1
         return CreateStrokeStyle(ref properties, dashes, dashes.Length);
     }
 
-    public Guid[] GetRegistereotdEffects()
+    public Guid[] GetRegisteredEffects()
     {
         Guid[] guids = Array.Empty<Guid>();
         GetRegisteredEffects(guids, 0, out _, out var count);


### PR DESCRIPTION
The correct name is GetRegisteredEffects, but it is now GetRegistere**ot**dEffects.

https://github.com/amerkoleci/Vortice.Windows/blob/63e46dc29156c56fbcb19097fc00db5127f20a67/src/Vortice.Direct2D1/ID2D1Factory1.cs#L37