### PR TITLE
[ENH] DirectML: Expose Dequantize operator

### DIFF
--- a/src/Vortice.DirectML/DequantizeOperatorDescription.cs
+++ b/src/Vortice.DirectML/DequantizeOperatorDescription.cs
@@ -1,0 +1,89 @@
+// Copyright © Aaron Sun, Amer Koleci, and Contributors.
+// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
+
+namespace Vortice.DirectML;
+
+public partial struct DequantizeOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
+{
+    /// <summary>
+    /// Gets the type of operator description.
+    /// </summary>
+    public OperatorType OperatorType => OperatorType.Dequantize;
+
+    /// <include file="Documentation.xml" path="/comments/comment[@id='DML_DEQUANTIZE_OPERATOR_DESC::InputTensor']/*" />
+    public TensorDescription InputTensor { get; set; }
+
+    /// <include file="Documentation.xml" path="/comments/comment[@id='DML_DEQUANTIZE_OPERATOR_DESC::QuantizationType']/*" />
+    public QuantizationType QuantizationType { get; set; }
+
+    /// <include file="Documentation.xml" path="/comments/comment[@id='DML_DEQUANTIZE_OPERATOR_DESC::QuantizationTensors']/*" />
+    public TensorDescription[] QuantizationTensors { get; set; }
+
+    /// <include file="Documentation.xml" path="/comments/comment[@id='DML_DEQUANTIZE_OPERATOR_DESC::OutputTensor']/*" />
+    public TensorDescription OutputTensor { get; set; }
+
+    /// <inheritdoc></inheritdoc>/>
+    public override string ToString() => $"Dequantize: QuantizationType={QuantizationType}";
+
+    #region Marshal
+    [StructLayout(LayoutKind.Sequential, Pack = 0)]
+    internal struct __Native
+    {
+        public IntPtr InputTensor;
+        public QuantizationType QuantizationType;
+        public uint QuantizationTensorCount;
+        public IntPtr QuantizationTensors;
+        public IntPtr OutputTensor;
+    }
+
+    unsafe IntPtr IOperatorDescriptionMarshal.__MarshalAlloc()
+    {
+        __Native* @ref = UnsafeUtilities.Alloc<__Native>();
+
+        @ref->InputTensor = InputTensor.__MarshalAlloc();
+        @ref->QuantizationType = QuantizationType;
+        @ref->QuantizationTensorCount = (uint)QuantizationTensors.Length;
+
+        @ref->QuantizationTensors = IntPtr.Zero;
+        if (QuantizationTensors.Length != 0)
+        {
+            var quantizationTensorsPtr = UnsafeUtilities.Alloc<TensorDescription.__Native>(QuantizationTensors.Length);
+            for (int i = 0; i < QuantizationTensors.Length; i++)
+            {
+                QuantizationTensors[i].__MarshalTo(ref quantizationTensorsPtr[i]);
+            }
+            @ref->QuantizationTensors = new(quantizationTensorsPtr);
+        }
+
+        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+
+        return new(@ref);
+    }
+
+    unsafe void IOperatorDescriptionMarshal.__MarshalFree(ref IntPtr pDesc)
+    {
+        var @ref = (__Native*)pDesc;
+
+        InputTensor.__MarshalFree(ref @ref->InputTensor);
+
+        if (@ref->QuantizationTensors != IntPtr.Zero)
+        {
+            var quantizationTensorsPtr = (TensorDescription.__Native*)@ref->QuantizationTensors;
+            for (int i = 0; i < QuantizationTensors.Length; i++)
+            {
+                QuantizationTensors[i].__MarshalFree(ref quantizationTensorsPtr[i]);
+            }
+            UnsafeUtilities.Free(@ref->QuantizationTensors);
+        }
+
+        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+
+        UnsafeUtilities.Free(@ref);
+    }
+    #endregion
+
+    public static implicit operator OperatorDescription(DequantizeOperatorDescription description)
+    {
+        return new(description);
+    }
+}

