### PR TITLE
Add Sucrose Wallpaper Engine link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Also, you need to install **Visual Studio 2022** with the following components:
 - [Veldrid](https://github.com/mellinoe/veldrid)
 - [MiniEngine](https://github.com/roy-t/MiniEngine3) 
 - [SharpAudio](https://github.com/feliwir/SharpAudio)
+- [Sucrose Wallpaper Engine](https://github.com/Taiizor/Sucrose)
 
 ## Samples
 - [Collection of samples](https://github.com/amerkoleci/Vortice.Windows/tree/HEAD/src/samples)


### PR DESCRIPTION
I recently discovered this project, and honestly, just a few days ago I was trying to move away from using [LibreHardwareMonitor](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor) because of ARM64 issues. The only real problem I had was determining which GPU corresponded to which LUID when using [Performance Counters](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.performancecounter) for GPU data. Thanks to this library, I’ve realized I can now handle that easily.

Actually, if the project were no longer being actively developed, I was planning to use my own native class instead. Anyway, I should have it integrated into my project within a few hours—but I already wanted to add my project to the related section in the meantime (: