### PR TITLE
Support vkd3d-native implementation of `ID3D12DescriptorHeap::GetCPUDescriptorHandleForHeapStart` on Linux

### DIFF
--- a/src/Vortice.Direct3D12/ID3D12DescriptorHeap.cs
+++ b/src/Vortice.Direct3D12/ID3D12DescriptorHeap.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
+using SharpGen.Runtime;
 using Vortice.Direct3D;
 
 namespace Vortice.Direct3D12;
@@ -15,6 +16,14 @@ public unsafe partial class ID3D12DescriptorHeap
     /// <unmanaged-short>ID3D12DescriptorHeap::GetCPUDescriptorHandleForHeapStart</unmanaged-short>
     public CpuDescriptorHandle GetCPUDescriptorHandleForHeapStart()
     {
+        // Implement vkd3d-native behavior on Linux
+        // See https://github.com/HansKristian-Work/vkd3d-proton/blob/fc2b6f419008ffc5fbdee8564c70cded29abf7bb/libs/vkd3d/resource.c#L7447
+        if (PlatformDetection.IsItaniumSystemV)
+        {
+            CpuDescriptorHandle result;
+            return *((delegate* unmanaged[Stdcall]<nint, CpuDescriptorHandle*, CpuDescriptorHandle*>)this[GetCPUDescriptorHandleForHeapStart__vtbl_index])(NativePointer, &result);
+        }
+        
         return ((delegate* unmanaged[MemberFunction]<nint, CpuDescriptorHandle>)this[GetCPUDescriptorHandleForHeapStart__vtbl_index])(NativePointer);
     }
 
@@ -23,6 +32,14 @@ public unsafe partial class ID3D12DescriptorHeap
     /// <unmanaged-short>ID3D12DescriptorHeap::GetGPUDescriptorHandleForHeapStart</unmanaged-short>
     public GpuDescriptorHandle GetGPUDescriptorHandleForHeapStart()
     {
+        // Implement vkd3d-native behavior on Linux
+        // See https://github.com/HansKristian-Work/vkd3d-proton/blob/fc2b6f419008ffc5fbdee8564c70cded29abf7bb/libs/vkd3d/resource.c#L7459
+        if (PlatformDetection.IsItaniumSystemV)
+        {
+            GpuDescriptorHandle result;
+            return *((delegate* unmanaged[Stdcall]<nint, GpuDescriptorHandle*, GpuDescriptorHandle*>)this[GetGPUDescriptorHandleForHeapStart__vtbl_index])(NativePointer, &result);
+        }
+        
         return ((delegate* unmanaged[MemberFunction]<nint, GpuDescriptorHandle>)this[GetGPUDescriptorHandleForHeapStart__vtbl_index])(NativePointer);
     }
 }


### PR DESCRIPTION
On Linux, vkd3d-native expects a pointer to a `D3D12_CPU_DESCRIPTOR_HANDLE` or `D3D12_GPU_DESCRIPTOR_HANDLE` to be passed as the second argument when calling `ID3D12DescriptorHeap::GetCPUDescriptorHandleForHeapStart` or `ID3D12DescriptorHeap::GetGPUDescriptorHandleForHeapStart`