### PR TITLE
Add trimming annotations

### DIFF
--- a/src/Vortice.D3DCompiler/Compiler.cs
+++ b/src/Vortice.D3DCompiler/Compiler.cs
@@ -723,7 +723,7 @@ public unsafe static partial class Compiler
         return blob;
     }
 
-    public static T Reflect<T>(ReadOnlySpan<byte> shaderBytecode) where T : ComObject
+    public static T Reflect<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ReadOnlySpan<byte> shaderBytecode) where T : ComObject
     {
         fixed (byte* shaderBytecodePtr = shaderBytecode)
         {
@@ -732,7 +732,7 @@ public unsafe static partial class Compiler
         }
     }
 
-    public static Result Reflect<T>(ReadOnlySpan<byte> shaderBytecode, out T? reflection) where T : ComObject
+    public static Result Reflect<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ReadOnlySpan<byte> shaderBytecode, out T? reflection) where T : ComObject
     {
         fixed (byte* shaderBytecodePtr = shaderBytecode)
         {
@@ -748,13 +748,13 @@ public unsafe static partial class Compiler
         }
     }
 
-    public static T Reflect<T>(byte[] shaderBytecode) where T : ComObject
+    public static T Reflect<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(byte[] shaderBytecode) where T : ComObject
     {
         ReadOnlySpan<byte> span = shaderBytecode.AsSpan();
         return Reflect<T>(span);
     }
 
