### PR TITLE
Adding of the bindings for IDirect3DDeviceManager9 in namespace  "Vortice.DirectXVA2api".

### DIFF
--- a/src/Vortice.Direct3D9/Mappings.xml
+++ b/src/Vortice.Direct3D9/Mappings.xml
@@ -33,6 +33,7 @@
     </post>
   </include>
   <include file="d3d9on12.h" namespace="Vortice.Direct3D9on12" attach="true"/>
+  <include file="dxva2api.h" namespace="Vortice.DirectXVA2api" attach="true"/>
 
   <extension>
     <define struct="Vortice.Direct3D9.Rect" sizeof="16" />
@@ -1504,5 +1505,31 @@
     <map param="Direct3DCreate9On12Ex::pOverrideList" type="void" keep-pointers="true"/>
 
     <remove function="D3DPERF.*" />
+
+    <!-- IDirect3DDeviceManager9  -->
+    <remove function="DXVA2CreateDirect3DDeviceManager9" />
+    <remove function="DXVA2CreateVideoService" />
+    <remove struct="DXVA2_VideoProcessBltParams" />
+    <remove interface ="IDirectXVideoAccelerationService" />
+    <remove interface ="IDirectXVideoDecoder" />
+    <remove interface ="IDirectXVideoDecoderService" />
+    <remove interface ="IDirectXVideoMemoryConfiguration" />
+    <remove interface ="IDirectXVideoProcessor" />
+    <remove interface ="IDirectXVideoProcessorService" />
+
+    <map method="IDirect3DDeviceManager9::CloseDeviceHandle" visibility="internal" />
+    <!-- HRESULT CloseDeviceHandle([in] HANDLE hDevice); -->
+    <map method="IDirect3DDeviceManager9::GetVideoService" visibility="internal" />
+    <!-- HRESULT GetVideoService([in] HANDLE hDevice,[in] REFIID riid, [out] void **ppService); -->
+    <map method="IDirect3DDeviceManager9::LockDevice" visibility="internal" />
+    <!-- HRESULT LockDevice([in] HANDLE hDevice, [out] IDirect3DDevice9 **ppDevice, [in]  BOOL fBlock);-->
+    <map method="IDirect3DDeviceManager9::OpenDeviceHandle" visibility="internal" />
+    <!-- HRESULT OpenDeviceHandle([out] HANDLE *phDevice);-->
+    <map method="IDirect3DDeviceManager9::ResetDevice" visibility="internal" />
+    <!-- HRESULT ResetDevice([in] IDirect3DDevice9 *pDevice,[in] UINT resetToken);-->
+    <map method="IDirect3DDeviceManager9::TestDevice" visibility="internal" />
+    <!-- HRESULT TestDevice([in] HANDLE hDevice);-->
+    <map method="IDirect3DDeviceManager9::UnlockDevice" visibility="internal" />
+    <!-- HRESULT UnlockDevice([in] HANDLE hDevice,[in] BOOL fSaveState);-->
   </mapping>
 </config>

--- a/src/Vortice.MediaFoundation/MediaFactory.cs
+++ b/src/Vortice.MediaFoundation/MediaFactory.cs
@@ -125,6 +125,14 @@ public unsafe partial class MediaFactory
         return new(pSourceActivate, count);
     }
 
+    public static unsafe IMFActivateCollection MFTEnumEx(Guid guidCategory, uint flags, RegisterTypeInfo? inputType, RegisterTypeInfo? outputType)
+    {
+        nint pppMFTActivate;
+        uint pnumMFTActivate;
+        MFTEnumEx(guidCategory, flags, inputType, outputType, out pppMFTActivate, out pnumMFTActivate);
+        return new(pppMFTActivate, pnumMFTActivate);
+    }
+
     public static unsafe IStream MFCreateStreamOnMFByteStream(IMFByteStream byteStream)
     {
         MFCreateStreamOnMFByteStream(byteStream, out IStream stream).CheckError();

--- a/src/Vortice.WinUI/Vortice.WinUI.csproj
+++ b/src/Vortice.WinUI/Vortice.WinUI.csproj
@@ -3,7 +3,7 @@
   <Sdk Name="SharpGenTools.Sdk" Version="$(SharpGenVersion)" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net8.0-windows10.0.22621;net8.0-windows10.0.22621</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net8.0-windows10.0.22621</TargetFrameworks>
     <Description>WinUI DirectX bindings</Description>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <EnableMsixTooling>true</EnableMsixTooling>


### PR DESCRIPTION
More details: As the documentation of the IDirect3DDeviceManager9 class is already in the Vortice.Direct3D9 project, I've added the dxva2api header file here. Taking example of "d3d9on12" file header has already been added in this project but in a dedicated namespace, I reproduce the same architecture by putting the class IDirect3DDeviceManager9 in the new namespace  "Vortice.DirectXVA2api".
Following the SharpGen builds errors, I've "removed"  all the functions, structs and interfaces not needed for now.