--- a/src/Vortice.DirectML/Documentation.xml
+++ b/src/Vortice.DirectML/Documentation.xml
@@ -4524,6 +4524,9 @@ for (UINT i = 0; i &lt; DimensionCount; ++i) {
   <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_MULTIHEAD_ATTENTION">
     <summary>Indicates the operator described by the <a href="https://learn.microsoft.com/windows/ai/directml/api/ns-directml-dml_multihead_attention_operator_desc">DML_MULTIHEAD_ATTENTION_OPERATOR_DESC</a> structure.</summary>
   </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_DEQUANTIZE">
+    <summary>Indicates the operator described by the <a href="https://learn.microsoft.com/windows/ai/directml/api/ns-directml-dml_dequantize_operator_desc">DML_DEQUANTIZE_OPERATOR_DESC</a> structure.</summary>
+  </comment>
   <comment id="DML_ACTIVATION_GELU_OPERATOR_DESC">
     <summary>
       <para>Performs the gaussian error linear unit (GELU) activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>. <c>f(x) = 0.5 * x * (1.0 + erf(x / sqrt(2)))</c>. This is the exact form, not the tanh approximation. This operator was introduced in DML_FEATURE_LEVEL_5_1.</para>
@@ -4610,5 +4613,23 @@ for (UINT i = 0; i &lt; DimensionCount; ++i) {
   </comment>
   <comment id="DML_MULTIHEAD_ATTENTION_OPERATOR_DESC::MaskType">
     <summary>Describes the behavior of <i>MaskTensor</i>.</summary>
+  </comment>
+  <comment id="DML_DEQUANTIZE_OPERATOR_DESC">
+    <summary>
+      <para>Dequantizes <i>InputTensor</i> element by element using the quantization parameters in <i>QuantizationTensors</i>, placing the result into <i>OutputTensor</i>: <c>output = (input - zeroPoint) * scale</c>. Every dimension of a quantization tensor must evenly divide the corresponding dimension of the input, so one scale (and zero point) can cover a block of elements; a quantization tensor of all 1's is per-tensor quantization, one matching the input is per-element. This operator was introduced in DML_FEATURE_LEVEL_6_3.</para>
+      <para>Microsoft Docs: <see href="https://learn.microsoft.com/windows/ai/directml/api/ns-directml-dml_dequantize_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_DEQUANTIZE_OPERATOR_DESC::InputTensor">
+    <summary>The quantized input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_DEQUANTIZE_OPERATOR_DESC::QuantizationType">
+    <summary>Which quantization parameters <i>QuantizationTensors</i> carries: a scale, or a scale and a zero point.</summary>
+  </comment>
+  <comment id="DML_DEQUANTIZE_OPERATOR_DESC::QuantizationTensors">
+    <summary>The quantization parameters, in the order <i>QuantizationType</i> lists them: the scale tensor, then the zero-point tensor when there is one. The scale has the data type of <i>OutputTensor</i>; the zero point has the data type of <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_DEQUANTIZE_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to, with the same sizes as <i>InputTensor</i>.</summary>
   </comment>
 </comments>

--- a/src/Vortice.DirectML/Mappings.xml
+++ b/src/Vortice.DirectML/Mappings.xml
@@ -231,6 +231,9 @@
     <!-- DML_TARGET_VERSION >= 0x6100 -->
     <remove field="DML_MULTIHEAD_ATTENTION_OPERATOR_DESC::.*" />
 
+    <!-- DML_TARGET_VERSION >= 0x6300 -->
+    <remove field="DML_DEQUANTIZE_OPERATOR_DESC::.*" />
+
     <!-- GraphDescription -->
     <map struct="DML_GRAPH_DESC" marshal="true" />
     <remove field="DML_GRAPH_DESC::.*" />

--- a/tests/Vortice.DirectML.Tests/OperatorTests.cs
+++ b/tests/Vortice.DirectML.Tests/OperatorTests.cs
@@ -1,6 +1,7 @@
 // Copyright © Aaron Sun, Amer Koleci, and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
+using System.Runtime.InteropServices;
 using NUnit.Framework;
 using Vortice.Direct3D12;
 using Vortice.DXGI;
@@ -172,6 +173,40 @@ public class OperatorTests
         Assert.That(output, Is.EqualTo(expected).Within(1e-4f));
     }
 
+    [TestCase]
+    public void DequantizeTest()
+    {
+        RequireFeatureLevel(FeatureLevel.Level6_3);
+
+        // Two rows of eight int8 values, one scale per block of four.
+        BufferTensorDescription inputTensor = CreateTensor(TensorDataType.Int8, 1, 1, 2, 8);
+        BufferTensorDescription scaleTensor = CreateTensor(1, 1, 2, 2);
+        BufferTensorDescription outputTensor = CreateTensor(1, 1, 2, 8);
+
+        var description = new DequantizeOperatorDescription
+        {
+            InputTensor = inputTensor,
+            QuantizationType = QuantizationType.Scale,
+            QuantizationTensors = [scaleTensor],
+            OutputTensor = outputTensor,
+        };
+
+        sbyte[] input = [-128, -1, 0, 1, 2, 3, 4, 127, 10, 20, 30, 40, -10, -20, -30, -40];
+        float[] scales = [0.5f, 2.0f, 0.1f, 1.0f];
+
+        // The harness uploads floats; the int8 values ride along packed four to a float.
+        float[] packedInput = MemoryMarshal.Cast<sbyte, float>(input).ToArray();
+        float[] output = Dispatch(description, [(inputTensor, packedInput), (scaleTensor, scales)], outputTensor);
+
+        var expected = new float[input.Length];
+        for (int i = 0; i < input.Length; i++)
+        {
+            expected[i] = input[i] * scales[i / 4];
+        }
+
+        Assert.That(output, Is.EqualTo(expected).Within(1e-6f));
+    }
+
     /// <summary>
     /// softmax(query x transposed(key) * scale) x value, per head, in doubles.
     /// </summary>
@@ -222,11 +257,14 @@ public class OperatorTests
         }
     }
 
-    private static BufferTensorDescription CreateTensor(params uint[] sizes)
+    private static BufferTensorDescription CreateTensor(params uint[] sizes) =>
+        CreateTensor(TensorDataType.Float32, sizes);
+
+    private static BufferTensorDescription CreateTensor(TensorDataType dataType, params uint[] sizes)
     {
         var tensor = new BufferTensorDescription
         {
-            DataType = TensorDataType.Float32,
+            DataType = dataType,
             Sizes = sizes,
             Flags = TensorFlags.None,
         };


### PR DESCRIPTION
Adds DequantizeOperatorDescription (DML_OPERATOR_DEQUANTIZE, feature level 6.3), with docs and a test.