-    public static Result Reflect<T>(byte[] shaderBytecode, out T? reflection) where T : ComObject
+    public static Result Reflect<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(byte[] shaderBytecode, out T? reflection) where T : ComObject
     {
         ReadOnlySpan<byte> span = shaderBytecode.AsSpan();
         return Reflect(span, out reflection);

--- a/src/Vortice.D3DCompiler/Vortice.D3DCompiler.csproj
+++ b/src/Vortice.D3DCompiler/Vortice.D3DCompiler.csproj
@@ -6,11 +6,12 @@
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Description>D3DCompiler bindings.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="SharpGen.Runtime" />
-    
+
     <SharpGenMapping Include="Mappings.xml" />
     <ProjectReference Include="..\Vortice.DirectX\Vortice.DirectX.csproj" />
   </ItemGroup>

--- a/src/Vortice.DXGI/DXGI.cs
+++ b/src/Vortice.DXGI/DXGI.cs
@@ -30,7 +30,7 @@ public partial class DXGI
     /// </summary>
     /// <param name="factory">The <see cref="IDXGIFactory1"/> being created.</param>
     /// <returns>Return the <see cref="Result"/>.</returns>
-    public static Result CreateDXGIFactory1<T>(out T? factory) where T : IDXGIFactory1
+    public static Result CreateDXGIFactory1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? factory) where T : IDXGIFactory1
     {
         Result result = CreateDXGIFactory1(typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)
@@ -47,7 +47,7 @@ public partial class DXGI
     /// Try to create new instance of <see cref="IDXGIFactory1"/>.
     /// </summary>
     /// <returns>Return an instance of <see cref="IDXGIFactory1"/> or null if failed.</returns>
-    public static T CreateDXGIFactory1<T>() where T : IDXGIFactory1
+    public static T CreateDXGIFactory1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : IDXGIFactory1
     {
         CreateDXGIFactory1(typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -59,7 +59,7 @@ public partial class DXGI
     /// <param name="debug">Whether to enable debug callback.</param>
     /// <param name="factory">The <see cref="IDXGIFactory2"/> being created.</param>
     /// <returns>Return the <see cref="Result"/>.</returns>
-    public static Result CreateDXGIFactory2<T>(bool debug, out T? factory) where T : IDXGIFactory2
+    public static Result CreateDXGIFactory2<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(bool debug, out T? factory) where T : IDXGIFactory2
     {
         int flags = debug ? CreateFactoryDebug : 0x00;
         Result result = CreateDXGIFactory2(flags, typeof(T).GUID, out IntPtr nativePtr);
@@ -78,7 +78,7 @@ public partial class DXGI
     /// </summary>
     /// <param name="debug">Whether to enable debug callback.</param>
     /// <returns>Return an instance of <see cref="IDXGIFactory2"/> or null if failed.</returns>
-    public static T CreateDXGIFactory2<T>(bool debug) where T : IDXGIFactory2
+    public static T CreateDXGIFactory2<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(bool debug) where T : IDXGIFactory2
     {
         int flags = debug ? CreateFactoryDebug : 0x00;
         CreateDXGIFactory2(flags, typeof(T).GUID, out IntPtr nativePtr).CheckError();
@@ -91,7 +91,7 @@ public partial class DXGI
     /// <typeparam name="T">The <see cref="ComObject"/> to get.</typeparam>
     /// <param name="debugInterface">Instance of T.</param>
     /// <returns>The result code.</returns>
-    public static Result DXGIGetDebugInterface1<T>(out T? debugInterface) where T : ComObject
+    public static Result DXGIGetDebugInterface1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? debugInterface) where T : ComObject
     {
         try
         {
@@ -117,7 +117,7 @@ public partial class DXGI
     /// </summary>
     /// <typeparam name="T">The <see cref="ComObject"/> to get.</typeparam>
     /// <returns>The <see cref="ComObject"/> to get.</returns>
-    public static T DXGIGetDebugInterface1<T>() where T : ComObject
+    public static T DXGIGetDebugInterface1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ComObject
     {
         DXGIGetDebugInterface1(0, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;

--- a/src/Vortice.DXGI/IDXGIDeviceSubObject.cs
+++ b/src/Vortice.DXGI/IDXGIDeviceSubObject.cs
@@ -1,17 +1,17 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.DXGI;
 
 public partial class IDXGIDeviceSubObject
 {
-    public T GetDevice<T>() where T : IDXGIDevice
+    public T GetDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : IDXGIDevice
     {
         GetDevice(typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result GetDevice<T>(out T? device) where T : IDXGIDevice
+    public Result GetDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? device) where T : IDXGIDevice
     {
         Result result = GetDevice(typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.DXGI/IDXGIFactory4.cs
+++ b/src/Vortice.DXGI/IDXGIFactory4.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.DXGI;
@@ -11,7 +11,7 @@ public partial class IDXGIFactory4
     /// <typeparam name="T">An instance of <see cref="IDXGIAdapter"/></typeparam>
     /// <param name="adapter">The adapter instance of <see cref="IDXGIAdapter"/>, make sure to dispose the instance.</param>
     /// <returns>The warp adapter.</returns>
-    public Result EnumWarpAdapter<T>(out T? adapter) where T : IDXGIAdapter
+    public Result EnumWarpAdapter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? adapter) where T : IDXGIAdapter
     {
         Result result = EnumWarpAdapter(typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)
@@ -29,7 +29,7 @@ public partial class IDXGIFactory4
     /// </summary>
     /// <typeparam name="T">An instance of <see cref="IDXGIAdapter"/> class.</typeparam>
     /// <returns>The adapter instance of <see cref="IDXGIAdapter"/>, make sure to dispose the instance.</returns>
-    public T EnumWarpAdapter<T>() where T : IDXGIAdapter
+    public T EnumWarpAdapter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : IDXGIAdapter
     {
         EnumWarpAdapter(typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -41,7 +41,7 @@ public partial class IDXGIFactory4
     /// <param name="adapterLuid">A unique value that identifies the adapter.</param>
     /// <param name="adapter">The adapter instance of <see cref="IDXGIAdapter"/>, make sure to dispose the instance.</param>
     /// <returns>The <see cref="Result"/>.</returns>
-    public Result EnumAdapterByLuid<T>(Luid adapterLuid, out T? adapter) where T : IDXGIAdapter
+    public Result EnumAdapterByLuid<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Luid adapterLuid, out T? adapter) where T : IDXGIAdapter
     {
         Result result = EnumAdapterByLuid(adapterLuid, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)
@@ -60,7 +60,7 @@ public partial class IDXGIFactory4
     /// <typeparam name="T">An instance of <see cref="IDXGIAdapter"/> class.</typeparam>
     /// <param name="adapterLuid">A unique value that identifies the adapter.</param>
     /// <returns>The adapter instance of <see cref="IDXGIAdapter"/>, make sure to dispose the instance.</returns>
-    public T EnumAdapterByLuid<T>(Luid adapterLuid) where T : IDXGIAdapter
+    public T EnumAdapterByLuid<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Luid adapterLuid) where T : IDXGIAdapter
     {
         EnumAdapterByLuid(adapterLuid, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;

--- a/src/Vortice.DXGI/IDXGIFactory6.cs
+++ b/src/Vortice.DXGI/IDXGIFactory6.cs
@@ -1,11 +1,11 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.DXGI;
 
 public partial class IDXGIFactory6
 {
-    public Result EnumAdapterByGpuPreference<T>(int index, GpuPreference gpuPreference, out T? adapter) where T : IDXGIAdapter
+    public Result EnumAdapterByGpuPreference<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int index, GpuPreference gpuPreference, out T? adapter) where T : IDXGIAdapter
     {
         Result result = EnumAdapterByGpuPreference(index, gpuPreference, typeof(T).GUID, out IntPtr adapterPtr);
         if (result.Success)
@@ -18,7 +18,7 @@ public partial class IDXGIFactory6
         return result;
     }
 
-    public T EnumAdapterByGpuPreference<T>(int index, GpuPreference gpuPreference) where T : IDXGIAdapter
+    public T EnumAdapterByGpuPreference<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int index, GpuPreference gpuPreference) where T : IDXGIAdapter
     {
         EnumAdapterByGpuPreference(index, gpuPreference, typeof(T).GUID, out IntPtr adapterPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(adapterPtr)!;

--- a/src/Vortice.DXGI/IDXGIObject.cs
+++ b/src/Vortice.DXGI/IDXGIObject.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.DXGI;
@@ -36,7 +36,7 @@ public unsafe partial class IDXGIObject
         }
     }
 
-    public Result GetParent<T>(out T? @object) where T : ComObject
+    public Result GetParent<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? @object) where T : ComObject
     {
         Result result = GetParent(typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -49,7 +49,7 @@ public unsafe partial class IDXGIObject
         return result;
     }
 
-    public T GetParent<T>() where T : ComObject
+    public T GetParent<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ComObject
     {
         GetParent(typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;

--- a/src/Vortice.DXGI/IDXGISurface2.cs
+++ b/src/Vortice.DXGI/IDXGISurface2.cs
@@ -5,13 +5,13 @@ namespace Vortice.DXGI;
 
 public partial class IDXGISurface2
 {
-    public T GetResource<T>(out int subresourceIndex) where T : ComObject
+    public T GetResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out int subresourceIndex) where T : ComObject
     {
         GetResource(typeof(T).GUID, out IntPtr nativePtr, out subresourceIndex).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result GetResource<T>(out int subresourceIndex, out T? parentResource) where T : ComObject
+    public Result GetResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out int subresourceIndex, out T? parentResource) where T : ComObject
     {
         Result result = GetResource(typeof(T).GUID, out IntPtr nativePtr, out subresourceIndex);
         if (result.Failure)

--- a/src/Vortice.DXGI/IDXGISwapChain.cs
+++ b/src/Vortice.DXGI/IDXGISwapChain.cs
@@ -20,7 +20,7 @@ public partial class IDXGISwapChain
         return output;
     }
 
-    public Result GetContainingOutput<T>(out T? output) where T : IDXGIOutput
+    public Result GetContainingOutput<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? output) where T : IDXGIOutput
     {
         Result result = GetContainingOutput(out IDXGIOutput outputTemp);
         if (result.Failure)
@@ -34,13 +34,13 @@ public partial class IDXGISwapChain
         return result;
     }
 
-    public T GetBuffer<T>(int index) where T : ComObject
+    public T GetBuffer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int index) where T : ComObject
     {
         GetBuffer(index, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result GetBuffer<T>(int index, out T? surface) where T : ComObject
+    public Result GetBuffer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int index, out T? surface) where T : ComObject
     {
         Result result = GetBuffer(index, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.DXGI/IDXGISwapChain1.cs
+++ b/src/Vortice.DXGI/IDXGISwapChain1.cs
@@ -26,7 +26,7 @@ public partial class IDXGISwapChain1
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public T GetCoreWindow<T>() where T : ComObject
+    public T GetCoreWindow<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ComObject
     {
         GetCoreWindow(typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -38,7 +38,7 @@ public partial class IDXGISwapChain1
     /// <typeparam name="T"></typeparam>
     /// <param name="coreWindow"></param>
     /// <returns></returns>
-    public Result GetCoreWindow<T>(out T? coreWindow) where T : ComObject
+    public Result GetCoreWindow<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? coreWindow) where T : ComObject
     {
         Result result = GetCoreWindow(typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.DXGI/Vortice.DXGI.csproj
+++ b/src/Vortice.DXGI/Vortice.DXGI.csproj
@@ -6,14 +6,15 @@
     <TargetFrameworks>net7.0;net8.0;net8.0-windows10.0.19041</TargetFrameworks>
     <Description>A .NET bindings for DXGI</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="SharpGen.Runtime" />
-    
+
     <SharpGenMapping Include="Mappings.xml" />
     <SharpGenExternalDocs Include="Documentation.xml" />
     <ProjectReference Include="..\Vortice.DirectX\Vortice.DirectX.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Vortice.Direct2D1/CustomEffectFactory.cs
+++ b/src/Vortice.Direct2D1/CustomEffectFactory.cs
@@ -126,7 +126,7 @@ internal class CustomEffectFactory
         }
     }
 
-    private class PropertyNative<U> : PropertyNativeBase where U : unmanaged
+    private class PropertyNative<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] U> : PropertyNativeBase where U : unmanaged
     {
         private PropertyNative(PropertyInfo propertyInfo, PropertyType propertyType) : base(propertyInfo, propertyType)
         {

--- a/src/Vortice.Direct2D1/D2D1.cs
+++ b/src/Vortice.Direct2D1/D2D1.cs
@@ -10,7 +10,7 @@ public static partial class D2D1
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static T D2D1CreateFactory<T>(
+    public static T D2D1CreateFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         FactoryType factoryType = FactoryType.SingleThreaded,
         DebugLevel debugLevel = DebugLevel.None) where T : ID2D1Factory
     {
@@ -29,7 +29,7 @@ public static partial class D2D1
     /// <param name="factoryType">The type of factory.</param>
     /// <param name="options">The <see cref="FactoryOptions"/>.</param>
     /// <returns>Return the <see cref="Result"/>.</returns>
-    public static T D2D1CreateFactory<T>(FactoryType factoryType, FactoryOptions options) where T : ID2D1Factory
+    public static T D2D1CreateFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(FactoryType factoryType, FactoryOptions options) where T : ID2D1Factory
     {
         D2D1CreateFactory(factoryType, typeof(T).GUID, options, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -40,7 +40,7 @@ public static partial class D2D1
     /// </summary>
     /// <param name="factory">The <see cref="ID2D1Factory"/> being created.</param>
     /// <returns>Return the <see cref="Result"/>.</returns>
-    public static Result D2D1CreateFactory<T>(out T? factory) where T : ID2D1Factory
+    public static Result D2D1CreateFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? factory) where T : ID2D1Factory
     {
         return D2D1CreateFactory(FactoryType.SingleThreaded, out factory);
     }
@@ -51,7 +51,7 @@ public static partial class D2D1
     /// <param name="factoryType">The type of factory.</param>
     /// <param name="factory">The <see cref="ID2D1Factory"/> being created.</param>
     /// <returns>Return the <see cref="Result"/>.</returns>
-    public static Result D2D1CreateFactory<T>(FactoryType factoryType, out T? factory) where T : ID2D1Factory
+    public static Result D2D1CreateFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(FactoryType factoryType, out T? factory) where T : ID2D1Factory
     {
         var options = new FactoryOptions
         {
@@ -76,7 +76,7 @@ public static partial class D2D1
     /// <param name="options">The <see cref="FactoryOptions"/>.</param>
     /// <param name="factory">The <see cref="ID2D1Factory"/> being created.</param>
     /// <returns>Return the <see cref="Result"/>.</returns>
-    public static Result D2D1CreateFactory<T>(FactoryType factoryType, FactoryOptions options, out T? factory) where T : ID2D1Factory
+    public static Result D2D1CreateFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(FactoryType factoryType, FactoryOptions options, out T? factory) where T : ID2D1Factory
     {
         Result result = D2D1CreateFactory(factoryType, typeof(T).GUID, options, out IntPtr nativePtr);
         if (result.Success)

--- a/src/Vortice.Direct2D1/DirectWrite/DWrite.cs
+++ b/src/Vortice.Direct2D1/DirectWrite/DWrite.cs
@@ -11,7 +11,7 @@ public static partial class DWrite
     /// <typeparam name="T">Type based on <see cref="IDWriteFactory"/>.</typeparam>
     /// <param name="factoryType">The <see cref="IDWriteFactory"/> type.</param>
     /// <returns>Return the <see cref="Result"/>.</returns>
-    public static T DWriteCreateFactory<T>(FactoryType factoryType = FactoryType.Shared) where T : IDWriteFactory
+    public static T DWriteCreateFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(FactoryType factoryType = FactoryType.Shared) where T : IDWriteFactory
     {
         DWriteCreateFactory(factoryType, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -23,7 +23,7 @@ public static partial class DWrite
     /// <typeparam name="T">Type based on <see cref="IDWriteFactory"/>.</typeparam>
     /// <param name="factory">The <see cref="IDWriteFactory"/> being created.</param>
     /// <returns>Return the <see cref="Result"/>.</returns>
-    public static Result DWriteCreateFactory<T>(out T? factory) where T : IDWriteFactory
+    public static Result DWriteCreateFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? factory) where T : IDWriteFactory
     {
         return DWriteCreateFactory(FactoryType.Shared, out factory);
     }
@@ -35,7 +35,7 @@ public static partial class DWrite
     /// <param name="factoryType">The type of factory.</param>
     /// <param name="factory">The <see cref="IDWriteFactory"/> being created.</param>
     /// <returns>Return the <see cref="Result"/>.</returns>
-    public static Result DWriteCreateFactory<T>(FactoryType factoryType, out T? factory) where T : IDWriteFactory
+    public static Result DWriteCreateFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]T>(FactoryType factoryType, out T? factory) where T : IDWriteFactory
     {
         Result result = DWriteCreateFactory(factoryType, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Direct2D1/ID2D1Properties.cs
+++ b/src/Vortice.Direct2D1/ID2D1Properties.cs
@@ -204,7 +204,7 @@ public unsafe partial class ID2D1Properties
         return value;
     }
 
-    public unsafe T? GetIUnknownValue<T>(int index) where T : ComObject
+    public unsafe T? GetIUnknownValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int index) where T : ComObject
     {
         IntPtr value = default;
         GetValue(index, PropertyType.IUnknown, &value, sizeof(IntPtr));

--- a/src/Vortice.Direct2D1/Vortice.Direct2D1.csproj
+++ b/src/Vortice.Direct2D1/Vortice.Direct2D1.csproj
@@ -6,8 +6,9 @@
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Description>Direct2D1 bindings.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
     <Using Include="System.Numerics" />
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="SharpGen.Runtime" />

--- a/src/Vortice.Direct3D11/Direct3D11on12/ID3D11On12Device.cs
+++ b/src/Vortice.Direct3D11/Direct3D11on12/ID3D11On12Device.cs
@@ -8,13 +8,13 @@ namespace Vortice.Direct3D11on12;
 
 public partial class ID3D11On12Device
 {
-    public T CreateWrappedResource<T>(IUnknown d3d12Resource, ResourceFlags flags, ResourceStates inState, ResourceStates outState) where T : ID3D11Resource
+    public T CreateWrappedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IUnknown d3d12Resource, ResourceFlags flags, ResourceStates inState, ResourceStates outState) where T : ID3D11Resource
     {
         CreateWrappedResource(d3d12Resource, flags, inState, outState, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateWrappedResource<T>(IUnknown d3d12Resource, ResourceFlags flags, ResourceStates inState, ResourceStates outState, out T? resource11) where T : ID3D11Resource
+    public Result CreateWrappedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IUnknown d3d12Resource, ResourceFlags flags, ResourceStates inState, ResourceStates outState, out T? resource11) where T : ID3D11Resource
     {
         Result result = CreateWrappedResource(d3d12Resource, flags, inState, outState, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)

--- a/src/Vortice.Direct3D11/Direct3D11on12/ID3D11On12Device1.cs
+++ b/src/Vortice.Direct3D11/Direct3D11on12/ID3D11On12Device1.cs
@@ -5,7 +5,7 @@ namespace Vortice.Direct3D11on12;
 
 public partial class ID3D11On12Device1
 {
-    public Result GetD3D12Device<T>(out T? device) where T : ComObject
+    public Result GetD3D12Device<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? device) where T : ComObject
     {
         Result result = GetD3D12Device(typeof(T).GUID, out IntPtr devicePtr);
         if (result.Failure)
@@ -18,7 +18,7 @@ public partial class ID3D11On12Device1
         return result;
     }
 
-    public T GetD3D12Device<T>() where T : ComObject
+    public T GetD3D12Device<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ComObject
     {
         GetD3D12Device(typeof(T).GUID, out IntPtr devicePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(devicePtr)!;

--- a/src/Vortice.Direct3D11/Direct3D11on12/ID3D11On12Device2.cs
+++ b/src/Vortice.Direct3D11/Direct3D11on12/ID3D11On12Device2.cs
@@ -7,13 +7,13 @@ namespace Vortice.Direct3D11on12;
 
 public partial class ID3D11On12Device2
 {
-    public T UnwrapUnderlyingResource<T>(ID3D11Resource resource, ComObject commandQueue) where T : ComObject
+    public T UnwrapUnderlyingResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ID3D11Resource resource, ComObject commandQueue) where T : ComObject
     {
         UnwrapUnderlyingResource(resource, commandQueue, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result UnwrapUnderlyingResource<T>(ID3D11Resource resource, ComObject commandQueue, out T? resource12) where T : ComObject
+    public Result UnwrapUnderlyingResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ID3D11Resource resource, ComObject commandQueue, out T? resource12) where T : ComObject
     {
         Result result = UnwrapUnderlyingResource(resource, commandQueue, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)

--- a/src/Vortice.Direct3D11/ID3D11Device.cs
+++ b/src/Vortice.Direct3D11/ID3D11Device.cs
@@ -979,7 +979,7 @@ public unsafe partial class ID3D11Device
     /// <typeparam name="T">Type of <see cref="ID3D11Resource"/> </typeparam>
     /// <param name="handle">A handle to the resource to open.</param>
     /// <returns>Instance of <see cref="ID3D11Resource"/>.</returns>
-    public T OpenSharedResource<T>(IntPtr handle) where T : ID3D11Resource
+    public T OpenSharedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr handle) where T : ID3D11Resource
     {
         OpenSharedResource(handle, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -992,7 +992,7 @@ public unsafe partial class ID3D11Device
     /// <param name="handle">A handle to the resource to open.</param>
     /// <param name="resource">Instance of <see cref="ID3D11Resource"/>.</param>
     /// <returns>The operation result.</returns>
-    public Result OpenSharedResource<T>(IntPtr handle, out T? resource) where T : ID3D11Resource
+    public Result OpenSharedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr handle, out T? resource) where T : ID3D11Resource
     {
         Result result = OpenSharedResource(handle, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)

--- a/src/Vortice.Direct3D11/ID3D11Device1.cs
+++ b/src/Vortice.Direct3D11/ID3D11Device1.cs
@@ -26,13 +26,13 @@ public partial class ID3D11Device1
     /// <typeparam name="T">A handle to the resource to open.</typeparam>
     /// <param name="handle"></param>
     /// <returns></returns>
-    public T OpenSharedResource1<T>(IntPtr handle) where T : ID3D11Resource
+    public T OpenSharedResource1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr handle) where T : ID3D11Resource
     {
         OpenSharedResource1(handle, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result OpenSharedResource1<T>(IntPtr handle, out T? resource) where T : ID3D11Resource
+    public Result OpenSharedResource1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr handle, out T? resource) where T : ID3D11Resource
     {
         Result result = OpenSharedResource1(handle, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)
@@ -45,13 +45,13 @@ public partial class ID3D11Device1
         return result;
     }
 
-    public T OpenSharedResourceByName<T>(string name, SharedResourceFlags access) where T : ID3D11Resource
+    public T OpenSharedResourceByName<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string name, SharedResourceFlags access) where T : ID3D11Resource
     {
         OpenSharedResourceByName(name, (int)access, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result OpenSharedResourceByName<T>(string name, SharedResourceFlags access, out T? resource) where T : ID3D11Resource
+    public Result OpenSharedResourceByName<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string name, SharedResourceFlags access, out T? resource) where T : ID3D11Resource
     {
         Result result = OpenSharedResourceByName(name, (int)access, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)

--- a/src/Vortice.Direct3D11/ID3D11Device5.cs
+++ b/src/Vortice.Direct3D11/ID3D11Device5.cs
@@ -11,13 +11,13 @@ public partial class ID3D11Device5
         return new ID3D11Fence(nativePtr);
     }
 
-    public T CreateFence<T>(ulong initialValue, FenceFlags flags = FenceFlags.None) where T : ID3D11Fence
+    public T CreateFence<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ulong initialValue, FenceFlags flags = FenceFlags.None) where T : ID3D11Fence
     {
         CreateFence(initialValue, flags, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateFence<T>(ulong initialValue, FenceFlags flags, out T? fence) where T: ID3D11Fence
+    public Result CreateFence<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ulong initialValue, FenceFlags flags, out T? fence) where T: ID3D11Fence
     {
         Result result = CreateFence(initialValue, flags, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)
@@ -30,19 +30,19 @@ public partial class ID3D11Device5
         return result;
     }
 
-    public ID3D11Fence OpenSharedFence(IntPtr fenceHandle) 
+    public ID3D11Fence OpenSharedFence(IntPtr fenceHandle)
     {
         OpenSharedFence(fenceHandle, typeof(ID3D11Fence).GUID, out IntPtr nativePtr).CheckError();
         return new ID3D11Fence(nativePtr);
     }
 
-    public T OpenSharedFence<T>(IntPtr fenceHandle) where T : ID3D11Fence
+    public T OpenSharedFence<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr fenceHandle) where T : ID3D11Fence
     {
         OpenSharedFence(fenceHandle, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result OpenSharedFence<T>(IntPtr fenceHandle, out T? fence) where T : ID3D11Fence
+    public Result OpenSharedFence<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr fenceHandle, out T? fence) where T : ID3D11Fence
     {
         Result result = OpenSharedFence(fenceHandle, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)

--- a/src/Vortice.Direct3D11/ID3D11VideoDevice.cs
+++ b/src/Vortice.Direct3D11/ID3D11VideoDevice.cs
@@ -60,7 +60,7 @@ public partial class ID3D11VideoDevice
         return CreateVideoProcessorEnumerator(ref description, out enumerator);
     }
 
-    public T CreateVideoProcessorEnumerator<T>(VideoProcessorContentDescription description) where T : ID3D11VideoProcessorEnumerator
+    public T CreateVideoProcessorEnumerator<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoProcessorContentDescription description) where T : ID3D11VideoProcessorEnumerator
     {
         using ID3D11VideoProcessorEnumerator enumerator = CreateVideoProcessorEnumerator(description);
         return enumerator.QueryInterface<T>();

--- a/src/Vortice.Direct3D11/IDirect3DDxgiInterfaceAccess.cs
+++ b/src/Vortice.Direct3D11/IDirect3DDxgiInterfaceAccess.cs
@@ -5,13 +5,13 @@ namespace Vortice.Direct3D11;
 
 public partial class IDirect3DDxgiInterfaceAccess
 {
-    public T GetInterface<T>() where T : ComObject
+    public T GetInterface<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ComObject
     {
         GetInterface(typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result GetInterface<T>(out T? @interface) where T: ComObject
+    public Result GetInterface<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? @interface) where T: ComObject
     {
         Result result = GetInterface(typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D11/Vortice.Direct3D11.csproj
+++ b/src/Vortice.Direct3D11/Vortice.Direct3D11.csproj
@@ -8,9 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="SharpGen.Runtime" />
-    
+
     <SharpGenMapping Include="Mappings.xml" />
     <SharpGenExternalDocs Include="Documentation.xml" />
     <ProjectReference Include="..\Vortice.DXGI\Vortice.DXGI.csproj" />

--- a/src/Vortice.Direct3D12/D3D12.cs
+++ b/src/Vortice.Direct3D12/D3D12.cs
@@ -150,12 +150,12 @@ public static unsafe partial class D3D12
         }
     }
 
-    public static Result D3D12CreateDevice<T>(IDXGIAdapter? adapter, out T? device) where T : ID3D12Device
+    public static Result D3D12CreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IDXGIAdapter? adapter, out T? device) where T : ID3D12Device
     {
         return D3D12CreateDevice(adapter, FeatureLevel.Level_11_0, out device);
     }
 
-    public static Result D3D12CreateDevice<T>(IDXGIAdapter? adapter, FeatureLevel minFeatureLevel, out T? device) where T : ID3D12Device
+    public static Result D3D12CreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IDXGIAdapter? adapter, FeatureLevel minFeatureLevel, out T? device) where T : ID3D12Device
     {
         Result result = D3D12CreateDevice(
             adapter != null ? adapter.NativePointer : IntPtr.Zero,
@@ -173,7 +173,7 @@ public static unsafe partial class D3D12
         return result;
     }
 
-    public static T D3D12CreateDevice<T>(IDXGIAdapter? adapter, FeatureLevel minFeatureLevel) where T : ID3D12Device
+    public static T D3D12CreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IDXGIAdapter? adapter, FeatureLevel minFeatureLevel) where T : ID3D12Device
     {
         D3D12CreateDevice(
             adapter != null ? adapter.NativePointer : IntPtr.Zero,
@@ -184,12 +184,12 @@ public static unsafe partial class D3D12
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public static Result D3D12CreateDevice<T>(IntPtr adapterPtr, out T? device) where T : ID3D12Device
+    public static Result D3D12CreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr adapterPtr, out T? device) where T : ID3D12Device
     {
         return D3D12CreateDevice(adapterPtr, FeatureLevel.Level_11_0, out device);
     }
 
-    public static Result D3D12CreateDevice<T>(IntPtr adapterPtr, FeatureLevel minFeatureLevel, out T? device) where T : ID3D12Device
+    public static Result D3D12CreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr adapterPtr, FeatureLevel minFeatureLevel, out T? device) where T : ID3D12Device
     {
         Result result = D3D12CreateDevice(adapterPtr, minFeatureLevel, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -202,7 +202,7 @@ public static unsafe partial class D3D12
         return result;
     }
 
-    public static T D3D12CreateDevice<T>(IntPtr adapterPtr, FeatureLevel minFeatureLevel) where T : ID3D12Device
+    public static T D3D12CreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr adapterPtr, FeatureLevel minFeatureLevel) where T : ID3D12Device
     {
         D3D12CreateDevice(adapterPtr, minFeatureLevel, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -215,7 +215,7 @@ public static unsafe partial class D3D12
         return result;
     }
 
-    public static Result D3D12GetDebugInterface<T>(out T? debugInterface) where T : ComObject
+    public static Result D3D12GetDebugInterface<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? debugInterface) where T : ComObject
     {
         Result result = D3D12GetDebugInterface(typeof(T).GUID, out IntPtr nativePtr);
 
@@ -229,7 +229,7 @@ public static unsafe partial class D3D12
         return result;
     }
 
-    public static T D3D12GetDebugInterface<T>() where T : ComObject
+    public static T D3D12GetDebugInterface<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ComObject
     {
         D3D12GetDebugInterface(typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -252,7 +252,7 @@ public static unsafe partial class D3D12
         D3D12EnableExperimentalFeatures(features.Length, features, IntPtr.Zero, null);
     }
 
-    private static Result D3D12CreateVersionedRootSignatureDeserializer<T>(void* signatureData, PointerSize signatureDataLength, out T? rootSignatureDeserializer) where T : ID3D12VersionedRootSignatureDeserializer
+    private static Result D3D12CreateVersionedRootSignatureDeserializer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(void* signatureData, PointerSize signatureDataLength, out T? rootSignatureDeserializer) where T : ID3D12VersionedRootSignatureDeserializer
     {
         Result result = D3D12CreateVersionedRootSignatureDeserializer(signatureData, signatureDataLength,
             typeof(T).GUID,
@@ -268,13 +268,13 @@ public static unsafe partial class D3D12
         return result;
     }
 
-    private static T D3D12CreateVersionedRootSignatureDeserializer<T>(void* signatureData, PointerSize signatureDataLength) where T : ID3D12VersionedRootSignatureDeserializer
+    private static T D3D12CreateVersionedRootSignatureDeserializer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(void* signatureData, PointerSize signatureDataLength) where T : ID3D12VersionedRootSignatureDeserializer
     {
         D3D12CreateVersionedRootSignatureDeserializer(signatureData, signatureDataLength, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public static Result D3D12CreateVersionedRootSignatureDeserializer<T>(byte[] signatureData, out T? rootSignatureDeserializer) where T : ID3D12VersionedRootSignatureDeserializer
+    public static Result D3D12CreateVersionedRootSignatureDeserializer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(byte[] signatureData, out T? rootSignatureDeserializer) where T : ID3D12VersionedRootSignatureDeserializer
     {
         fixed (byte* dataPtr = signatureData)
         {
@@ -282,12 +282,12 @@ public static unsafe partial class D3D12
         }
     }
 
-    public static Result D3D12CreateVersionedRootSignatureDeserializer<T>(Blob signatureData, out T? rootSignatureDeserializer) where T : ID3D12VersionedRootSignatureDeserializer
+    public static Result D3D12CreateVersionedRootSignatureDeserializer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Blob signatureData, out T? rootSignatureDeserializer) where T : ID3D12VersionedRootSignatureDeserializer
     {
         return D3D12CreateVersionedRootSignatureDeserializer(signatureData.BufferPointer.ToPointer(), signatureData.BufferSize, out rootSignatureDeserializer);
     }
 
-    public static T D3D12CreateVersionedRootSignatureDeserializer<T>(byte[] signatureData) where T : ID3D12VersionedRootSignatureDeserializer
+    public static T D3D12CreateVersionedRootSignatureDeserializer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(byte[] signatureData) where T : ID3D12VersionedRootSignatureDeserializer
     {
         fixed (byte* dataPtr = signatureData)
         {
@@ -295,7 +295,7 @@ public static unsafe partial class D3D12
         }
     }
 
-    public static T D3D12CreateVersionedRootSignatureDeserializer<T>(Blob signatureData) where T : ID3D12VersionedRootSignatureDeserializer
+    public static T D3D12CreateVersionedRootSignatureDeserializer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Blob signatureData) where T : ID3D12VersionedRootSignatureDeserializer
     {
         return D3D12CreateVersionedRootSignatureDeserializer<T>(signatureData.BufferPointer.ToPointer(), signatureData.BufferSize);
     }

--- a/src/Vortice.Direct3D12/ID3D12DSRDeviceFactory.cs
+++ b/src/Vortice.Direct3D12/ID3D12DSRDeviceFactory.cs
@@ -5,13 +5,13 @@ namespace Vortice.Direct3D12;
 
 public partial class ID3D12DSRDeviceFactory
 {
-    public T CreateDSRDevice<T>(ID3D12Device d3D12Device, int nodeMask = 0) where T : ComObject
+    public T CreateDSRDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ID3D12Device d3D12Device, int nodeMask = 0) where T : ComObject
     {
         CreateDSRDevice(d3D12Device, nodeMask, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateDSRDevice<T>(ID3D12Device d3D12Device, int nodeMask, out T? DSRDevice) where T : ComObject
+    public Result CreateDSRDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ID3D12Device d3D12Device, int nodeMask, out T? DSRDevice) where T : ComObject
     {
         Result result = CreateDSRDevice(d3D12Device, nodeMask, typeof(T).GUID, out IntPtr nativePtr);
 

--- a/src/Vortice.Direct3D12/ID3D12Device.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device.cs
@@ -454,7 +454,7 @@ public unsafe partial class ID3D12Device
         return result;
     }
 
-    public T CreateCommittedResource<T>(HeapProperties heapProperties,
+    public T CreateCommittedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(HeapProperties heapProperties,
         HeapFlags heapFlags,
         ResourceDescription description,
         ResourceStates initialResourceState,
@@ -472,7 +472,7 @@ public unsafe partial class ID3D12Device
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateCommittedResource<T>(HeapProperties heapProperties, HeapFlags heapFlags, ResourceDescription description, ResourceStates initialResourceState, out T? resource) where T : ID3D12Resource
+    public Result CreateCommittedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(HeapProperties heapProperties, HeapFlags heapFlags, ResourceDescription description, ResourceStates initialResourceState, out T? resource) where T : ID3D12Resource
     {
         Result result = CreateCommittedResource(
             ref heapProperties,
@@ -493,7 +493,7 @@ public unsafe partial class ID3D12Device
         return result;
     }
 
-    public Result CreateCommittedResource<T>(HeapProperties heapProperties,
+    public Result CreateCommittedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(HeapProperties heapProperties,
         HeapFlags heapFlags,
         ResourceDescription description,
         ResourceStates initialResourceState,
@@ -521,7 +521,7 @@ public unsafe partial class ID3D12Device
     #endregion
 
     #region CreateCommandQueue
-    public Result CreateCommandQueue<T>(in CommandQueueDescription description, out T? commandQueue) where T : ID3D12CommandQueue
+    public Result CreateCommandQueue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in CommandQueueDescription description, out T? commandQueue) where T : ID3D12CommandQueue
     {
         Result result = CreateCommandQueue(description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -534,18 +534,18 @@ public unsafe partial class ID3D12Device
         return result;
     }
 
-    public T CreateCommandQueue<T>(in CommandQueueDescription description) where T : ID3D12CommandQueue
+    public T CreateCommandQueue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in CommandQueueDescription description) where T : ID3D12CommandQueue
     {
         CreateCommandQueue(description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public T CreateCommandQueue<T>(CommandListType type, int priority = 0, CommandQueueFlags flags = CommandQueueFlags.None, int nodeMask = 0) where T : ID3D12CommandQueue
+    public T CreateCommandQueue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(CommandListType type, int priority = 0, CommandQueueFlags flags = CommandQueueFlags.None, int nodeMask = 0) where T : ID3D12CommandQueue
     {
         return CreateCommandQueue<T>(new CommandQueueDescription(type, priority, flags, nodeMask));
     }
 
-    public T CreateCommandQueue<T>(CommandListType type, CommandQueuePriority priority, CommandQueueFlags flags = CommandQueueFlags.None, int nodeMask = 0) where T : ID3D12CommandQueue
+    public T CreateCommandQueue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(CommandListType type, CommandQueuePriority priority, CommandQueueFlags flags = CommandQueueFlags.None, int nodeMask = 0) where T : ID3D12CommandQueue
     {
         return CreateCommandQueue<T>(new CommandQueueDescription(type, priority, flags, nodeMask));
     }
@@ -601,13 +601,13 @@ public unsafe partial class ID3D12Device
         return result;
     }
 
-    public T CreateDescriptorHeap<T>(in DescriptorHeapDescription description) where T : ID3D12DescriptorHeap
+    public T CreateDescriptorHeap<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in DescriptorHeapDescription description) where T : ID3D12DescriptorHeap
     {
         CreateDescriptorHeap(description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateDescriptorHeap<T>(in DescriptorHeapDescription description, out T? descriptorHeap) where T : ID3D12DescriptorHeap
+    public Result CreateDescriptorHeap<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in DescriptorHeapDescription description, out T? descriptorHeap) where T : ID3D12DescriptorHeap
     {
         Result result = CreateDescriptorHeap(description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -641,13 +641,13 @@ public unsafe partial class ID3D12Device
         return result;
     }
 
-    public T CreateCommandAllocator<T>(CommandListType type) where T : ID3D12CommandAllocator
+    public T CreateCommandAllocator<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(CommandListType type) where T : ID3D12CommandAllocator
     {
         CreateCommandAllocator(type, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateCommandAllocator<T>(CommandListType type, out T? commandAllocator) where T : ID3D12CommandAllocator
+    public Result CreateCommandAllocator<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(CommandListType type, out T? commandAllocator) where T : ID3D12CommandAllocator
     {
         Result result = CreateCommandAllocator(type, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -662,19 +662,19 @@ public unsafe partial class ID3D12Device
     #endregion
 
     #region CreateCommandList
-    public T CreateCommandList<T>(CommandListType type, ID3D12CommandAllocator commandAllocator, ID3D12PipelineState? initialState = default) where T : ID3D12CommandList
+    public T CreateCommandList<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(CommandListType type, ID3D12CommandAllocator commandAllocator, ID3D12PipelineState? initialState = default) where T : ID3D12CommandList
     {
         CreateCommandList(0, type, commandAllocator, initialState, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public T CreateCommandList<T>(int nodeMask, CommandListType type, ID3D12CommandAllocator commandAllocator, ID3D12PipelineState? initialState = default) where T : ID3D12CommandList
+    public T CreateCommandList<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, CommandListType type, ID3D12CommandAllocator commandAllocator, ID3D12PipelineState? initialState = default) where T : ID3D12CommandList
     {
         CreateCommandList(nodeMask, type, commandAllocator, initialState, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateCommandList<T>(int nodeMask, CommandListType type, ID3D12CommandAllocator commandAllocator, ID3D12PipelineState initialState, out T? commandList) where T : ID3D12CommandList
+    public Result CreateCommandList<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, CommandListType type, ID3D12CommandAllocator commandAllocator, ID3D12PipelineState initialState, out T? commandList) where T : ID3D12CommandList
     {
         Result result = CreateCommandList(nodeMask, type, commandAllocator, initialState, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -709,13 +709,13 @@ public unsafe partial class ID3D12Device
         return result;
     }
 
-    public T CreateFence<T>(ulong initialValue = 0, FenceFlags flags = FenceFlags.None) where T : ID3D12Fence
+    public T CreateFence<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ulong initialValue = 0, FenceFlags flags = FenceFlags.None) where T : ID3D12Fence
     {
         CreateFence(initialValue, flags, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateFence<T>(ulong initialValue, FenceFlags flags, out T? fence) where T : ID3D12Fence
+    public Result CreateFence<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ulong initialValue, FenceFlags flags, out T? fence) where T : ID3D12Fence
     {
         Result result = CreateFence(initialValue, flags, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -730,13 +730,13 @@ public unsafe partial class ID3D12Device
     #endregion
 
     #region CreateHeap
-    public T CreateHeap<T>(in HeapDescription description) where T : ID3D12Heap
+    public T CreateHeap<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in HeapDescription description) where T : ID3D12Heap
     {
         CreateHeap(description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateHeap<T>(in HeapDescription description, out T? heap) where T : ID3D12Heap
+    public Result CreateHeap<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in HeapDescription description, out T? heap) where T : ID3D12Heap
     {
         Result result = CreateHeap(description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -751,7 +751,7 @@ public unsafe partial class ID3D12Device
     #endregion
 
     #region CreateRootSignature
-    public Result CreateRootSignature<T>(int nodeMask, IntPtr blobWithRootSignature, PointerSize blobLengthInBytes, out T? rootSignature) where T : ID3D12RootSignature
+    public Result CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, IntPtr blobWithRootSignature, PointerSize blobLengthInBytes, out T? rootSignature) where T : ID3D12RootSignature
     {
         Result result = CreateRootSignature(nodeMask, blobWithRootSignature, blobLengthInBytes, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -764,12 +764,12 @@ public unsafe partial class ID3D12Device
         return result;
     }
 
-    public Result CreateRootSignature<T>(int nodeMask, Blob blob, out T? rootSignature) where T : ID3D12RootSignature
+    public Result CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, Blob blob, out T? rootSignature) where T : ID3D12RootSignature
     {
         return CreateRootSignature(nodeMask, blob.BufferPointer, blob.BufferSize, out rootSignature);
     }
 
-    public Result CreateRootSignature<T>(int nodeMask, byte[] blobWithRootSignature, out T? rootSignature) where T : ID3D12RootSignature
+    public Result CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, byte[] blobWithRootSignature, out T? rootSignature) where T : ID3D12RootSignature
     {
         fixed (void* pBuffer = blobWithRootSignature)
         {
@@ -777,18 +777,18 @@ public unsafe partial class ID3D12Device
         }
     }
 
-    public T CreateRootSignature<T>(int nodeMask, IntPtr blobWithRootSignature, PointerSize blobLengthInBytes) where T : ID3D12RootSignature
+    public T CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, IntPtr blobWithRootSignature, PointerSize blobLengthInBytes) where T : ID3D12RootSignature
     {
         CreateRootSignature(nodeMask, blobWithRootSignature, blobLengthInBytes, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public T CreateRootSignature<T>(int nodeMask, Blob blob) where T : ID3D12RootSignature
+    public T CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, Blob blob) where T : ID3D12RootSignature
     {
         return CreateRootSignature<T>(nodeMask, blob.BufferPointer, blob.BufferSize);
     }
 
-    public unsafe T CreateRootSignature<T>(int nodeMask, byte[] blobWithRootSignature) where T : ID3D12RootSignature
+    public unsafe T CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, byte[] blobWithRootSignature) where T : ID3D12RootSignature
     {
         fixed (void* pBuffer = blobWithRootSignature)
         {
@@ -796,18 +796,18 @@ public unsafe partial class ID3D12Device
         }
     }
 
-    public T CreateRootSignature<T>(IntPtr blobWithRootSignature, PointerSize blobLengthInBytes) where T : ID3D12RootSignature
+    public T CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr blobWithRootSignature, PointerSize blobLengthInBytes) where T : ID3D12RootSignature
     {
         CreateRootSignature(0, blobWithRootSignature, blobLengthInBytes, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public T CreateRootSignature<T>(Blob blob) where T : ID3D12RootSignature
+    public T CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Blob blob) where T : ID3D12RootSignature
     {
         return CreateRootSignature<T>(0, blob.BufferPointer, blob.BufferSize);
     }
 
-    public unsafe T CreateRootSignature<T>(byte[] blobWithRootSignature) where T : ID3D12RootSignature
+    public unsafe T CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(byte[] blobWithRootSignature) where T : ID3D12RootSignature
     {
         fixed (void* pBuffer = blobWithRootSignature)
         {
@@ -815,12 +815,12 @@ public unsafe partial class ID3D12Device
         }
     }
 
-    public T CreateRootSignature<T>(in RootSignatureDescription description, RootSignatureVersion version) where T : ID3D12RootSignature
+    public T CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in RootSignatureDescription description, RootSignatureVersion version) where T : ID3D12RootSignature
     {
         return CreateRootSignature<T>(0, description, version);
     }
 
-    public T CreateRootSignature<T>(int nodeMask, in RootSignatureDescription description, RootSignatureVersion version) where T : ID3D12RootSignature
+    public T CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, in RootSignatureDescription description, RootSignatureVersion version) where T : ID3D12RootSignature
     {
         Result result = D3D12.D3D12SerializeRootSignature(description, version, out Blob blob, out Blob errorBlob);
         if (result.Failure)
@@ -845,7 +845,7 @@ public unsafe partial class ID3D12Device
         }
     }
 
-    public Result CreateRootSignature<T>(int nodeMask, in RootSignatureDescription description, RootSignatureVersion version, out T? rootSignature) where T : ID3D12RootSignature
+    public Result CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, in RootSignatureDescription description, RootSignatureVersion version, out T? rootSignature) where T : ID3D12RootSignature
     {
         Result result = D3D12.D3D12SerializeRootSignature(description, version, out Blob blob, out Blob errorBlob);
         if (result.Failure)
@@ -874,39 +874,39 @@ public unsafe partial class ID3D12Device
         }
     }
 
-    public T CreateRootSignature<T>(in RootSignatureDescription1 description) where T : ID3D12RootSignature
+    public T CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in RootSignatureDescription1 description) where T : ID3D12RootSignature
     {
         return CreateRootSignature<T>(0, new VersionedRootSignatureDescription(description));
     }
 
 
-    public T CreateRootSignature<T>(int nodeMask, in RootSignatureDescription1 description) where T : ID3D12RootSignature
+    public T CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, in RootSignatureDescription1 description) where T : ID3D12RootSignature
     {
         return CreateRootSignature<T>(nodeMask, new VersionedRootSignatureDescription(description));
     }
 
-    public T CreateRootSignature<T>(in VersionedRootSignatureDescription description) where T : ID3D12RootSignature
+    public T CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]T>(in VersionedRootSignatureDescription description) where T : ID3D12RootSignature
     {
         return CreateRootSignature<T>(0, description);
     }
 
-    public T CreateRootSignature<T>(int nodeMask, in VersionedRootSignatureDescription description) where T : ID3D12RootSignature
+    public T CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, in VersionedRootSignatureDescription description) where T : ID3D12RootSignature
     {
         CreateRootSignature(nodeMask, description, out T? rootSignature).CheckError();
         return rootSignature!;
     }
 
-    public Result CreateRootSignature<T>(in RootSignatureDescription1 description, out T? rootSignature) where T : ID3D12RootSignature
+    public Result CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in RootSignatureDescription1 description, out T? rootSignature) where T : ID3D12RootSignature
     {
         return CreateRootSignature<T>(0, new VersionedRootSignatureDescription(description), out rootSignature);
     }
 
-    public Result CreateRootSignature<T>(int nodeMask, in RootSignatureDescription1 description, out T? rootSignature) where T : ID3D12RootSignature
+    public Result CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, in RootSignatureDescription1 description, out T? rootSignature) where T : ID3D12RootSignature
     {
         return CreateRootSignature<T>(0, new VersionedRootSignatureDescription(description), out rootSignature);
     }
 
-    public Result CreateRootSignature<T>(in VersionedRootSignatureDescription description, out T? rootSignature) where T : ID3D12RootSignature
+    public Result CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in VersionedRootSignatureDescription description, out T? rootSignature) where T : ID3D12RootSignature
     {
         return CreateRootSignature<T>(0, description, out rootSignature);
     }
@@ -922,7 +922,7 @@ public unsafe partial class ID3D12Device
         return rootSignature!;
     }
 
-    public Result CreateRootSignature<T>(int nodeMask, in VersionedRootSignatureDescription description, out T? rootSignature) where T : ID3D12RootSignature
+    public Result CreateRootSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, in VersionedRootSignatureDescription description, out T? rootSignature) where T : ID3D12RootSignature
     {
         Result result = Result.Ok;
         Blob? signature = null;
@@ -1020,13 +1020,13 @@ public unsafe partial class ID3D12Device
     #endregion
 
     #region CreateCommandSignature
-    public T CreateCommandSignature<T>(CommandSignatureDescription description, ID3D12RootSignature? rootSignature) where T : ID3D12CommandSignature
+    public T CreateCommandSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(CommandSignatureDescription description, ID3D12RootSignature? rootSignature) where T : ID3D12CommandSignature
     {
         CreateCommandSignature(description, rootSignature, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateCommandSignature<T>(CommandSignatureDescription description, ID3D12RootSignature? rootSignature, out T? commandSignature) where T : ID3D12CommandSignature
+    public Result CreateCommandSignature<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]T>(CommandSignatureDescription description, ID3D12RootSignature? rootSignature, out T? commandSignature) where T : ID3D12CommandSignature
     {
         Result result = CreateCommandSignature(description, rootSignature, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -1041,13 +1041,13 @@ public unsafe partial class ID3D12Device
     #endregion
 
     #region CreateComputePipelineState
-    public T CreateComputePipelineState<T>(ComputePipelineStateDescription description) where T : ID3D12PipelineState
+    public T CreateComputePipelineState<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ComputePipelineStateDescription description) where T : ID3D12PipelineState
     {
         CreateComputePipelineState(description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateComputePipelineState<T>(ComputePipelineStateDescription description, out T? pipelineState) where T : ID3D12PipelineState
+    public Result CreateComputePipelineState<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ComputePipelineStateDescription description, out T? pipelineState) where T : ID3D12PipelineState
     {
         Result result = CreateComputePipelineState(description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -1081,13 +1081,13 @@ public unsafe partial class ID3D12Device
     #endregion
 
     #region CreateGraphicsPipelineState
-    public T CreateGraphicsPipelineState<T>(GraphicsPipelineStateDescription description) where T : ID3D12PipelineState
+    public T CreateGraphicsPipelineState<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(GraphicsPipelineStateDescription description) where T : ID3D12PipelineState
     {
         CreateGraphicsPipelineState(description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateGraphicsPipelineState<T>(GraphicsPipelineStateDescription description, out T? pipelineState) where T : ID3D12PipelineState
+    public Result CreateGraphicsPipelineState<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(GraphicsPipelineStateDescription description, out T? pipelineState) where T : ID3D12PipelineState
     {
         Result result = CreateGraphicsPipelineState(description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -1121,13 +1121,13 @@ public unsafe partial class ID3D12Device
     #endregion
 
     #region CreateQueryHeap
-    public T CreateQueryHeap<T>(QueryHeapDescription description) where T : ID3D12QueryHeap
+    public T CreateQueryHeap<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(QueryHeapDescription description) where T : ID3D12QueryHeap
     {
         CreateQueryHeap(description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateQueryHeap<T>(in QueryHeapDescription description, out T? queryHeap) where T : ID3D12QueryHeap
+    public Result CreateQueryHeap<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in QueryHeapDescription description, out T? queryHeap) where T : ID3D12QueryHeap
     {
         Result result = CreateQueryHeap(description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -1142,7 +1142,7 @@ public unsafe partial class ID3D12Device
     #endregion
 
     #region CreatePlacedResource
-    public T CreatePlacedResource<T>(
+    public T CreatePlacedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         ID3D12Heap heap,
         ulong heapOffset,
         ResourceDescription resourceDescription,
@@ -1153,7 +1153,7 @@ public unsafe partial class ID3D12Device
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreatePlacedResource<T>(
+    public Result CreatePlacedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         ID3D12Heap heap,
         ulong heapOffset,
         ResourceDescription resourceDescription,
@@ -1171,7 +1171,7 @@ public unsafe partial class ID3D12Device
         return result;
     }
 
-    public Result CreatePlacedResource<T>(
+    public Result CreatePlacedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         ID3D12Heap heap,
         ulong heapOffset,
         ResourceDescription resourceDescription,
@@ -1192,13 +1192,13 @@ public unsafe partial class ID3D12Device
     #endregion
 
     #region CreateReservedResource
-    public T CreateReservedResource<T>(ResourceDescription resourceDescription, ResourceStates initialState, ClearValue? clearValue = null) where T : ID3D12Resource
+    public T CreateReservedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ResourceDescription resourceDescription, ResourceStates initialState, ClearValue? clearValue = null) where T : ID3D12Resource
     {
         CreateReservedResource(ref resourceDescription, initialState, clearValue, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateReservedResource<T>(ResourceDescription resourceDescription, ResourceStates initialState, out T? resource) where T : ID3D12Resource
+    public Result CreateReservedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ResourceDescription resourceDescription, ResourceStates initialState, out T? resource) where T : ID3D12Resource
     {
         Result result = CreateReservedResource(ref resourceDescription, initialState, null, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -1211,7 +1211,7 @@ public unsafe partial class ID3D12Device
         return result;
     }
 
-    public Result CreateReservedResource<T>(ResourceDescription resourceDescription, ResourceStates initialState, in ClearValue clearValue, out T? resource) where T : ID3D12Resource
+    public Result CreateReservedResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ResourceDescription resourceDescription, ResourceStates initialState, in ClearValue clearValue, out T? resource) where T : ID3D12Resource
     {
         Result result = CreateReservedResource(ref resourceDescription, initialState, clearValue, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -1325,7 +1325,7 @@ public unsafe partial class ID3D12Device
     /// <typeparam name="T">The handle that was output by the call to <see cref="CreateSharedHandle(ID3D12DeviceChild, SecurityAttributes?, string)"/> </typeparam>
     /// <param name="handle"></param>
     /// <returns>Instance of <see cref="ID3D12Heap"/>, <see cref="ID3D12Resource"/> or <see cref="ID3D12Fence"/>.</returns>
-    public T OpenSharedHandle<T>(IntPtr handle) where T : ComObject
+    public T OpenSharedHandle<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr handle) where T : ComObject
     {
         OpenSharedHandle(handle, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -1338,7 +1338,7 @@ public unsafe partial class ID3D12Device
     /// <param name="handle"></param>
     /// <param name="sharedHandle">The shared handle instance.</param>
     /// <returns>The <see cref="Result"/> of the operation.</returns>
-    public Result OpenSharedHandle<T>(IntPtr handle, out T? sharedHandle) where T : ComObject
+    public Result OpenSharedHandle<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr handle, out T? sharedHandle) where T : ComObject
     {
         Result result = OpenSharedHandle(handle, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/ID3D12Device1.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device1.cs
@@ -51,13 +51,13 @@ public unsafe partial class ID3D12Device1
         return result;
     }
 
-    public T CreatePipelineLibrary<T>(Blob blob) where T : ID3D12PipelineLibrary
+    public T CreatePipelineLibrary<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Blob blob) where T : ID3D12PipelineLibrary
     {
         CreatePipelineLibrary(blob.BufferPointer.ToPointer(), blob.BufferSize, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreatePipelineLibrary<T>(Blob blob, out T? pipelineLibrary) where T : ID3D12PipelineLibrary
+    public Result CreatePipelineLibrary<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Blob blob, out T? pipelineLibrary) where T : ID3D12PipelineLibrary
     {
         Result result = CreatePipelineLibrary(blob.BufferPointer.ToPointer(), blob.BufferSize, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/ID3D12Device10.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device10.cs
@@ -7,7 +7,7 @@ namespace Vortice.Direct3D12;
 
 public unsafe partial class ID3D12Device10
 {
-    public T CreateCommittedResource3<T>(
+    public T CreateCommittedResource3<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         HeapProperties heapProperties,
         HeapFlags heapFlags,
         ResourceDescription1 description,
@@ -51,7 +51,7 @@ public unsafe partial class ID3D12Device10
         }
     }
 
-    public T CreatePlacedResource2<T>(
+    public T CreatePlacedResource2<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         ID3D12Heap heap,
         ulong heapOffset,
         ResourceDescription1 description,
@@ -88,7 +88,7 @@ public unsafe partial class ID3D12Device10
         }
     }
 
-    public T CreateReservedResource2<T>(
+    public T CreateReservedResource2<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         ResourceDescription description,
         BarrierLayout initialLayout,
         ClearValue? optimizedClearValue,

--- a/src/Vortice.Direct3D12/ID3D12Device2.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device2.cs
@@ -18,7 +18,7 @@ public unsafe partial class ID3D12Device2
         return new ID3D12PipelineState(nativePtr);
     }
 
-    public T CreatePipelineState<T, TData>(TData data)
+    public T CreatePipelineState<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T, TData>(TData data)
         where T : ID3D12PipelineState
         where TData : unmanaged
     {
@@ -31,13 +31,13 @@ public unsafe partial class ID3D12Device2
         return CreatePipelineState<T>(description);
     }
 
-    public T CreatePipelineState<T>(PipelineStateStreamDescription description) where T : ID3D12PipelineState
+    public T CreatePipelineState<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(PipelineStateStreamDescription description) where T : ID3D12PipelineState
     {
         CreatePipelineState(ref description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreatePipelineState<T>(PipelineStateStreamDescription description, out T? pipelineState) where T : ID3D12PipelineState
+    public Result CreatePipelineState<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(PipelineStateStreamDescription description, out T? pipelineState) where T : ID3D12PipelineState
     {
         Result result = CreatePipelineState(ref description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/ID3D12Device3.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device3.cs
@@ -14,19 +14,19 @@ public partial class ID3D12Device3
     }
 
     /// <summary>
-    /// Creates a special-purpose diagnostic heap in system memory from an address. 
+    /// Creates a special-purpose diagnostic heap in system memory from an address.
     /// The created heap can persist even in the event of a GPU-fault or device-removed scenario.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="address">The address used to create the heap.</param>
     /// <returns></returns>
-    public T OpenExistingHeapFromAddress<T>(IntPtr address) where T : ID3D12Heap
+    public T OpenExistingHeapFromAddress<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr address) where T : ID3D12Heap
     {
         OpenExistingHeapFromAddress(address, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result OpenExistingHeapFromAddress<T>(IntPtr address, out T? heap) where T : ID3D12Heap
+    public Result OpenExistingHeapFromAddress<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr address, out T? heap) where T : ID3D12Heap
     {
         Result result = OpenExistingHeapFromAddress(address, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -39,13 +39,13 @@ public partial class ID3D12Device3
         return result;
     }
 
-    public T OpenExistingHeapFromFileMapping<T>(IntPtr fileMapping) where T : ID3D12Heap
+    public T OpenExistingHeapFromFileMapping<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr fileMapping) where T : ID3D12Heap
     {
         OpenExistingHeapFromFileMapping(fileMapping, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result OpenExistingHeapFromFileMapping<T>(IntPtr fileMapping, out T? heap) where T : ID3D12Heap
+    public Result OpenExistingHeapFromFileMapping<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr fileMapping, out T? heap) where T : ID3D12Heap
     {
         Result result = OpenExistingHeapFromFileMapping(fileMapping, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/ID3D12Device4.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device4.cs
@@ -6,24 +6,24 @@ namespace Vortice.Direct3D12;
 public partial class ID3D12Device4
 {
     #region CreateCommandList1
-    public T CreateCommandList1<T>(CommandListType type, CommandListFlags commandListFlags = CommandListFlags.None) where T : ID3D12CommandList
+    public T CreateCommandList1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(CommandListType type, CommandListFlags commandListFlags = CommandListFlags.None) where T : ID3D12CommandList
     {
         CreateCommandList1(0, type, commandListFlags, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public T CreateCommandList1<T>(int nodeMask, CommandListType type, CommandListFlags commandListFlags = CommandListFlags.None) where T : ID3D12CommandList
+    public T CreateCommandList1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, CommandListType type, CommandListFlags commandListFlags = CommandListFlags.None) where T : ID3D12CommandList
     {
         CreateCommandList1(nodeMask, type, commandListFlags, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateCommandList1<T>(CommandListType type, CommandListFlags commandListFlags, out T? commandList) where T : ID3D12CommandList
+    public Result CreateCommandList1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(CommandListType type, CommandListFlags commandListFlags, out T? commandList) where T : ID3D12CommandList
     {
         return CreateCommandList1<T>(0, type, commandListFlags, out commandList);
     }
 
-    public Result CreateCommandList1<T>(int nodeMask, CommandListType type, CommandListFlags commandListFlags, out T? commandList) where T : ID3D12CommandList
+    public Result CreateCommandList1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int nodeMask, CommandListType type, CommandListFlags commandListFlags, out T? commandList) where T : ID3D12CommandList
     {
         Result result = CreateCommandList1(nodeMask, type, commandListFlags, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -38,7 +38,7 @@ public partial class ID3D12Device4
     #endregion
 
     #region CreateCommittedResource1
-    public T CreateCommittedResource1<T>(
+    public T CreateCommittedResource1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         HeapProperties heapProperties,
         HeapFlags heapFlags,
         ResourceDescription description,
@@ -55,7 +55,7 @@ public partial class ID3D12Device4
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateCommittedResource1<T>(
+    public Result CreateCommittedResource1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         HeapProperties heapProperties,
         HeapFlags heapFlags,
         ResourceDescription description,
@@ -79,7 +79,7 @@ public partial class ID3D12Device4
         return result;
     }
 
-    public Result CreateCommittedResource1<T>(
+    public Result CreateCommittedResource1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         HeapProperties heapProperties,
         HeapFlags heapFlags,
         ResourceDescription description,
@@ -106,13 +106,13 @@ public partial class ID3D12Device4
     #endregion
 
     #region CreateHeap1
-    public T CreateHeap1<T>(HeapDescription description, ID3D12ProtectedResourceSession protectedSession) where T : ID3D12Heap
+    public T CreateHeap1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(HeapDescription description, ID3D12ProtectedResourceSession protectedSession) where T : ID3D12Heap
     {
         CreateHeap1(ref description, protectedSession, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateHeap1<T>(HeapDescription description, ID3D12ProtectedResourceSession protectedSession, out T? heap) where T : ID3D12Heap
+    public Result CreateHeap1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(HeapDescription description, ID3D12ProtectedResourceSession protectedSession, out T? heap) where T : ID3D12Heap
     {
         Result result = CreateHeap1(ref description, protectedSession, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -127,13 +127,13 @@ public partial class ID3D12Device4
     #endregion
 
     #region CreateProtectedResourceSession
-    public T CreateProtectedResourceSession<T>(ProtectedResourceSessionDescription description) where T : ID3D12ProtectedResourceSession
+    public T CreateProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ProtectedResourceSessionDescription description) where T : ID3D12ProtectedResourceSession
     {
         CreateProtectedResourceSession(description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateProtectedResourceSession<T>(ProtectedResourceSessionDescription description, out T? resource) where T : ID3D12ProtectedResourceSession
+    public Result CreateProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ProtectedResourceSessionDescription description, out T? resource) where T : ID3D12ProtectedResourceSession
     {
         Result result = CreateProtectedResourceSession(description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -148,13 +148,13 @@ public partial class ID3D12Device4
     #endregion
 
     #region CreateReservedResource1
-    public T CreateReservedResource1<T>(ResourceDescription description, ResourceStates initialState, ClearValue clearValue, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12Resource
+    public T CreateReservedResource1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ResourceDescription description, ResourceStates initialState, ClearValue clearValue, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12Resource
     {
         CreateReservedResource1(ref description, initialState, clearValue, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateReservedResource1<T>(ResourceDescription description, ResourceStates initialState, ClearValue clearValue, ID3D12ProtectedResourceSession protectedResourceSession, out T? resource) where T : ID3D12Resource
+    public Result CreateReservedResource1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ResourceDescription description, ResourceStates initialState, ClearValue clearValue, ID3D12ProtectedResourceSession protectedResourceSession, out T? resource) where T : ID3D12Resource
     {
         Result result = CreateReservedResource1(ref description, initialState, clearValue, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -167,13 +167,13 @@ public partial class ID3D12Device4
         return result;
     }
 
-    public T CreateReservedResource1<T>(ResourceDescription description, ResourceStates initialState, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12Resource
+    public T CreateReservedResource1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ResourceDescription description, ResourceStates initialState, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12Resource
     {
         CreateReservedResource1(ref description, initialState, null, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateReservedResource1<T>(ResourceDescription description, ResourceStates initialState, ID3D12ProtectedResourceSession protectedResourceSession, out T? resource) where T : ID3D12Resource
+    public Result CreateReservedResource1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ResourceDescription description, ResourceStates initialState, ID3D12ProtectedResourceSession protectedResourceSession, out T? resource) where T : ID3D12Resource
     {
         Result result = CreateReservedResource1(ref description, initialState, null, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/ID3D12Device5.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device5.cs
@@ -12,7 +12,7 @@ public partial class ID3D12Device5
     /// </summary>
     /// <param name="commandId">A <see cref="Guid"/> of the meta command that you wish to instantiate.</param>
     /// <returns>An instance of <see cref="ID3D12MetaCommand"/>.</returns>
-    public T CreateMetaCommand<T>(Guid commandId) where T : ID3D12MetaCommand
+    public T CreateMetaCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid commandId) where T : ID3D12MetaCommand
     {
         CreateMetaCommand(commandId, 0, IntPtr.Zero, 0, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -24,7 +24,7 @@ public partial class ID3D12Device5
     /// <param name="commandId">A <see cref="Guid"/> of the meta command that you wish to instantiate.</param>
     /// <param name="metaCommand">An instance of <see cref="ID3D12MetaCommand"/>.</param>
     /// <returns>The result of operation.</returns>
-    public Result CreateMetaCommand<T>(Guid commandId, out T? metaCommand) where T : ID3D12MetaCommand
+    public Result CreateMetaCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid commandId, out T? metaCommand) where T : ID3D12MetaCommand
     {
         Result result = CreateMetaCommand(commandId, 0, IntPtr.Zero, 0, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -41,10 +41,10 @@ public partial class ID3D12Device5
     /// Creates an instance of the specified meta command.
     /// </summary>
     /// <param name="commandId">A <see cref="Guid"/> of the meta command that you wish to instantiate.</param>
-    /// <param name="nodeMask">For single-adapter operation, set this to zero. If there are multiple adapter nodes, set a bit to identify the node (one of the device's physical adapters) to which the meta command applies. 
+    /// <param name="nodeMask">For single-adapter operation, set this to zero. If there are multiple adapter nodes, set a bit to identify the node (one of the device's physical adapters) to which the meta command applies.
     /// Each bit in the mask corresponds to a single node. Only one bit must be set. </param>
     /// <returns>An instance of <see cref="ID3D12MetaCommand"/>.</returns>
-    public T CreateMetaCommand<T>(Guid commandId, int nodeMask) where T : ID3D12MetaCommand
+    public T CreateMetaCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid commandId, int nodeMask) where T : ID3D12MetaCommand
     {
         CreateMetaCommand(commandId, nodeMask, IntPtr.Zero, 0, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -54,11 +54,11 @@ public partial class ID3D12Device5
     /// Creates an instance of the specified meta command.
     /// </summary>
     /// <param name="commandId">A <see cref="Guid"/> of the meta command that you wish to instantiate.</param>
-    /// <param name="nodeMask">For single-adapter operation, set this to zero. If there are multiple adapter nodes, set a bit to identify the node (one of the device's physical adapters) to which the meta command applies. 
+    /// <param name="nodeMask">For single-adapter operation, set this to zero. If there are multiple adapter nodes, set a bit to identify the node (one of the device's physical adapters) to which the meta command applies.
     /// Each bit in the mask corresponds to a single node. Only one bit must be set. </param>
     /// <param name="metaCommand">An instance of <see cref="ID3D12MetaCommand"/>.</param>
     /// <returns>The result of operation.</returns>
-    public Result CreateMetaCommand<T>(Guid commandId, int nodeMask, out T? metaCommand) where T : ID3D12MetaCommand
+    public Result CreateMetaCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid commandId, int nodeMask, out T? metaCommand) where T : ID3D12MetaCommand
     {
         Result result = CreateMetaCommand(commandId, nodeMask, IntPtr.Zero, 0, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -77,7 +77,7 @@ public partial class ID3D12Device5
     /// <param name="commandId">A <see cref="Guid"/> of the meta command that you wish to instantiate.</param>
     /// <param name="blob">Blob containing the values of the parameters for creating the meta command.</param>
     /// <returns>An instance of <see cref="ID3D12MetaCommand"/>.</returns>
-    public T CreateMetaCommand<T>(Guid commandId, Blob blob) where T : ID3D12MetaCommand
+    public T CreateMetaCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid commandId, Blob blob) where T : ID3D12MetaCommand
     {
         CreateMetaCommand(commandId, 0, blob.BufferPointer, blob.BufferSize, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -90,7 +90,7 @@ public partial class ID3D12Device5
     /// <param name="blob">Blob containing the values of the parameters for creating the meta command.</param>
     /// <param name="metaCommand">An instance of <see cref="ID3D12MetaCommand"/>.</param>
     /// <returns>The result of operation</returns>
-    public Result CreateMetaCommand<T>(Guid commandId, Blob blob, out T? metaCommand) where T : ID3D12MetaCommand
+    public Result CreateMetaCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid commandId, Blob blob, out T? metaCommand) where T : ID3D12MetaCommand
     {
         Result result = CreateMetaCommand(commandId, 0, blob.BufferPointer, blob.BufferSize, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -107,11 +107,11 @@ public partial class ID3D12Device5
     /// Creates an instance of the specified meta command.
     /// </summary>
     /// <param name="commandId">A <see cref="Guid"/> of the meta command that you wish to instantiate.</param>
-    /// <param name="nodeMask">For single-adapter operation, set this to zero. If there are multiple adapter nodes, set a bit to identify the node (one of the device's physical adapters) to which the meta command applies. 
+    /// <param name="nodeMask">For single-adapter operation, set this to zero. If there are multiple adapter nodes, set a bit to identify the node (one of the device's physical adapters) to which the meta command applies.
     /// Each bit in the mask corresponds to a single node. Only one bit must be set. </param>
     /// <param name="blob">Blob containing the values of the parameters for creating the meta command.</param>
     /// <returns>An instance of <see cref="ID3D12MetaCommand"/>.</returns>
-    public T CreateMetaCommand<T>(Guid commandId, int nodeMask, Blob blob) where T : ID3D12MetaCommand
+    public T CreateMetaCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid commandId, int nodeMask, Blob blob) where T : ID3D12MetaCommand
     {
         CreateMetaCommand(commandId, nodeMask, blob.BufferPointer, blob.BufferSize, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -121,12 +121,12 @@ public partial class ID3D12Device5
     /// Creates an instance of the specified meta command.
     /// </summary>
     /// <param name="commandId">A <see cref="Guid"/> of the meta command that you wish to instantiate.</param>
-    /// <param name="nodeMask">For single-adapter operation, set this to zero. If there are multiple adapter nodes, set a bit to identify the node (one of the device's physical adapters) to which the meta command applies. 
+    /// <param name="nodeMask">For single-adapter operation, set this to zero. If there are multiple adapter nodes, set a bit to identify the node (one of the device's physical adapters) to which the meta command applies.
     /// Each bit in the mask corresponds to a single node. Only one bit must be set. </param>
     /// <param name="blob">Blob containing the values of the parameters for creating the meta command.</param>
     /// <param name="metaCommand">An instance of <see cref="ID3D12MetaCommand"/>.</param>
     /// <returns>The result of the operation.</returns>
-    public Result CreateMetaCommand<T>(Guid commandId, int nodeMask, Blob blob, out T? metaCommand) where T : ID3D12MetaCommand
+    public Result CreateMetaCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid commandId, int nodeMask, Blob blob, out T? metaCommand) where T : ID3D12MetaCommand
     {
         Result result = CreateMetaCommand(commandId, nodeMask, blob.BufferPointer, blob.BufferSize, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -145,7 +145,7 @@ public partial class ID3D12Device5
     /// </summary>
     /// <param name="description">The description of the state object to create.</param>
     /// <returns>An instance of <see cref="ID3D12StateObject"/>.</returns>
-    public T CreateStateObject<T>(StateObjectDescription description) where T : ID3D12StateObject
+    public T CreateStateObject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(StateObjectDescription description) where T : ID3D12StateObject
     {
         CreateStateObject(description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -157,7 +157,7 @@ public partial class ID3D12Device5
     /// <param name="description">The description of the state object to create.</param>
     /// <param name="stateObject">An instance of <see cref="ID3D12StateObject"/>.</param>
     /// <returns>The result of operation.</returns>
-    public Result CreateStateObject<T>(StateObjectDescription description, out T? stateObject) where T : ID3D12StateObject
+    public Result CreateStateObject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(StateObjectDescription description, out T? stateObject) where T : ID3D12StateObject
     {
         Result result = CreateStateObject(description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -175,7 +175,7 @@ public partial class ID3D12Device5
     /// </summary>
     /// <param name="description">The description of the state object to create.</param>
     /// <returns>An instance of <see cref="ID3D12StateObject"/>.</returns>
-    public ID3D12StateObject CreateStateObject(StateObjectDescription description) 
+    public ID3D12StateObject CreateStateObject(StateObjectDescription description)
     {
         CreateStateObject(description, typeof(ID3D12StateObject).GUID, out IntPtr nativePtr).CheckError();
         return new(nativePtr);
@@ -187,7 +187,7 @@ public partial class ID3D12Device5
     /// <param name="description">The description of the state object to create.</param>
     /// <param name="stateObject">An instance of <see cref="ID3D12StateObject"/>.</param>
     /// <returns>The result of operation.</returns>
-    public Result CreateStateObject(StateObjectDescription description, out ID3D12StateObject? stateObject) 
+    public Result CreateStateObject(StateObjectDescription description, out ID3D12StateObject? stateObject)
     {
         Result result = CreateStateObject(description, typeof(ID3D12StateObject).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/ID3D12Device7.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device7.cs
@@ -5,13 +5,13 @@ namespace Vortice.Direct3D12;
 
 public partial class ID3D12Device7
 {
-    public T AddToStateObject<T>(StateObjectDescription addition, ID3D12StateObject stateObjectToGrowFrom) where T : ID3D12StateObject
+    public T AddToStateObject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(StateObjectDescription addition, ID3D12StateObject stateObjectToGrowFrom) where T : ID3D12StateObject
     {
         AddToStateObject(addition, stateObjectToGrowFrom, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result AddToStateObject<T>(StateObjectDescription addition, ID3D12StateObject stateObjectToGrowFrom, out T? newStateObject) where T : ID3D12StateObject
+    public Result AddToStateObject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(StateObjectDescription addition, ID3D12StateObject stateObjectToGrowFrom, out T? newStateObject) where T : ID3D12StateObject
     {
         Result result = AddToStateObject(addition, stateObjectToGrowFrom, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -24,13 +24,13 @@ public partial class ID3D12Device7
         return result;
     }
 
-    public T CreateProtectedResourceSession1<T>(ProtectedResourceSessionDescription1 description) where T : ID3D12ProtectedResourceSession
+    public T CreateProtectedResourceSession1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ProtectedResourceSessionDescription1 description) where T : ID3D12ProtectedResourceSession
     {
         CreateProtectedResourceSession1(ref description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateProtectedResourceSession1<T>(ProtectedResourceSessionDescription1 description, out T? session) where T : ID3D12ProtectedResourceSession
+    public Result CreateProtectedResourceSession1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ProtectedResourceSessionDescription1 description, out T? session) where T : ID3D12ProtectedResourceSession
     {
         Result result = CreateProtectedResourceSession1(ref description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/ID3D12Device8.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device8.cs
@@ -7,7 +7,7 @@ namespace Vortice.Direct3D12;
 
 public partial class ID3D12Device8
 {
-    public T CreateCommittedResource2<T>(
+    public T CreateCommittedResource2<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         HeapProperties heapProperties,
         HeapFlags heapFlags,
         ResourceDescription1 description,
@@ -26,7 +26,7 @@ public partial class ID3D12Device8
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public T CreateCommittedResource2<T>(
+    public T CreateCommittedResource2<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         HeapProperties heapProperties,
         HeapFlags heapFlags,
         ResourceDescription1 description,
@@ -47,7 +47,7 @@ public partial class ID3D12Device8
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public T? CreatePlacedResource1<T>(ID3D12Heap heap, ulong heapOffset, ResourceDescription1 description, ResourceStates initialState, ClearValue? optimizedClearValue = null) where T : ID3D12Resource
+    public T? CreatePlacedResource1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ID3D12Heap heap, ulong heapOffset, ResourceDescription1 description, ResourceStates initialState, ClearValue? optimizedClearValue = null) where T : ID3D12Resource
     {
         Result result = CreatePlacedResource1(
             heap,
@@ -65,7 +65,7 @@ public partial class ID3D12Device8
         return default;
     }
 
-    public Result CreatePlacedResource1<T>(
+    public Result CreatePlacedResource1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         ID3D12Heap heap,
         ulong heapOffset,
         ResourceDescription1 description,
@@ -90,7 +90,7 @@ public partial class ID3D12Device8
         return result;
     }
 
-    public Result CreatePlacedResource1<T>(
+    public Result CreatePlacedResource1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         ID3D12Heap heap,
         ulong heapOffset,
         ResourceDescription1 description,

--- a/src/Vortice.Direct3D12/ID3D12Device9.cs
+++ b/src/Vortice.Direct3D12/ID3D12Device9.cs
@@ -5,7 +5,7 @@ namespace Vortice.Direct3D12;
 
 public partial class ID3D12Device9
 {
-    public ID3D12CommandQueue CreateCommandQueue1(in CommandQueueDescription description, Guid creatorID) 
+    public ID3D12CommandQueue CreateCommandQueue1(in CommandQueueDescription description, Guid creatorID)
     {
         CreateCommandQueue1(description, creatorID, typeof(ID3D12CommandQueue).GUID, out IntPtr nativePtr).CheckError();
         return new ID3D12CommandQueue(nativePtr);
@@ -24,13 +24,13 @@ public partial class ID3D12Device9
         return result;
     }
 
-    public T CreateCommandQueue1<T>(in CommandQueueDescription description, Guid creatorID) where T : ID3D12CommandQueue
+    public T CreateCommandQueue1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in CommandQueueDescription description, Guid creatorID) where T : ID3D12CommandQueue
     {
         CreateCommandQueue1(description, creatorID, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateCommandQueue1<T>(in CommandQueueDescription description, Guid creatorID, out T? commandQueue) where T : ID3D12CommandQueue
+    public Result CreateCommandQueue1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in CommandQueueDescription description, Guid creatorID, out T? commandQueue) where T : ID3D12CommandQueue
     {
         Result result = CreateCommandQueue1(description, creatorID, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -43,13 +43,13 @@ public partial class ID3D12Device9
         return result;
     }
 
-    public T CreateShaderCacheSession<T>(ShaderCacheSessionDescription description) where T : ID3D12ShaderCacheSession
+    public T CreateShaderCacheSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ShaderCacheSessionDescription description) where T : ID3D12ShaderCacheSession
     {
         CreateShaderCacheSession(ref description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateShaderCacheSession<T>(ShaderCacheSessionDescription description, out T? session) where T : ID3D12ShaderCacheSession
+    public Result CreateShaderCacheSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ShaderCacheSessionDescription description, out T? session) where T : ID3D12ShaderCacheSession
     {
         Result result = CreateShaderCacheSession(ref description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/ID3D12DeviceChild.cs
+++ b/src/Vortice.Direct3D12/ID3D12DeviceChild.cs
@@ -5,7 +5,7 @@ namespace Vortice.Direct3D12;
 
 public partial class ID3D12DeviceChild
 {
-    public Result GetDevice<T>(out T? device) where T : ID3D12Device
+    public Result GetDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? device) where T : ID3D12Device
     {
         Result result = GetDevice(typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -18,7 +18,7 @@ public partial class ID3D12DeviceChild
         return result;
     }
 
-    public T GetDevice<T>() where T : ID3D12Device
+    public T GetDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ID3D12Device
     {
         GetDevice(typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;

--- a/src/Vortice.Direct3D12/ID3D12DeviceConfiguration.cs
+++ b/src/Vortice.Direct3D12/ID3D12DeviceConfiguration.cs
@@ -5,13 +5,13 @@ namespace Vortice.Direct3D12;
 
 public unsafe partial class ID3D12DeviceConfiguration
 {
-    public ID3D12VersionedRootSignatureDeserializer CreateVersionedRootSignatureDeserializer(IntPtr blob, PointerSize size) 
+    public ID3D12VersionedRootSignatureDeserializer CreateVersionedRootSignatureDeserializer(IntPtr blob, PointerSize size)
     {
         CreateVersionedRootSignatureDeserializer(blob.ToPointer(), size, typeof(ID3D12VersionedRootSignatureDeserializer).GUID, out IntPtr nativePtr).CheckError();
         return new(nativePtr)!;
     }
 
-    public Result CreateVersionedRootSignatureDeserializer(IntPtr blob, PointerSize size, out ID3D12VersionedRootSignatureDeserializer? deserializer) 
+    public Result CreateVersionedRootSignatureDeserializer(IntPtr blob, PointerSize size, out ID3D12VersionedRootSignatureDeserializer? deserializer)
     {
         Result result = CreateVersionedRootSignatureDeserializer(blob.ToPointer(), size, typeof(ID3D12VersionedRootSignatureDeserializer).GUID, out IntPtr nativePtr);
 
@@ -25,13 +25,13 @@ public unsafe partial class ID3D12DeviceConfiguration
         return result;
     }
 
-    public T CreateVersionedRootSignatureDeserializer<T>(IntPtr blob, PointerSize size) where T : ID3D12VersionedRootSignatureDeserializer
+    public T CreateVersionedRootSignatureDeserializer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr blob, PointerSize size) where T : ID3D12VersionedRootSignatureDeserializer
     {
         CreateVersionedRootSignatureDeserializer(blob.ToPointer(), size, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateVersionedRootSignatureDeserializer<T>(IntPtr blob, PointerSize size, out T? deserializer) where T : ID3D12VersionedRootSignatureDeserializer
+    public Result CreateVersionedRootSignatureDeserializer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr blob, PointerSize size, out T? deserializer) where T : ID3D12VersionedRootSignatureDeserializer
     {
         Result result = CreateVersionedRootSignatureDeserializer(blob.ToPointer(), size, typeof(T).GUID, out IntPtr nativePtr);
 

--- a/src/Vortice.Direct3D12/ID3D12DeviceFactory.cs
+++ b/src/Vortice.Direct3D12/ID3D12DeviceFactory.cs
@@ -7,13 +7,13 @@ namespace Vortice.Direct3D12;
 
 public partial class ID3D12DeviceFactory
 {
-    public T GetConfigurationInterface<T>(Guid classId) where T : ComObject
+    public T GetConfigurationInterface<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid classId) where T : ComObject
     {
         GetConfigurationInterface(classId, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result GetConfigurationInterface<T>(Guid classId, out T? @interface) where T : ComObject
+    public Result GetConfigurationInterface<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid classId, out T? @interface) where T : ComObject
     {
         Result result = GetConfigurationInterface(classId, typeof(T).GUID, out IntPtr nativePtr);
 
@@ -27,13 +27,13 @@ public partial class ID3D12DeviceFactory
         return result;
     }
 
-    public T CreateDevice<T>(ComObject? adapter, FeatureLevel featureLevel) where T : ID3D12Device
+    public T CreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ComObject? adapter, FeatureLevel featureLevel) where T : ID3D12Device
     {
         CreateDevice(adapter != null ? adapter.NativePointer : IntPtr.Zero, featureLevel, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateDevice<T>(ComObject? adapter, FeatureLevel featureLevel, out T? device) where T : ID3D12Device
+    public Result CreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ComObject? adapter, FeatureLevel featureLevel, out T? device) where T : ID3D12Device
     {
         Result result = CreateDevice(
             adapter != null ? adapter.NativePointer : IntPtr.Zero,
@@ -50,13 +50,13 @@ public partial class ID3D12DeviceFactory
         return result;
     }
 
-    public T CreateDevice<T>(IntPtr adapterPtr, FeatureLevel featureLevel) where T : ID3D12Device
+    public T CreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr adapterPtr, FeatureLevel featureLevel) where T : ID3D12Device
     {
         CreateDevice(adapterPtr, featureLevel, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateDevice<T>(IntPtr adapterPtr, FeatureLevel featureLevel, out T? device) where T : ID3D12Device
+    public Result CreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr adapterPtr, FeatureLevel featureLevel, out T? device) where T : ID3D12Device
     {
         Result result = CreateDevice(
             adapterPtr,

--- a/src/Vortice.Direct3D12/ID3D12ProtectedSession.cs
+++ b/src/Vortice.Direct3D12/ID3D12ProtectedSession.cs
@@ -17,7 +17,7 @@ public partial class ID3D12ProtectedSession
     /// <typeparam name="T">Instance type of <see cref="ID3D12Fence"/>.</typeparam>
     /// <param name="fence">An instance to the fence for the given protected session.</param>
     /// <returns>The operation result.</returns>
-    public Result GetStatusFence<T>(out T? fence) where T : ID3D12Fence
+    public Result GetStatusFence<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? fence) where T : ID3D12Fence
     {
         Result result = GetStatusFence(typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -30,7 +30,7 @@ public partial class ID3D12ProtectedSession
         return result;
     }
 
-    public T GetStatusFence<T>() where T : ID3D12Fence
+    public T GetStatusFence<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ID3D12Fence
     {
         GetStatusFence(typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;

--- a/src/Vortice.Direct3D12/ID3D12SDKConfiguration1.cs
+++ b/src/Vortice.Direct3D12/ID3D12SDKConfiguration1.cs
@@ -5,7 +5,7 @@ namespace Vortice.Direct3D12;
 
 public partial class ID3D12SDKConfiguration1
 {
-    public ID3D12DeviceFactory CreateDeviceFactory(int sdkVersion, string sdkPath) 
+    public ID3D12DeviceFactory CreateDeviceFactory(int sdkVersion, string sdkPath)
     {
         CreateDeviceFactory(sdkVersion, sdkPath, typeof(ID3D12DeviceFactory).GUID, out IntPtr nativePtr).CheckError();
         return new(nativePtr);
@@ -25,13 +25,13 @@ public partial class ID3D12SDKConfiguration1
         return result;
     }
 
-    public T CreateDeviceFactory<T>(int sdkVersion, string sdkPath) where T : ID3D12DeviceFactory
+    public T CreateDeviceFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int sdkVersion, string sdkPath) where T : ID3D12DeviceFactory
     {
         CreateDeviceFactory(sdkVersion, sdkPath, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateDeviceFactory<T>(int sdkVersion, string sdkPath, out T? factory) where T : ID3D12DeviceFactory
+    public Result CreateDeviceFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int sdkVersion, string sdkPath, out T? factory) where T : ID3D12DeviceFactory
     {
         Result result = CreateDeviceFactory(sdkVersion, sdkPath, typeof(T).GUID, out IntPtr nativePtr);
 

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoDecoder1.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoDecoder1.cs
@@ -5,7 +5,7 @@ namespace Vortice.Direct3D12.Video;
 
 public partial class ID3D12VideoDecoder1
 {
-    public Result GetProtectedResourceSession<T>(out T? protectedSession) where T : ID3D12ProtectedResourceSession
+    public Result GetProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? protectedSession) where T : ID3D12ProtectedResourceSession
     {
         Result result = GetProtectedResourceSession(typeof(T).GUID, out IntPtr protectedSessionPtr);
         if (result.Failure)
@@ -18,7 +18,7 @@ public partial class ID3D12VideoDecoder1
         return result;
     }
 
-    public T GetProtectedResourceSession<T>() where T : ID3D12ProtectedResourceSession
+    public T GetProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ID3D12ProtectedResourceSession
     {
         GetProtectedResourceSession(typeof(T).GUID, out IntPtr protectedSessionPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(protectedSessionPtr)!;

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoDecoderHeap1.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoDecoderHeap1.cs
@@ -5,7 +5,7 @@ namespace Vortice.Direct3D12.Video;
 
 public partial class ID3D12VideoDecoderHeap1
 {
-    public Result GetProtectedResourceSession<T>(out T? protectedSession) where T : ID3D12ProtectedResourceSession
+    public Result GetProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? protectedSession) where T : ID3D12ProtectedResourceSession
     {
         Result result = GetProtectedResourceSession(typeof(T).GUID, out IntPtr protectedSessionPtr);
         if (result.Failure)
@@ -18,7 +18,7 @@ public partial class ID3D12VideoDecoderHeap1
         return result;
     }
 
-    public T GetProtectedResourceSession<T>() where T : ID3D12ProtectedResourceSession
+    public T GetProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ID3D12ProtectedResourceSession
     {
         GetProtectedResourceSession(typeof(T).GUID, out IntPtr protectedSessionPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(protectedSessionPtr)!;

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoDevice.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoDevice.cs
@@ -30,7 +30,7 @@ public partial class ID3D12VideoDevice
         return new ID3D12VideoDecoder(nativePtr);
     }
 
-    public Result CreateVideoDecoder(VideoDecoderDescription description, out ID3D12VideoDecoder? videoDecoder) 
+    public Result CreateVideoDecoder(VideoDecoderDescription description, out ID3D12VideoDecoder? videoDecoder)
     {
         Result result = CreateVideoDecoder(ref description, typeof(ID3D12VideoDecoder).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -43,13 +43,13 @@ public partial class ID3D12VideoDevice
         return result;
     }
 
-    public T CreateVideoDecoder<T>(VideoDecoderDescription description) where T : ID3D12VideoDecoder
+    public T CreateVideoDecoder<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoDecoderDescription description) where T : ID3D12VideoDecoder
     {
         CreateVideoDecoder(ref description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateVideoDecoder<T>(VideoDecoderDescription description, out T? videoDecoder) where T : ID3D12VideoDecoder
+    public Result CreateVideoDecoder<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoDecoderDescription description, out T? videoDecoder) where T : ID3D12VideoDecoder
     {
         Result result = CreateVideoDecoder(ref description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -70,7 +70,7 @@ public partial class ID3D12VideoDevice
         return new ID3D12VideoDecoderHeap(nativePtr);
     }
 
-    public Result CreateVideoDecoderHeap(VideoDecoderHeapDescription description, out ID3D12VideoDecoderHeap? videoDecoder) 
+    public Result CreateVideoDecoderHeap(VideoDecoderHeapDescription description, out ID3D12VideoDecoderHeap? videoDecoder)
     {
         Result result = CreateVideoDecoderHeap(ref description, typeof(ID3D12VideoDecoderHeap).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -83,13 +83,13 @@ public partial class ID3D12VideoDevice
         return result;
     }
 
-    public T CreateVideoDecoderHeap<T>(VideoDecoderHeapDescription description) where T : ID3D12VideoDecoderHeap
+    public T CreateVideoDecoderHeap<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoDecoderHeapDescription description) where T : ID3D12VideoDecoderHeap
     {
         CreateVideoDecoderHeap(ref description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateVideoDecoderHeap<T>(VideoDecoderHeapDescription description, out T? videoDecoder) where T : ID3D12VideoDecoderHeap
+    public Result CreateVideoDecoderHeap<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoDecoderHeapDescription description, out T? videoDecoder) where T : ID3D12VideoDecoderHeap
     {
         Result result = CreateVideoDecoderHeap(ref description, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -116,7 +116,7 @@ public partial class ID3D12VideoDevice
         return new ID3D12VideoProcessor(nativePtr);
     }
 
-    public T CreateVideoProcessor<T>(
+    public T CreateVideoProcessor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         int nodeMask,
         VideoProcessOutputStreamDescription outputStreamDescription,
         VideoProcessInputStreamDescription[] inputStreamDescriptions) where T : ID3D12VideoProcessor
@@ -125,7 +125,7 @@ public partial class ID3D12VideoDevice
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public T CreateVideoProcessor<T>(
+    public T CreateVideoProcessor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         int nodeMask,
         VideoProcessOutputStreamDescription outputStreamDescription,
         int inputStreamDescriptionsCount,
@@ -135,7 +135,7 @@ public partial class ID3D12VideoDevice
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateVideoProcessor<T>(
+    public Result CreateVideoProcessor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         int nodeMask,
         VideoProcessOutputStreamDescription outputStreamDescription,
         VideoProcessInputStreamDescription[] inputStreamDescriptions,
@@ -152,7 +152,7 @@ public partial class ID3D12VideoDevice
         return result;
     }
 
-    public Result CreateVideoProcessor<T>(
+    public Result CreateVideoProcessor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         int nodeMask,
         VideoProcessOutputStreamDescription outputStreamDescription,
         int inputStreamDescriptionsCount,

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoDevice1.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoDevice1.cs
@@ -15,13 +15,13 @@ public partial class ID3D12VideoDevice1
         return new ID3D12VideoMotionEstimator(nativePtr);
     }
 
-    public T CreateVideoMotionEstimator<T>(VideoMotionEstimatorDescription description, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12VideoMotionEstimator
+    public T CreateVideoMotionEstimator<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoMotionEstimatorDescription description, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12VideoMotionEstimator
     {
         CreateVideoMotionEstimator(ref description, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateVideoMotionEstimator<T>(VideoMotionEstimatorDescription description, ID3D12ProtectedResourceSession protectedResourceSession, out T? videoMotionEstimator) where T : ID3D12VideoMotionEstimator
+    public Result CreateVideoMotionEstimator<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoMotionEstimatorDescription description, ID3D12ProtectedResourceSession protectedResourceSession, out T? videoMotionEstimator) where T : ID3D12VideoMotionEstimator
     {
         Result result = CreateVideoMotionEstimator(ref description, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -40,13 +40,13 @@ public partial class ID3D12VideoDevice1
         return new ID3D12VideoMotionVectorHeap(nativePtr);
     }
 
-    public T CreateVideoMotionVectorHeap<T>(VideoMotionVectorHeapDescription description, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12VideoMotionVectorHeap
+    public T CreateVideoMotionVectorHeap<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoMotionVectorHeapDescription description, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12VideoMotionVectorHeap
     {
         CreateVideoMotionVectorHeap(ref description, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateVideoMotionVectorHeap<T>(VideoMotionVectorHeapDescription description, ID3D12ProtectedResourceSession protectedResourceSession, out T? videoMotionEstimator) where T : ID3D12VideoMotionVectorHeap
+    public Result CreateVideoMotionVectorHeap<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoMotionVectorHeapDescription description, ID3D12ProtectedResourceSession protectedResourceSession, out T? videoMotionEstimator) where T : ID3D12VideoMotionVectorHeap
     {
         Result result = CreateVideoMotionVectorHeap(ref description, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoDevice2.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoDevice2.cs
@@ -16,13 +16,13 @@ public partial class ID3D12VideoDevice2
         return new ID3D12VideoDecoder1(nativePtr);
     }
 
-    public T CreateVideoDecoder1<T>(VideoDecoderDescription description, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12VideoDecoder1
+    public T CreateVideoDecoder1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoDecoderDescription description, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12VideoDecoder1
     {
         CreateVideoDecoder1(ref description, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateVideoDecoder1<T>(VideoDecoderDescription description, ID3D12ProtectedResourceSession protectedResourceSession, out T? videoDecoder) where T : ID3D12VideoDecoder1
+    public Result CreateVideoDecoder1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoDecoderDescription description, ID3D12ProtectedResourceSession protectedResourceSession, out T? videoDecoder) where T : ID3D12VideoDecoder1
     {
         Result result = CreateVideoDecoder1(ref description, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -43,13 +43,13 @@ public partial class ID3D12VideoDevice2
         return new ID3D12VideoDecoderHeap1(nativePtr);
     }
 
-    public T CreateVideoDecoderHeap1<T>(VideoDecoderHeapDescription description, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12VideoDecoderHeap1
+    public T CreateVideoDecoderHeap1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoDecoderHeapDescription description, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12VideoDecoderHeap1
     {
         CreateVideoDecoderHeap1(ref description, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateVideoDecoderHeap1<T>(VideoDecoderHeapDescription description, ID3D12ProtectedResourceSession protectedResourceSession, out T? videoDecoder) where T : ID3D12VideoDecoderHeap1
+    public Result CreateVideoDecoderHeap1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoDecoderHeapDescription description, ID3D12ProtectedResourceSession protectedResourceSession, out T? videoDecoder) where T : ID3D12VideoDecoderHeap1
     {
         Result result = CreateVideoDecoderHeap1(ref description, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -70,13 +70,13 @@ public partial class ID3D12VideoDevice2
         return new ID3D12VideoExtensionCommand(nativePtr);
     }
 
-    public T CreateVideoExtensionCommand<T>(VideoExtensionCommandDescription description, IntPtr creationParameters, PointerSize creationParametersDataSizeInBytes, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12VideoExtensionCommand
+    public T CreateVideoExtensionCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(VideoExtensionCommandDescription description, IntPtr creationParameters, PointerSize creationParametersDataSizeInBytes, ID3D12ProtectedResourceSession protectedResourceSession) where T : ID3D12VideoExtensionCommand
     {
         CreateVideoExtensionCommand(ref description, creationParameters, creationParametersDataSizeInBytes, protectedResourceSession, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateVideoExtensionCommand<T>(
+    public Result CreateVideoExtensionCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         VideoExtensionCommandDescription description,
         IntPtr creationParameters,
         PointerSize creationParametersDataSizeInBytes,
@@ -132,7 +132,7 @@ public partial class ID3D12VideoDevice2
         return new ID3D12VideoProcessor(nativePtr);
     }
 
-    public T CreateVideoProcessor1<T>(
+    public T CreateVideoProcessor1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         int nodeMask,
         VideoProcessOutputStreamDescription outputStreamDescription,
         VideoProcessInputStreamDescription[] inputStreamDescriptions,
@@ -150,7 +150,7 @@ public partial class ID3D12VideoDevice2
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public T CreateVideoProcessor1<T>(
+    public T CreateVideoProcessor1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         int nodeMask,
         VideoProcessOutputStreamDescription outputStreamDescription,
         int inputStreamDescriptionsCount,
@@ -168,7 +168,7 @@ public partial class ID3D12VideoDevice2
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateVideoProcessor1<T>(
+    public Result CreateVideoProcessor1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         int nodeMask,
         VideoProcessOutputStreamDescription outputStreamDescription,
         VideoProcessInputStreamDescription[] inputStreamDescriptions,
@@ -192,7 +192,7 @@ public partial class ID3D12VideoDevice2
         return result;
     }
 
-    public Result CreateVideoProcessor1<T>(
+    public Result CreateVideoProcessor1<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
         int nodeMask,
         VideoProcessOutputStreamDescription outputStreamDescription,
         int inputStreamDescriptionsCount,

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoExtensionCommand.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoExtensionCommand.cs
@@ -5,13 +5,13 @@ namespace Vortice.Direct3D12.Video;
 
 public partial class ID3D12VideoExtensionCommand
 {
-    public T GetProtectedResourceSession<T>() where T : ID3D12ProtectedResourceSession
+    public T GetProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ID3D12ProtectedResourceSession
     {
         GetProtectedResourceSession(typeof(T).GUID, out IntPtr protectedSessionPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(protectedSessionPtr)!;
     }
 
-    public  Result GetProtectedResourceSession<T>(out T? protectedSession) where T : ID3D12ProtectedResourceSession
+    public  Result GetProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? protectedSession) where T : ID3D12ProtectedResourceSession
     {
         Result result = GetProtectedResourceSession(typeof(T).GUID, out IntPtr protectedSessionPtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoMotionEstimator.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoMotionEstimator.cs
@@ -5,13 +5,13 @@ namespace Vortice.Direct3D12.Video;
 
 public partial class ID3D12VideoMotionEstimator
 {
-    public T GetProtectedResourceSession<T>() where T : ID3D12ProtectedResourceSession
+    public T GetProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ID3D12ProtectedResourceSession
     {
         GetProtectedResourceSession(typeof(T).GUID, out IntPtr protectedSessionPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(protectedSessionPtr)!;
     }
 
-    public Result GetProtectedResourceSession<T>(out T? protectedSession) where T : ID3D12ProtectedResourceSession
+    public Result GetProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? protectedSession) where T : ID3D12ProtectedResourceSession
     {
         Result result = GetProtectedResourceSession(typeof(T).GUID, out IntPtr protectedSessionPtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoMotionVectorHeap.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoMotionVectorHeap.cs
@@ -5,13 +5,13 @@ namespace Vortice.Direct3D12.Video;
 
 public partial class ID3D12VideoMotionVectorHeap
 {
-    public T GetProtectedResourceSession<T>() where T : ID3D12ProtectedResourceSession
+    public T GetProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ID3D12ProtectedResourceSession
     {
         GetProtectedResourceSession(typeof(T).GUID, out IntPtr protectedSessionPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(protectedSessionPtr)!;
     }
 
-    public Result GetProtectedResourceSession<T>(out T? protectedSession) where T : ID3D12ProtectedResourceSession
+    public Result GetProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? protectedSession) where T : ID3D12ProtectedResourceSession
     {
         Result result = GetProtectedResourceSession(typeof(T).GUID, out IntPtr protectedSessionPtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/Video/ID3D12VideoProcessor1.cs
+++ b/src/Vortice.Direct3D12/Video/ID3D12VideoProcessor1.cs
@@ -5,13 +5,13 @@ namespace Vortice.Direct3D12.Video;
 
 public partial class ID3D12VideoProcessor1
 {
-    public T GetProtectedResourceSession<T>() where T : ID3D12ProtectedResourceSession
+    public T GetProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ID3D12ProtectedResourceSession
     {
         GetProtectedResourceSession(typeof(T).GUID, out IntPtr protectedSessionPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(protectedSessionPtr)!;
     }
 
-    public Result GetProtectedResourceSession<T>(out T? protectedSession) where T : ID3D12ProtectedResourceSession
+    public Result GetProtectedResourceSession<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]T>(out T? protectedSession) where T : ID3D12ProtectedResourceSession
     {
         Result result = GetProtectedResourceSession(typeof(T).GUID, out IntPtr protectedSessionPtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D12/Vortice.Direct3D12.csproj
+++ b/src/Vortice.Direct3D12/Vortice.Direct3D12.csproj
@@ -8,9 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="SharpGen.Runtime" />
-    
+
     <SharpGenMapping Include="Mappings.xml" />
     <SharpGenExternalDocs Include="Documentation.xml" />
     <ProjectReference Include="..\Vortice.DXGI\Vortice.DXGI.csproj" />

--- a/src/Vortice.Direct3D9/Direct3D9on12/IDirect3DDevice9On12.cs
+++ b/src/Vortice.Direct3D9/Direct3D9on12/IDirect3DDevice9On12.cs
@@ -7,7 +7,7 @@ namespace Vortice.Direct3D9on12;
 
 public partial class IDirect3DDevice9On12
 {
-    public Result GetD3D12Device<T>(out T? device) where T : ComObject
+    public Result GetD3D12Device<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? device) where T : ComObject
     {
         Result result = GetD3D12Device(typeof(T).GUID, out IntPtr devicePtr);
         if (result.Failure)
@@ -20,19 +20,19 @@ public partial class IDirect3DDevice9On12
         return result;
     }
 
-    public T GetD3D12Device<T>() where T : ComObject
+    public T GetD3D12Device<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ComObject
     {
         GetD3D12Device(typeof(T).GUID, out IntPtr devicePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(devicePtr)!;
     }
 
-    public T UnwrapUnderlyingResource<T>(IDirect3DResource9 resource, ComObject commandQueue) where T : ComObject
+    public T UnwrapUnderlyingResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IDirect3DResource9 resource, ComObject commandQueue) where T : ComObject
     {
         UnwrapUnderlyingResource(resource, commandQueue, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result UnwrapUnderlyingResource<T>(IDirect3DResource9 resource, ComObject commandQueue, out T? resource12) where T : ComObject
+    public Result UnwrapUnderlyingResource<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IDirect3DResource9 resource, ComObject commandQueue, out T? resource12) where T : ComObject
     {
         Result result = UnwrapUnderlyingResource(resource, commandQueue, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)

--- a/src/Vortice.Direct3D9/IDirect3DSurface9.cs
+++ b/src/Vortice.Direct3D9/IDirect3DSurface9.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.Direct3D9;
@@ -11,13 +11,13 @@ public unsafe partial class IDirect3DSurface9
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns>The parent container texture.</returns>
-    public T GetContainer<T>() where T : ComObject
+    public T GetContainer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ComObject
     {
         GetContainer(typeof(T).GUID, out IntPtr containerPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(containerPtr)!;
     }
 
-    public Result GetContainer<T>(out T? container) where T : ComObject
+    public Result GetContainer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? container) where T : ComObject
     {
         Result result = GetContainer(typeof(T).GUID, out IntPtr containerPtr);
         if (result.Failure)

--- a/src/Vortice.Direct3D9/IDirect3DVolume9.cs
+++ b/src/Vortice.Direct3D9/IDirect3DVolume9.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using Vortice.Mathematics;
@@ -7,7 +7,7 @@ namespace Vortice.Direct3D9;
 
 public unsafe partial class IDirect3DVolume9
 {
-    public T GetContainer<T>(Guid guid) where T : ComObject
+    public T GetContainer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid guid) where T : ComObject
     {
         IntPtr containerPtr = GetContainer(guid);
         return MarshallingHelpers.FromPointer<T>(containerPtr)!;

--- a/src/Vortice.Direct3D9/Vortice.Direct3D9.csproj
+++ b/src/Vortice.Direct3D9/Vortice.Direct3D9.csproj
@@ -10,11 +10,12 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <Compile Remove="Shims/UnscopedRefAttribute.cs" />
   </ItemGroup>
-  
+
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="SharpGen.Runtime" />
-    
+
     <SharpGenMapping Include="Mappings.xml" />
     <SharpGenExternalDocs Include="Documentation.xml" />
     <PackageReference Include="SharpGen.Runtime.COM" />

--- a/src/Vortice.DirectComposition/DComp.cs
+++ b/src/Vortice.DirectComposition/DComp.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using Vortice.Direct2D1;
@@ -14,7 +14,7 @@ public static partial class DComp
     /// <typeparam name="T">A generic type of <see cref="IDCompositionDevice"/>.</typeparam>
     /// <param name="dxgiDevice">The DXGI device <see cref="IDXGIDevice"/> to use to create DirectComposition surface objects.</param>
     /// <returns>An instance of <see cref="IDCompositionDevice"/> interface .</returns>
-    public static T DCompositionCreateDevice<T>(IDXGIDevice dxgiDevice) where T : IDCompositionDevice
+    public static T DCompositionCreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IDXGIDevice dxgiDevice) where T : IDCompositionDevice
     {
         DCompositionCreateDevice(dxgiDevice, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -27,7 +27,7 @@ public static partial class DComp
     /// <param name="dxgiDevice">The DXGI device <see cref="IDXGIDevice"/> to use to create DirectComposition surface objects.</param>
     /// <param name="compositionDevice">An instance of <see cref="IDCompositionDevice"/> interface or null if failure</param>
     /// <returns>The <see cref="Result"/> code.</returns>
-    public static Result DCompositionCreateDevice<T>(IDXGIDevice dxgiDevice, out T? compositionDevice) where T : IDCompositionDevice
+    public static Result DCompositionCreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IDXGIDevice dxgiDevice, out T? compositionDevice) where T : IDCompositionDevice
     {
         Result result = DCompositionCreateDevice(dxgiDevice, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -46,7 +46,7 @@ public static partial class DComp
     /// <typeparam name="T">A generic type of <see cref="IDCompositionDevice"/>.</typeparam>
     /// <param name="renderingDevice">An optional instance to a DirectX device to be used to create DirectComposition surface objects. Must be a instance of an object implementing the <see cref="IDXGIDevice"/> or <see cref="ID2D1Device"/> interfaces.</param>
     /// <returns>An instance of <see cref="IDCompositionDevice"/> interface.</returns>
-    public static T DCompositionCreateDevice2<T>(IUnknown renderingDevice) where T : IDCompositionDevice
+    public static T DCompositionCreateDevice2<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IUnknown renderingDevice) where T : IDCompositionDevice
     {
         DCompositionCreateDevice2(renderingDevice, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -59,7 +59,7 @@ public static partial class DComp
     /// <param name="renderingDevice">An optional instance to a DirectX device to be used to create DirectComposition surface objects. Must be a instance of an object implementing the <see cref="IDXGIDevice"/> or <see cref="ID2D1Device"/> interfaces.</param>
     /// <param name="compositionDevice">An instance of <see cref="IDCompositionDevice"/> interface or null if failure</param>
     /// <returns>The <see cref="Result"/> code.</returns>
-    public static Result DCompositionCreateDevice2<T>(IUnknown renderingDevice, out T? compositionDevice) where T : IDCompositionDevice
+    public static Result DCompositionCreateDevice2<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IUnknown renderingDevice, out T? compositionDevice) where T : IDCompositionDevice
     {
         Result result = DCompositionCreateDevice2(renderingDevice, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -78,7 +78,7 @@ public static partial class DComp
     /// <typeparam name="T">A generic type of <see cref="IDCompositionDevice"/>.</typeparam>
     /// <param name="renderingDevice">An optional instance to a DirectX device to be used to create DirectComposition surface objects. Must be a instance of an object implementing the <see cref="IDXGIDevice"/> or <see cref="ID2D1Device"/> interfaces.</param>
     /// <returns>An instance of <see cref="IDCompositionDevice"/> interface.</returns>
-    public static T DCompositionCreateDevice3<T>(IUnknown renderingDevice) where T : IDCompositionDevice
+    public static T DCompositionCreateDevice3<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IUnknown renderingDevice) where T : IDCompositionDevice
     {
         DCompositionCreateDevice3(renderingDevice, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -91,7 +91,7 @@ public static partial class DComp
     /// <param name="renderingDevice">An optional instance to a DirectX device to be used to create DirectComposition surface objects. Must be a instance of an object implementing the <see cref="IDXGIDevice"/> or <see cref="ID2D1Device"/> interfaces.</param>
     /// <param name="compositionDevice">An instance of <see cref="IDCompositionDevice"/> interface or null if failure</param>
     /// <returns>The <see cref="Result"/> code.</returns>
-    public static Result DCompositionCreateDevice3<T>(IUnknown renderingDevice, out T? compositionDevice) where T : IDCompositionDevice
+    public static Result DCompositionCreateDevice3<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IUnknown renderingDevice, out T? compositionDevice) where T : IDCompositionDevice
     {
         Result result = DCompositionCreateDevice3(renderingDevice, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.DirectComposition/IDCompositionSurface.cs
+++ b/src/Vortice.DirectComposition/IDCompositionSurface.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using Vortice.Mathematics;
@@ -7,13 +7,13 @@ namespace Vortice.DirectComposition;
 
 public partial class IDCompositionSurface
 {
-    public T BeginDraw<T>(RawRect? updateRect, out Int2 updateOffset) where T : ComObject
+    public T BeginDraw<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(RawRect? updateRect, out Int2 updateOffset) where T : ComObject
     {
         BeginDraw(updateRect, typeof(T).GUID, out IntPtr updateObjectPtr, out updateOffset).CheckError();
         return MarshallingHelpers.FromPointer<T>(updateObjectPtr)!;
     }
 
-    public Result BeginDraw<T>(RawRect? updateRect, out T? updateObject, out Int2 updateOffset) where T : ComObject
+    public Result BeginDraw<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(RawRect? updateRect, out T? updateObject, out Int2 updateOffset) where T : ComObject
     {
         Result result = BeginDraw(updateRect, typeof(T).GUID, out IntPtr updateObjectPtr, out updateOffset);
         if (result.Failure)

--- a/src/Vortice.DirectComposition/Vortice.DirectComposition.csproj
+++ b/src/Vortice.DirectComposition/Vortice.DirectComposition.csproj
@@ -6,11 +6,12 @@
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Description>DirectComposition bindings.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis"/>
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="SharpGen.Runtime" />
-    
+
     <SharpGenMapping Include="Mappings.xml" />
     <SharpGenExternalDocs Include="Documentation.xml" />
     <ProjectReference Include="..\Vortice.Direct2D1\Vortice.Direct2D1.csproj" />

--- a/src/Vortice.DirectInput/IDirectInputDevice8.cs
+++ b/src/Vortice.DirectInput/IDirectInputDevice8.cs
@@ -409,13 +409,13 @@ public unsafe partial class IDirectInputDevice8
         WriteEffectToFile(fileName, effects.Length, effects, (int)(includeNonstandardEffects ? EffectFileFlags.IncludeNonStandard : 0));
     }
 
-    public Result SetDataFormat<TRaw>() where TRaw : unmanaged
+    public Result SetDataFormat<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)] TRaw>() where TRaw : unmanaged
     {
         var dataFormat = GetDataFormat<TRaw>();
         return SetDataFormat(dataFormat);
     }
 
-    private unsafe DataFormat GetDataFormat<TRaw>() where TRaw : unmanaged
+    private unsafe DataFormat GetDataFormat<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)] TRaw>() where TRaw : unmanaged
     {
         if (_dataFormat == null)
         {

--- a/src/Vortice.DirectInput/KeyboardState.cs
+++ b/src/Vortice.DirectInput/KeyboardState.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,7 +28,7 @@ public class KeyboardState : IDeviceState<RawKeyboardState, KeyboardUpdate>
 
     static KeyboardState()
     {
-        foreach (Key key in Enum.GetValues(typeof(Key)))
+        foreach (Key key in Enum.GetValues<Key>())
         {
             _allKeys.Add(key);
         }

--- a/src/Vortice.DirectInput/Vortice.DirectInput.csproj
+++ b/src/Vortice.DirectInput/Vortice.DirectInput.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
+
     <SharpGenMapping Include="Mappings.xml" />
     <ProjectReference Include="..\Vortice.DirectX\Vortice.DirectX.csproj" />
   </ItemGroup>

--- a/src/Vortice.DirectML/DML.cs
+++ b/src/Vortice.DirectML/DML.cs
@@ -115,14 +115,14 @@ public static partial class DML
         return new(nativePtr);
     }
 
-    public static T DMLCreateDevice<T>(ID3D12Device d3d12Device, CreateDeviceFlags createDeviceFlags)
+    public static T DMLCreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ID3D12Device d3d12Device, CreateDeviceFlags createDeviceFlags)
         where T : IDMLDevice
     {
         DMLCreateDevice(d3d12Device, createDeviceFlags, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr) ?? throw new NullReferenceException();
     }
 
-    public static Result DMLCreateDevice<T>(ID3D12Device d3d12Device, CreateDeviceFlags createDeviceFlags, out T? device)
+    public static Result DMLCreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ID3D12Device d3d12Device, CreateDeviceFlags createDeviceFlags, out T? device)
         where T : IDMLDevice
     {
         Result result = DMLCreateDevice(
@@ -141,7 +141,7 @@ public static partial class DML
         return result;
     }
 
-    public static T DMLCreateDevice<T>(ID3D12Device d3d12Device, CreateDeviceFlags createDeviceFlags, FeatureLevel minimumFeatureLevel)
+    public static T DMLCreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ID3D12Device d3d12Device, CreateDeviceFlags createDeviceFlags, FeatureLevel minimumFeatureLevel)
         where T : IDMLDevice
     {
         DMLCreateDevice1(
@@ -154,7 +154,7 @@ public static partial class DML
         return MarshallingHelpers.FromPointer<T>(nativePtr) ?? throw new NullReferenceException();
     }
 
-    public static Result DMLCreateDevice<T>(ID3D12Device d3d12Device, CreateDeviceFlags createDeviceFlags, FeatureLevel minimumFeatureLevel, out T? device)
+    public static Result DMLCreateDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ID3D12Device d3d12Device, CreateDeviceFlags createDeviceFlags, FeatureLevel minimumFeatureLevel, out T? device)
         where T : IDMLDevice
     {
         Result result = DMLCreateDevice1(

--- a/src/Vortice.DirectML/IDMLDevice.cs
+++ b/src/Vortice.DirectML/IDMLDevice.cs
@@ -10,7 +10,7 @@ public partial class IDMLDevice
     /// <summary>
     /// Gets the highest supported feature level.
     /// </summary>
-    public FeatureLevel HighestFeatureLevel => CheckFeatureLevelsSupport((FeatureLevel[])Enum.GetValues(typeof(FeatureLevel)));
+    public FeatureLevel HighestFeatureLevel => CheckFeatureLevelsSupport(Enum.GetValues<FeatureLevel>());
 
     /// <summary>
     /// Query for the feature levels supported by the device

--- a/src/Vortice.DirectML/Vortice.DirectML.csproj
+++ b/src/Vortice.DirectML/Vortice.DirectML.csproj
@@ -6,11 +6,11 @@
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Description>DirectML bindings.</Description>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <Authors>Aaron Sun, Amer Koleci</Authors>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Content Include="build\Vortice.DirectML.props" PackagePath="build\Vortice.DirectML.props" />
     <Content Include="runtimes\win-arm\native\DirectML.Debug.dll" PackagePath="runtimes\win-arm\DirectML.Debug.dll" CopyToOutputDirectory="PreserveNewest" />
@@ -23,11 +23,12 @@
     <Content Include="runtimes\win-x86\native\DirectML.dll" PackagePath="runtimes\win-x86\DirectML.dll" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="runtimes\LICENSE.txt" PackagePath="runtimes\LICENSE.txt" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <SharpGenMapping Include="Mappings.xml" />
     <SharpGenExternalDocs Include="Documentation.xml" />
-    
+
+    <Using Include="System.Diagnostics.CodeAnalysis"/>
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="SharpGen.Runtime" />
     <ProjectReference Include="..\Vortice.DirectX\Vortice.DirectX.csproj" />

--- a/src/Vortice.DirectStorage/DirectStorage.cs
+++ b/src/Vortice.DirectStorage/DirectStorage.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.DirectStorage;
@@ -101,7 +101,7 @@ public static partial class DirectStorage
     /// </summary>
     /// <param name="factory">Specifies the DStorage factory interface, such as <see cref="IDStorageFactory"/>.</param>
     /// <returns>Return the <see cref="Result"/>.</returns>
-    public static Result DStorageGetFactory<T>(out T? factory) where T : ComObject
+    public static Result DStorageGetFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? factory) where T : ComObject
     {
         Result result = DStorageGetFactory(typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)
@@ -119,7 +119,7 @@ public static partial class DirectStorage
     /// open files for DStorage access, and other global operations.
     /// </summary>
     /// <returns>Return the DStorage factory interface, such as <see cref="IDStorageFactory"/>..</returns>
-    public static T DStorageGetFactory<T>() where T : ComObject
+    public static T DStorageGetFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ComObject
     {
         DStorageGetFactory(typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -144,7 +144,7 @@ public static partial class DirectStorage
         return new(nativePtr)!;
     }
 
-    public static Result DStorageCreateCompressionCodec<T>(CompressionFormat format, uint numThreads, out T? codec) where T : ComObject
+    public static Result DStorageCreateCompressionCodec<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(CompressionFormat format, uint numThreads, out T? codec) where T : ComObject
     {
         Result result = DStorageCreateCompressionCodec(format, numThreads, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)
@@ -157,7 +157,7 @@ public static partial class DirectStorage
         return result;
     }
 
-    public static T DStorageCreateCompressionCodec<T>(CompressionFormat format, uint numThreads) where T : ComObject
+    public static T DStorageCreateCompressionCodec<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(CompressionFormat format, uint numThreads) where T : ComObject
     {
         DStorageCreateCompressionCodec(format, numThreads, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;

--- a/src/Vortice.DirectStorage/IDStorageFactory.cs
+++ b/src/Vortice.DirectStorage/IDStorageFactory.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.DirectStorage;
@@ -12,7 +12,7 @@ public partial class IDStorageFactory
     /// <param name="description">Descriptor to specify the properties of the queue.</param>
     /// <param name="queue">Receives the new queue created.</param>
     /// <returns>The result of operation.</returns>
-    public Result CreateQueue<T>(QueueDesc description, out T? queue) where T : ComObject
+    public Result CreateQueue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(QueueDesc description, out T? queue) where T : ComObject
     {
         Result result = CreateQueue(ref description, typeof(T).GUID, out IntPtr nativePtr);
 
@@ -32,7 +32,7 @@ public partial class IDStorageFactory
     /// <typeparam name="T">Type to create, such as <see cref="IDStorageQueue"/>.</typeparam>
     /// <param name="description">Descriptor to specify the properties of the queue.</param>
     /// <returns>The new queue created.</returns>
-    public T CreateQueue<T>(QueueDesc description) where T : ComObject
+    public T CreateQueue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(QueueDesc description) where T : ComObject
     {
         CreateQueue(ref description, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -65,7 +65,7 @@ public partial class IDStorageFactory
     /// <param name="path">Path of the file to be opened.</param>
     /// <param name="file">Receives the new file opened.</param>
     /// <returns>The result of operation.</returns>
-    public Result OpenFile<T>(string path, out T? file) where T : ComObject
+    public Result OpenFile<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string path, out T? file) where T : ComObject
     {
         Result result = OpenFile(path, typeof(T).GUID, out IntPtr nativePtr);
 
@@ -85,7 +85,7 @@ public partial class IDStorageFactory
     /// <typeparam name="T">Type of storage file, such as <see cref="IDStorageFile"/>.</typeparam>
     /// <param name="path">Path of the file to be opened.</param>
     /// <returns>The new file opened.</returns>
-    public T OpenFile<T>(string path) where T : ComObject
+    public T OpenFile<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string path) where T : ComObject
     {
         OpenFile(path, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
@@ -122,7 +122,7 @@ public partial class IDStorageFactory
         return new IDStorageFile(nativePtr);
     }
 
-    public Result CreateStatusArray<T>(uint capacity, string name, out T? statusArray) where T : ComObject
+    public Result CreateStatusArray<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(uint capacity, string name, out T? statusArray) where T : ComObject
     {
         Result result = CreateStatusArray(capacity, name, typeof(T).GUID, out IntPtr nativePtr);
 
@@ -136,13 +136,13 @@ public partial class IDStorageFactory
         return result;
     }
 
-    public T CreateStatusArray<T>(uint capacity, string name) where T : ComObject
+    public T CreateStatusArray<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(uint capacity, string name) where T : ComObject
     {
         CreateStatusArray(capacity, name, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result CreateStatusArray(uint capacity, string name, out IDStorageStatusArray? statusArray) 
+    public Result CreateStatusArray(uint capacity, string name, out IDStorageStatusArray? statusArray)
     {
         Result result = CreateStatusArray(capacity, name, typeof(IDStorageStatusArray).GUID, out IntPtr nativePtr);
 

--- a/src/Vortice.DirectStorage/Vortice.DirectStorage.csproj
+++ b/src/Vortice.DirectStorage/Vortice.DirectStorage.csproj
@@ -22,9 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="SharpGen.Runtime" />
-    
+
     <SharpGenMapping Include="Mappings.xml" />
     <ProjectReference Include="..\Vortice.Direct3D12\Vortice.Direct3D12.csproj" />
   </ItemGroup>

--- a/src/Vortice.DirectX/DXCore/DXCore.cs
+++ b/src/Vortice.DirectX/DXCore/DXCore.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.DXCore;
@@ -25,7 +25,7 @@ public static partial class DXCore
     /// </summary>
     /// <param name="factory">The <see cref="IDXCoreAdapterFactory"/> being created.</param>
     /// <returns>Return the <see cref="Result"/>.</returns>
-    public static Result DXCoreCreateAdapterFactory<T>(out T? factory) where T : IDXCoreAdapterFactory
+    public static Result DXCoreCreateAdapterFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? factory) where T : IDXCoreAdapterFactory
     {
         Result result = DXCoreCreateAdapterFactory(typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)
@@ -42,7 +42,7 @@ public static partial class DXCore
     /// Try to create new instance of <see cref="IDXCoreAdapterFactory"/>.
     /// </summary>
     /// <returns>Return an instance of <see cref="IDXCoreAdapterFactory"/> or null if failed.</returns>
-    public static T DXCoreCreateAdapterFactory<T>() where T : IDXCoreAdapterFactory
+    public static T DXCoreCreateAdapterFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : IDXCoreAdapterFactory
     {
         DXCoreCreateAdapterFactory(typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;

--- a/src/Vortice.DirectX/DXCore/IDXCoreAdapter.cs
+++ b/src/Vortice.DirectX/DXCore/IDXCoreAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.DXCore;
@@ -30,13 +30,13 @@ public unsafe partial class IDXCoreAdapter
         }
     }
 
-    public T GetFactory<T>() where T : IDXCoreAdapterFactory
+    public T GetFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : IDXCoreAdapterFactory
     {
         GetFactory(typeof(T).GUID, out IntPtr factoryPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(factoryPtr)!;
     }
 
-    public Result GetFactory<T>(out T? factory) where T : IDXCoreAdapterFactory
+    public Result GetFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? factory) where T : IDXCoreAdapterFactory
     {
         Result result = GetFactory(typeof(T).GUID, out IntPtr factoryPtr);
         if (result.Failure)

--- a/src/Vortice.DirectX/DXCore/IDXCoreAdapterFactory.cs
+++ b/src/Vortice.DirectX/DXCore/IDXCoreAdapterFactory.cs
@@ -1,16 +1,16 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.DXCore;
 
 public partial class IDXCoreAdapterFactory
 {
-    public Result CreateAdapterList<T>(Guid[] filterAttributes, out T? adapterList) where T : IDXCoreAdapterList
+    public Result CreateAdapterList<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid[] filterAttributes, out T? adapterList) where T : IDXCoreAdapterList
     {
         return CreateAdapterList(filterAttributes.Length, filterAttributes, out adapterList);
     }
 
-    public Result CreateAdapterList<T>(int numAttributes, Guid[] filterAttributes, out T? adapterList) where T : IDXCoreAdapterList
+    public Result CreateAdapterList<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int numAttributes, Guid[] filterAttributes, out T? adapterList) where T : IDXCoreAdapterList
     {
         Result result = CreateAdapterList(numAttributes, filterAttributes, typeof(T).GUID, out IntPtr adapterListPtr);
         if (result.Failure)
@@ -23,18 +23,18 @@ public partial class IDXCoreAdapterFactory
         return result;
     }
 
-    public T CreateAdapterList<T>(Guid[] filterAttributes) where T : IDXCoreAdapterList
+    public T CreateAdapterList<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid[] filterAttributes) where T : IDXCoreAdapterList
     {
         return CreateAdapterList<T>(filterAttributes.Length, filterAttributes);
     }
 
-    public T CreateAdapterList<T>(int numAttributes, Guid[] filterAttributes) where T : IDXCoreAdapterList
+    public T CreateAdapterList<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int numAttributes, Guid[] filterAttributes) where T : IDXCoreAdapterList
     {
         CreateAdapterList(numAttributes, filterAttributes, typeof(T).GUID, out IntPtr adapterListPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(adapterListPtr)!;
     }
 
-    public Result GetAdapterByLuid<T>(Luid adapterLUID, out T? adapter) where T : IDXCoreAdapter
+    public Result GetAdapterByLuid<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Luid adapterLUID, out T? adapter) where T : IDXCoreAdapter
     {
         Result result = GetAdapterByLuid(adapterLUID, typeof(T).GUID, out IntPtr adapterPtr);
         if (result.Failure)
@@ -47,7 +47,7 @@ public partial class IDXCoreAdapterFactory
         return result;
     }
 
-    public T GetAdapterByLuid<T>(Luid adapterLUID) where T : IDXCoreAdapter
+    public T GetAdapterByLuid<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Luid adapterLUID) where T : IDXCoreAdapter
     {
         GetAdapterByLuid(adapterLUID, typeof(T).GUID, out IntPtr adapterPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(adapterPtr)!;

--- a/src/Vortice.DirectX/DXCore/IDXCoreAdapterList.cs
+++ b/src/Vortice.DirectX/DXCore/IDXCoreAdapterList.cs
@@ -1,17 +1,17 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.DXCore;
 
 public partial class IDXCoreAdapterList
 {
-    public T GetAdapter<T>(int index) where T : IDXCoreAdapter
+    public T GetAdapter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int index) where T : IDXCoreAdapter
     {
         GetAdapter(index, typeof(T).GUID, out IntPtr adapterPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(adapterPtr)!;
     }
 
-    public Result GetAdapter<T>(int index, out T? adapter) where T : IDXCoreAdapter
+    public Result GetAdapter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int index, out T? adapter) where T : IDXCoreAdapter
     {
         Result result = GetAdapter(index, typeof(T).GUID, out IntPtr adapterPtr);
         if (result.Failure)
@@ -24,13 +24,13 @@ public partial class IDXCoreAdapterList
         return result;
     }
 
-    public T GetFactory<T>() where T : IDXCoreAdapterFactory
+    public T GetFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : IDXCoreAdapterFactory
     {
         GetFactory(typeof(T).GUID, out IntPtr factoryPtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(factoryPtr)!;
     }
 
-    public Result GetFactory<T>(out T? factory) where T : IDXCoreAdapterFactory
+    public Result GetFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? factory) where T : IDXCoreAdapterFactory
     {
         Result result = GetFactory(typeof(T).GUID, out IntPtr factoryPtr);
         if (result.Failure)

--- a/src/Vortice.DirectX/Vortice.DirectX.csproj
+++ b/src/Vortice.DirectX/Vortice.DirectX.csproj
@@ -9,9 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="SharpGen.Runtime" />
-    
+
     <SharpGenMapping Include="Mappings.xml" />
     <PackageReference Include="Vortice.Mathematics" />
     <PackageReference Include="SharpGen.Runtime.COM" />
@@ -41,7 +42,7 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Vortice.Direct3D12, PublicKey=$(VorticePublicKey)</_Parameter1>
     </AssemblyAttribute>
-    
+
   </ItemGroup>
 
   <ItemGroup Condition="'$(SignAssembly)' != 'true'">

--- a/src/Vortice.Dxc/Dxc.cs
+++ b/src/Vortice.Dxc/Dxc.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Runtime.CompilerServices;
@@ -184,7 +184,7 @@ public static partial class Dxc
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static T CreateDxcCompiler<T>() where T : ComObject
+    public static T CreateDxcCompiler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ComObject
     {
         return DxcCreateInstance<T>(CLSID_DxcCompiler);
     }
@@ -225,13 +225,13 @@ public static partial class Dxc
         }
     }
 
-    public static T DxcCreateInstance<T>(Guid classGuid) where T : ComObject
+    public static T DxcCreateInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid classGuid) where T : ComObject
     {
         DxcCreateInstance(classGuid, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public static Result DxcCreateInstance<T>(Guid classGuid, out T? instance) where T : ComObject
+    public static Result DxcCreateInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid classGuid, out T? instance) where T : ComObject
     {
         Result result = DxcCreateInstance(classGuid, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)

--- a/src/Vortice.Dxc/Dxil.cs
+++ b/src/Vortice.Dxc/Dxil.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Runtime.CompilerServices;
@@ -15,7 +15,7 @@ public static partial class Dxil
     }
 
 
-    public static Result DxilCreateInstance<T>(Guid classGuid, out T? instance) where T : ComObject
+    public static Result DxilCreateInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid classGuid, out T? instance) where T : ComObject
     {
         Result result = DxcCreateInstance(classGuid, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Success)

--- a/src/Vortice.Dxc/IDxcCompiler3.cs
+++ b/src/Vortice.Dxc/IDxcCompiler3.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 // Implementation based on https://github.com/tgjones/DotNetDxc
 
@@ -12,7 +12,7 @@ public partial class IDxcCompiler3
         return result!;
     }
 
-    public unsafe Result Compile<T>(string source, string[] arguments, IDxcIncludeHandler includeHandler, out T? result) where T : ComObject
+    public unsafe Result Compile<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string source, string[] arguments, IDxcIncludeHandler includeHandler, out T? result) where T : ComObject
     {
         IntPtr shaderSourcePtr = Marshal.StringToHGlobalAnsi(source);
         IntPtr* argumentsPtr = (IntPtr*)0;
@@ -57,13 +57,13 @@ public partial class IDxcCompiler3
         }
     }
 
-    public T Disassemble<T>(in DxcBuffer buffer) where T : IDxcResult
+    public T Disassemble<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in DxcBuffer buffer) where T : IDxcResult
     {
         Disassemble(buffer, out T? result).CheckError();
         return result!;
     }
 
-    public unsafe Result Disassemble<T>(DxcBuffer buffer, out T? result) where T : IDxcResult
+    public unsafe Result Disassemble<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(DxcBuffer buffer, out T? result) where T : IDxcResult
     {
         Result hr = Disassemble(ref buffer, typeof(T).GUID, out IntPtr nativePtr);
         if (hr.Failure)
@@ -76,13 +76,13 @@ public partial class IDxcCompiler3
         return hr;
     }
 
-    public T Disassemble<T>(string source) where T : IDxcResult
+    public T Disassemble<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string source) where T : IDxcResult
     {
         Disassemble(source, out T? result).CheckError();
         return result!;
     }
 
-    public unsafe Result Disassemble<T>(string source, out T? result) where T : IDxcResult
+    public unsafe Result Disassemble<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string source, out T? result) where T : IDxcResult
     {
         IntPtr shaderSourcePtr = Marshal.StringToHGlobalAnsi(source);
 

--- a/src/Vortice.Dxc/IDxcContainerReflection.cs
+++ b/src/Vortice.Dxc/IDxcContainerReflection.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.Dxc;
@@ -29,7 +29,7 @@ public partial class IDxcContainerReflection
         return result;
     }
 
-    public T? GetPartReflection<T>(int index) where T : ComObject
+    public T? GetPartReflection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int index) where T : ComObject
     {
         Result result = GetPartReflection(index, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)
@@ -40,7 +40,7 @@ public partial class IDxcContainerReflection
         return MarshallingHelpers.FromPointer<T>(nativePtr);
     }
 
-    public Result GetPartReflection<T>(int index, out T? @object) where T : ComObject
+    public Result GetPartReflection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int index, out T? @object) where T : ComObject
     {
         Result result = GetPartReflection(index, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.Dxc/IDxcExtraOutputs.cs
+++ b/src/Vortice.Dxc/IDxcExtraOutputs.cs
@@ -1,17 +1,17 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.Dxc;
 
 public partial class IDxcExtraOutputs
 {
-    public T GetOutput<T>(int index, out IDxcBlobWide outputType, out IDxcBlobWide outputName) where T : IDxcBlob
+    public T GetOutput<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int index, out IDxcBlobWide outputType, out IDxcBlobWide outputName) where T : IDxcBlob
     {
         GetOutput(index, typeof(T).GUID, out IntPtr nativePtr, out outputType, out outputName).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result GetOutput<T>(int index, out T? @object, out IDxcBlobWide outputType, out IDxcBlobWide outputName) where T : IDxcBlob
+    public Result GetOutput<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(int index, out T? @object, out IDxcBlobWide outputType, out IDxcBlobWide outputName) where T : IDxcBlob
     {
         Result result = GetOutput(index, typeof(T).GUID, out IntPtr nativePtr, out outputType, out outputName);
         if (result.Failure)

--- a/src/Vortice.Dxc/IDxcResult.cs
+++ b/src/Vortice.Dxc/IDxcResult.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.Dxc;
@@ -60,19 +60,19 @@ public partial class IDxcResult
     }
 
 
-    public T GetOutput<T>(DxcOutKind kind) where T : ComObject
+    public T GetOutput<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(DxcOutKind kind) where T : ComObject
     {
         GetOutput(kind, typeof(T).GUID, out IntPtr nativePtr, out _).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public unsafe T GetOutput<T>(DxcOutKind kind, out IDxcBlobWide? outputName) where T : ComObject
+    public unsafe T GetOutput<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(DxcOutKind kind, out IDxcBlobWide? outputName) where T : ComObject
     {
         GetOutput(kind, typeof(T).GUID, out IntPtr nativePtr, out outputName).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result GetOutput<T>(DxcOutKind kind, out T? @object) where T : ComObject
+    public Result GetOutput<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(DxcOutKind kind, out T? @object) where T : ComObject
     {
         Result result = GetOutput(kind, typeof(T).GUID, out IntPtr nativePtr, out _);
         if (result.Failure)
@@ -85,7 +85,7 @@ public partial class IDxcResult
         return result;
     }
 
-    public unsafe Result GetOutput<T>(DxcOutKind kind, out T? @object, out IDxcBlobWide? outputName) where T : ComObject
+    public unsafe Result GetOutput<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(DxcOutKind kind, out T? @object, out IDxcBlobWide? outputName) where T : ComObject
     {
         Result result = GetOutput(kind, typeof(T).GUID, out IntPtr nativePtr, out outputName);
         if (result.Failure)

--- a/src/Vortice.Dxc/IDxcUtils.cs
+++ b/src/Vortice.Dxc/IDxcUtils.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace Vortice.Dxc;
@@ -11,7 +11,7 @@ public partial class IDxcUtils
         return handler;
     }
 
-    public Result CreateReflection<T>(IDxcBlob blob, out T? reflection) where T : ComObject
+    public Result CreateReflection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IDxcBlob blob, out T? reflection) where T : ComObject
     {
         DxcBuffer reflectionData = new DxcBuffer
         {
@@ -31,7 +31,7 @@ public partial class IDxcUtils
         return result;
     }
 
-    public T CreateReflection<T>(IDxcBlob blob) where T : ComObject
+    public T CreateReflection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IDxcBlob blob) where T : ComObject
     {
         DxcBuffer reflectionData = new DxcBuffer
         {

--- a/src/Vortice.Dxc/Vortice.Dxc.csproj
+++ b/src/Vortice.Dxc/Vortice.Dxc.csproj
@@ -9,9 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis"/>
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="SharpGen.Runtime" />
-    
+
     <SharpGenMapping Include="Mappings.xml" />
     <PackageReference Include="SharpGen.Runtime.COM" />
   </ItemGroup>

--- a/src/Vortice.MediaFoundation/IMFActivate.cs
+++ b/src/Vortice.MediaFoundation/IMFActivate.cs
@@ -7,13 +7,13 @@ namespace Vortice.MediaFoundation;
 
 public unsafe partial class IMFActivate
 {
-    public T ActivateObject<T>() where T : ComObject
+    public T ActivateObject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>() where T : ComObject
     {
         ActivateObject(typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr);
     }
 
-    public Result ActivateObject<T>(out T? @object) where T : ComObject
+    public Result ActivateObject<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? @object) where T : ComObject
     {
         Result result = ActivateObject(typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.MediaFoundation/IMFAttributes.cs
+++ b/src/Vortice.MediaFoundation/IMFAttributes.cs
@@ -204,12 +204,12 @@ public unsafe partial class IMFAttributes
         return value;
     }
 
-    /// <summary>	
+    /// <summary>
     /// Gets an item value
-    /// </summary>	
-    /// <param name="guidKey">GUID of the key.</param>	
-    /// <returns>The value associated to this key.</returns>	
-    /// <unmanaged-short>IMFAttributes::GetItem</unmanaged-short>	
+    /// </summary>
+    /// <param name="guidKey">GUID of the key.</param>
+    /// <returns>The value associated to this key.</returns>
+    /// <unmanaged-short>IMFAttributes::GetItem</unmanaged-short>
     public object Get(Guid guidKey)
     {
         AttributeType itemType = GetItemType(guidKey);
@@ -235,15 +235,15 @@ public unsafe partial class IMFAttributes
         throw new ArgumentException("The type of the value is not supported");
     }
 
-    /// <summary>	
-    /// <p><strong>Applies to: </strong>desktop apps | Metro style apps</p><p> </p><p>Retrieves an attribute at the specified index.</p>	
-    /// </summary>	
-    /// <param name="index"><dd> <p>Index of the attribute to retrieve. To get the number of attributes, call <strong><see cref="GetCount"/></strong>.</p> </dd></param>	
-    /// <param name="guidKey"><dd> <p>Receives the <see cref="Guid"/> that identifies this attribute.</p> </dd></param>	
-    /// <returns>The value associated to this index</returns>	
-    /// <remarks>	
-    /// <p>To enumerate all of an object's attributes in a thread-safe way, do the following:</p><ol> <li> <p>Call <strong><see cref="LockStore"/></strong> to prevent another thread from adding or deleting attributes.</p> </li> <li> <p>Call <strong><see cref="GetCount"/></strong> to find the number of attributes.</p> </li> <li> <p>Call <strong>GetItemByIndex</strong> to get each attribute by index.</p> </li> <li> <p>Call <strong><see cref="UnlockStore"/></strong> to unlock the attribute store.</p> </li> </ol><p>This interface is available on the following platforms if the Windows Media Format 11 SDK redistributable components are installed:</p><ul> <li>Windows?XP with Service Pack?2 (SP2) and later.</li> <li>Windows?XP Media Center Edition?2005 with KB900325 (Windows?XP Media Center Edition?2005) and KB925766 (October 2006 Update Rollup for Windows?XP Media Center Edition) installed.</li> </ul>	
-    /// </remarks>	
+    /// <summary>
+    /// <p><strong>Applies to: </strong>desktop apps | Metro style apps</p><p> </p><p>Retrieves an attribute at the specified index.</p>
+    /// </summary>
+    /// <param name="index"><dd> <p>Index of the attribute to retrieve. To get the number of attributes, call <strong><see cref="GetCount"/></strong>.</p> </dd></param>
+    /// <param name="guidKey"><dd> <p>Receives the <see cref="Guid"/> that identifies this attribute.</p> </dd></param>
+    /// <returns>The value associated to this index</returns>
+    /// <remarks>
+    /// <p>To enumerate all of an object's attributes in a thread-safe way, do the following:</p><ol> <li> <p>Call <strong><see cref="LockStore"/></strong> to prevent another thread from adding or deleting attributes.</p> </li> <li> <p>Call <strong><see cref="GetCount"/></strong> to find the number of attributes.</p> </li> <li> <p>Call <strong>GetItemByIndex</strong> to get each attribute by index.</p> </li> <li> <p>Call <strong><see cref="UnlockStore"/></strong> to unlock the attribute store.</p> </li> </ol><p>This interface is available on the following platforms if the Windows Media Format 11 SDK redistributable components are installed:</p><ul> <li>Windows?XP with Service Pack?2 (SP2) and later.</li> <li>Windows?XP Media Center Edition?2005 with KB900325 (Windows?XP Media Center Edition?2005) and KB925766 (October 2006 Update Rollup for Windows?XP Media Center Edition) installed.</li> </ul>
+    /// </remarks>
     public object GetByIndex(uint index, out Guid guidKey)
     {
         guidKey = GetItemByIndex(index, IntPtr.Zero);
@@ -252,12 +252,12 @@ public unsafe partial class IMFAttributes
 
     // TODO: Get/Set add typed methods like Get
 
-    /// <summary>	
+    /// <summary>
     /// Gets an item value
-    /// </summary>	
-    /// <param name="guidKey">GUID of the key.</param>	
-    /// <returns>The value associated to this key.</returns>	
-    public unsafe T Get<T>(Guid guidKey)
+    /// </summary>
+    /// <param name="guidKey">GUID of the key.</param>
+    /// <returns>The value associated to this key.</returns>
+    public unsafe T Get<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Guid guidKey)
     {
             // Perform conversions to supported types
             // int
@@ -367,15 +367,15 @@ public unsafe partial class IMFAttributes
         throw new ArgumentException("The type of the value is not supported");
     }
 
-    /// <summary>	
+    /// <summary>
     /// Gets an item value
-    /// </summary>	
-    /// <param name="guidKey">GUID of the key.</param>	
-    /// <returns>The value associated to this key.</returns>	
-    /// <msdn-id>ms704598</msdn-id>	
-    /// <unmanaged>HRESULT IMFAttributes::GetItem([In] const GUID&amp; guidKey,[In] void* pValue)</unmanaged>	
-    /// <unmanaged-short>IMFAttributes::GetItem</unmanaged-short>	
-    public T Get<T>(MediaAttributeKey<T> guidKey)
+    /// </summary>
+    /// <param name="guidKey">GUID of the key.</param>
+    /// <returns>The value associated to this key.</returns>
+    /// <msdn-id>ms704598</msdn-id>
+    /// <unmanaged>HRESULT IMFAttributes::GetItem([In] const GUID&amp; guidKey,[In] void* pValue)</unmanaged>
+    /// <unmanaged-short>IMFAttributes::GetItem</unmanaged-short>
+    public T Get<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(MediaAttributeKey<T> guidKey)
     {
         return Get<T>(guidKey.Guid);
     }
@@ -407,18 +407,18 @@ public unsafe partial class IMFAttributes
         SetUInt32(guidKey, value);
     }
 
-    /// <summary>	
-    /// <p><strong>Applies to: </strong>desktop apps | Metro style apps</p><p> Adds an attribute value with a specified key. </p>	
-    /// </summary>	
-    /// <param name="guidKey"><dd> <p> A <see cref="System.Guid"/> that identifies the value to set. If this key already exists, the method overwrites the old value. </p> </dd></param>	
-    /// <param name="value"><dd> <p> A <strong><see cref="Variant"/></strong> that contains the attribute value. The method copies the value. The <strong><see cref="Variant"/></strong> type must be one of the types listed in the <strong><see cref="AttributeType"/></strong> enumeration. </p> </dd></param>	
-    /// <returns><p> The method returns an <strong><see cref="Result"/></strong>. Possible values include, but are not limited to, those in the following table. </p><table> <tr><th>Return code</th><th>Description</th></tr> <tr><td> <dl> <dt><strong><see cref="Result.Ok"/></strong></dt> </dl> </td><td> <p> The method succeeded. </p> </td></tr> <tr><td> <dl> <dt><strong>E_OUTOFMEMORY</strong></dt> </dl> </td><td> <p> Insufficient memory. </p> </td></tr> <tr><td> <dl> <dt><strong>MF_E_INVALIDTYPE</strong></dt> </dl> </td><td> <p> Invalid attribute type. </p> </td></tr> </table><p>?</p></returns>	
-    /// <remarks>	
-    /// <p> This method checks whether the <strong><see cref="Variant"/></strong> type is one of the attribute types defined in <strong><see cref="AttributeType"/></strong>, and fails if an unsupported type is used. However, this method does not check whether the <strong><see cref="Variant"/></strong> is the correct type for the specified attribute <see cref="System.Guid"/>. (There is no programmatic way to associate attribute GUIDs with property types.) For a list of Media Foundation attributes and their data types, see Media Foundation Attributes. </p><p>This interface is available on the following platforms if the Windows Media Format 11 SDK redistributable components are installed:</p><ul> <li>Windows?XP with Service Pack?2 (SP2) and later.</li> <li>Windows?XP Media Center Edition?2005 with KB900325 (Windows?XP Media Center Edition?2005) and KB925766 (October 2006 Update Rollup for Windows?XP Media Center Edition) installed.</li> </ul>	
-    /// </remarks>	
-    /// <msdn-id>bb970346</msdn-id>	
-    /// <unmanaged>HRESULT IMFAttributes::SetItem([In] const GUID&amp; guidKey,[In] const PROPVARIANT&amp; Value)</unmanaged>	
-    /// <unmanaged-short>IMFAttributes::SetItem</unmanaged-short>	
+    /// <summary>
+    /// <p><strong>Applies to: </strong>desktop apps | Metro style apps</p><p> Adds an attribute value with a specified key. </p>
+    /// </summary>
+    /// <param name="guidKey"><dd> <p> A <see cref="System.Guid"/> that identifies the value to set. If this key already exists, the method overwrites the old value. </p> </dd></param>
+    /// <param name="value"><dd> <p> A <strong><see cref="Variant"/></strong> that contains the attribute value. The method copies the value. The <strong><see cref="Variant"/></strong> type must be one of the types listed in the <strong><see cref="AttributeType"/></strong> enumeration. </p> </dd></param>
+    /// <returns><p> The method returns an <strong><see cref="Result"/></strong>. Possible values include, but are not limited to, those in the following table. </p><table> <tr><th>Return code</th><th>Description</th></tr> <tr><td> <dl> <dt><strong><see cref="Result.Ok"/></strong></dt> </dl> </td><td> <p> The method succeeded. </p> </td></tr> <tr><td> <dl> <dt><strong>E_OUTOFMEMORY</strong></dt> </dl> </td><td> <p> Insufficient memory. </p> </td></tr> <tr><td> <dl> <dt><strong>MF_E_INVALIDTYPE</strong></dt> </dl> </td><td> <p> Invalid attribute type. </p> </td></tr> </table><p>?</p></returns>
+    /// <remarks>
+    /// <p> This method checks whether the <strong><see cref="Variant"/></strong> type is one of the attribute types defined in <strong><see cref="AttributeType"/></strong>, and fails if an unsupported type is used. However, this method does not check whether the <strong><see cref="Variant"/></strong> is the correct type for the specified attribute <see cref="System.Guid"/>. (There is no programmatic way to associate attribute GUIDs with property types.) For a list of Media Foundation attributes and their data types, see Media Foundation Attributes. </p><p>This interface is available on the following platforms if the Windows Media Format 11 SDK redistributable components are installed:</p><ul> <li>Windows?XP with Service Pack?2 (SP2) and later.</li> <li>Windows?XP Media Center Edition?2005 with KB900325 (Windows?XP Media Center Edition?2005) and KB925766 (October 2006 Update Rollup for Windows?XP Media Center Edition) installed.</li> </ul>
+    /// </remarks>
+    /// <msdn-id>bb970346</msdn-id>
+    /// <unmanaged>HRESULT IMFAttributes::SetItem([In] const GUID&amp; guidKey,[In] const PROPVARIANT&amp; Value)</unmanaged>
+    /// <unmanaged-short>IMFAttributes::SetItem</unmanaged-short>
     public void Set<T>(Guid guidKey, T value)
     {
         // Perform conversions to supported types
@@ -512,18 +512,18 @@ public unsafe partial class IMFAttributes
         throw new ArgumentException("The type of the value is not supported");
     }
 
-    /// <summary>	
-    /// <p><strong>Applies to: </strong>desktop apps | Metro style apps</p><p> Adds an attribute value with a specified key. </p>	
-    /// </summary>	
-    /// <param name="guidKey"><dd> <p> A <see cref="System.Guid"/> that identifies the value to set. If this key already exists, the method overwrites the old value. </p> </dd></param>	
-    /// <param name="value"><dd> <p> A <strong><see cref="Variant"/></strong> that contains the attribute value. The method copies the value. The <strong><see cref="Variant"/></strong> type must be one of the types listed in the <strong><see cref="AttributeType"/></strong> enumeration. </p> </dd></param>	
-    /// <returns><p> The method returns an <strong><see cref="Result"/></strong>. Possible values include, but are not limited to, those in the following table. </p><table> <tr><th>Return code</th><th>Description</th></tr> <tr><td> <dl> <dt><strong><see cref="Result.Ok"/></strong></dt> </dl> </td><td> <p> The method succeeded. </p> </td></tr> <tr><td> <dl> <dt><strong>E_OUTOFMEMORY</strong></dt> </dl> </td><td> <p> Insufficient memory. </p> </td></tr> <tr><td> <dl> <dt><strong>MF_E_INVALIDTYPE</strong></dt> </dl> </td><td> <p> Invalid attribute type. </p> </td></tr> </table><p>?</p></returns>	
-    /// <remarks>	
-    /// <p> This method checks whether the <strong><see cref="Variant"/></strong> type is one of the attribute types defined in <strong><see cref="AttributeType"/></strong>, and fails if an unsupported type is used. However, this method does not check whether the <strong><see cref="Variant"/></strong> is the correct type for the specified attribute <see cref="System.Guid"/>. (There is no programmatic way to associate attribute GUIDs with property types.) For a list of Media Foundation attributes and their data types, see Media Foundation Attributes. </p><p>This interface is available on the following platforms if the Windows Media Format 11 SDK redistributable components are installed:</p><ul> <li>Windows?XP with Service Pack?2 (SP2) and later.</li> <li>Windows?XP Media Center Edition?2005 with KB900325 (Windows?XP Media Center Edition?2005) and KB925766 (October 2006 Update Rollup for Windows?XP Media Center Edition) installed.</li> </ul>	
-    /// </remarks>	
-    /// <msdn-id>bb970346</msdn-id>	
-    /// <unmanaged>HRESULT IMFAttributes::SetItem([In] const GUID&amp; guidKey,[In] const PROPVARIANT&amp; Value)</unmanaged>	
-    /// <unmanaged-short>IMFAttributes::SetItem</unmanaged-short>	
+    /// <summary>
+    /// <p><strong>Applies to: </strong>desktop apps | Metro style apps</p><p> Adds an attribute value with a specified key. </p>
+    /// </summary>
+    /// <param name="guidKey"><dd> <p> A <see cref="System.Guid"/> that identifies the value to set. If this key already exists, the method overwrites the old value. </p> </dd></param>
+    /// <param name="value"><dd> <p> A <strong><see cref="Variant"/></strong> that contains the attribute value. The method copies the value. The <strong><see cref="Variant"/></strong> type must be one of the types listed in the <strong><see cref="AttributeType"/></strong> enumeration. </p> </dd></param>
+    /// <returns><p> The method returns an <strong><see cref="Result"/></strong>. Possible values include, but are not limited to, those in the following table. </p><table> <tr><th>Return code</th><th>Description</th></tr> <tr><td> <dl> <dt><strong><see cref="Result.Ok"/></strong></dt> </dl> </td><td> <p> The method succeeded. </p> </td></tr> <tr><td> <dl> <dt><strong>E_OUTOFMEMORY</strong></dt> </dl> </td><td> <p> Insufficient memory. </p> </td></tr> <tr><td> <dl> <dt><strong>MF_E_INVALIDTYPE</strong></dt> </dl> </td><td> <p> Invalid attribute type. </p> </td></tr> </table><p>?</p></returns>
+    /// <remarks>
+    /// <p> This method checks whether the <strong><see cref="Variant"/></strong> type is one of the attribute types defined in <strong><see cref="AttributeType"/></strong>, and fails if an unsupported type is used. However, this method does not check whether the <strong><see cref="Variant"/></strong> is the correct type for the specified attribute <see cref="System.Guid"/>. (There is no programmatic way to associate attribute GUIDs with property types.) For a list of Media Foundation attributes and their data types, see Media Foundation Attributes. </p><p>This interface is available on the following platforms if the Windows Media Format 11 SDK redistributable components are installed:</p><ul> <li>Windows?XP with Service Pack?2 (SP2) and later.</li> <li>Windows?XP Media Center Edition?2005 with KB900325 (Windows?XP Media Center Edition?2005) and KB925766 (October 2006 Update Rollup for Windows?XP Media Center Edition) installed.</li> </ul>
+    /// </remarks>
+    /// <msdn-id>bb970346</msdn-id>
+    /// <unmanaged>HRESULT IMFAttributes::SetItem([In] const GUID&amp; guidKey,[In] const PROPVARIANT&amp; Value)</unmanaged>
+    /// <unmanaged-short>IMFAttributes::SetItem</unmanaged-short>
     public void Set<T>(MediaAttributeKey<T> guidKey, T value)
     {
         Set(guidKey.Guid, value);

--- a/src/Vortice.MediaFoundation/IMFDXGIDeviceManager.cs
+++ b/src/Vortice.MediaFoundation/IMFDXGIDeviceManager.cs
@@ -11,13 +11,13 @@ public partial class IMFDXGIDeviceManager
 
     public Result ResetDevice(ComObject direct3D11Device) => ResetDevice(direct3D11Device, ResetToken);
 
-    public T LockDevice<T>(IntPtr deviceHandle, bool block) where T : ComObject
+    public T LockDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr deviceHandle, bool block) where T : ComObject
     {
         LockDevice(deviceHandle, typeof(T).GUID, out IntPtr unkDevice, block).CheckError();
         return MarshallingHelpers.FromPointer<T>(unkDevice)!;
     }
 
-    public Result LockDevice<T>(IntPtr deviceHandle, bool block, out T? device) where T : ComObject
+    public Result LockDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr deviceHandle, bool block, out T? device) where T : ComObject
     {
         Result result = LockDevice(deviceHandle, typeof(T).GUID, out IntPtr unkDevice, block);
         if (result.Failure)
@@ -33,13 +33,13 @@ public partial class IMFDXGIDeviceManager
 
     public Result UnlockDevice(IntPtr hDevice) => UnlockDevice(hDevice, false);
 
-    public T GetVideoService<T>(IntPtr deviceHandle) where T : ComObject
+    public T GetVideoService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr deviceHandle) where T : ComObject
     {
         GetVideoService(deviceHandle, typeof(T).GUID, out IntPtr nativePtr).CheckError();
         return MarshallingHelpers.FromPointer<T>(nativePtr)!;
     }
 
-    public Result GetVideoService<T>(IntPtr deviceHandle, out T? service) where T : ComObject
+    public Result GetVideoService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IntPtr deviceHandle, out T? service) where T : ComObject
     {
         Result result = GetVideoService(deviceHandle, typeof(T).GUID, out IntPtr nativePtr);
         if (result.Failure)

--- a/src/Vortice.MediaFoundation/Vortice.MediaFoundation.csproj
+++ b/src/Vortice.MediaFoundation/Vortice.MediaFoundation.csproj
@@ -8,8 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
+
     <SharpGenMapping Include="Mappings.xml" />
     <ProjectReference Include="..\Vortice.DirectX\Vortice.DirectX.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Vortice.WinUI/Composition/ICompositionDrawingSurfaceInterop.cs
+++ b/src/Vortice.WinUI/Composition/ICompositionDrawingSurfaceInterop.cs
@@ -14,7 +14,7 @@ public unsafe partial class ICompositionDrawingSurfaceInterop : ComObject
 
     public static explicit operator ICompositionDrawingSurfaceInterop?(IntPtr nativePtr) => nativePtr == IntPtr.Zero ? null : new(nativePtr);
 
-    public Result BeginDraw<T>(in Rectangle updateRect, out T? updateObject, out Point offset) where T : ComObject
+    public Result BeginDraw<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in Rectangle updateRect, out T? updateObject, out Point offset) where T : ComObject
     {
         RawRect updateRectRaw = updateRect;
         IntPtr updateObjectPtr = IntPtr.Zero;
@@ -29,7 +29,7 @@ public unsafe partial class ICompositionDrawingSurfaceInterop : ComObject
         }
     }
 
-    public T BeginDraw<T>(in Rectangle updateRect, out Point offset) where T : ComObject
+    public T BeginDraw<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in Rectangle updateRect, out Point offset) where T : ComObject
     {
         RawRect updateRectRaw = updateRect;
         IntPtr updateObjectPtr = IntPtr.Zero;

--- a/src/Vortice.WinUI/Composition/ICompositionGraphicsDeviceInterop.cs
+++ b/src/Vortice.WinUI/Composition/ICompositionGraphicsDeviceInterop.cs
@@ -12,7 +12,7 @@ public partial class ICompositionGraphicsDeviceInterop : ComObject
 
     public static explicit operator ICompositionGraphicsDeviceInterop?(IntPtr nativePtr) => nativePtr == IntPtr.Zero ? null : new(nativePtr);
 
-    public unsafe Result GetRenderingDevice<T>(out T? device) where T : ComObject
+    public unsafe Result GetRenderingDevice<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(out T? device) where T : ComObject
     {
         IntPtr devicePtr = default;
         Result result = (Result)((delegate* unmanaged<IntPtr, void*, int>)this[3])(NativePointer, &devicePtr);
@@ -27,7 +27,7 @@ public partial class ICompositionGraphicsDeviceInterop : ComObject
         return result;
     }
 
-    public unsafe Result SetRenderingDevice(IUnknown device) 
+    public unsafe Result SetRenderingDevice(IUnknown device)
     {
         IntPtr devicePtr = MarshallingHelpers.ToCallbackPtr<IUnknown>(device);
         return (Result)((delegate* unmanaged<IntPtr, IntPtr, int>)this[4])(NativePointer, devicePtr);

--- a/src/Vortice.WinUI/ISurfaceImageSourceNativeWithD2D.cs
+++ b/src/Vortice.WinUI/ISurfaceImageSourceNativeWithD2D.cs
@@ -31,7 +31,7 @@ public unsafe class ISurfaceImageSourceNativeWithD2D : ComObject
         return result;
     }
 
-    public Result BeginDraw<T>(in Rectangle updateRect, out T? updateObject, out Point offset) where T : ComObject
+    public Result BeginDraw<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in Rectangle updateRect, out T? updateObject, out Point offset) where T : ComObject
     {
         RawRect updateRectRaw = updateRect;
         Result result = BeginDraw(updateRectRaw, typeof(T).GUID, out IntPtr updateObjectPtr, out offset);
@@ -45,7 +45,7 @@ public unsafe class ISurfaceImageSourceNativeWithD2D : ComObject
         return result;
     }
 
-    public T BeginDraw<T>(in Rectangle updateRect, out Point offset) where T : ComObject
+    public T BeginDraw<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(in Rectangle updateRect, out Point offset) where T : ComObject
     {
         RawRect updateRectRaw = updateRect;
         BeginDraw(updateRectRaw, typeof(T).GUID, out IntPtr updateObjectPtr, out offset).CheckError();

--- a/src/Vortice.WinUI/Vortice.WinUI.csproj
+++ b/src/Vortice.WinUI/Vortice.WinUI.csproj
@@ -10,9 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="SharpGen.Runtime" />
-    
+
     <SharpGenMapping Include="Mappings.xml" />
     <ProjectReference Include="..\Vortice.DXGI\Vortice.DXGI.csproj" />
   </ItemGroup>
@@ -20,5 +21,5 @@
   <ItemGroup Condition="$(TargetFramework.Contains('-windows10'))">
     <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
This adds `DynamicallyAccessedMembers` annotations to most required areas, and fixes the vast majority of warnings caused by their absence. This should improve compatibility with more aggressive trimming modes in .NET 8.

In my case specifically, I'm seeing constructors trimmed out despite the annotations being present on the underlying Marshal helpers from SharpGenTools. With these annotations in place, trimming works successfully.

Please let me know if any changes need to be made; I'd like to see this merged in sooner rather than later. Thank you!