### PR TITLE
[ENH] DirectML: Expose ActivationSwish operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Current Stable Release:    3.8.3 (February 2026)
 -----------------------------------------------
 Release:     3.8.x (August 2026)
 - [ENH] DirectML: Expose ActivationGelu, ActivationSoftmax1 and MultiheadAttention operators
+- [ENH] DirectML: Expose ActivationSwish operator
 - [FIX] DirectML: A default BindingDescription binds as DML_BINDING_TYPE_NONE, so optional operator tensors can be skipped in BindInputs/BindOutputs
 
 -----------------------------------------------

--- a/src/Vortice.DirectML/ActivationSwishOperatorDescription.cs
+++ b/src/Vortice.DirectML/ActivationSwishOperatorDescription.cs
@@ -1,0 +1,60 @@
+// Copyright © Aaron Sun, Amer Koleci, and Contributors.
+// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
+
+namespace Vortice.DirectML;
+
+public partial struct ActivationSwishOperatorDescription : IOperatorDescription, IOperatorDescriptionMarshal
+{
+    /// <summary>
+    /// Gets the type of operator description.
+    /// </summary>
+    public OperatorType OperatorType => OperatorType.ActivationSwish;
+
+    /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SWISH_OPERATOR_DESC::InputTensor']/*" />
+    public TensorDescription InputTensor { get; set; }
+
+    /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SWISH_OPERATOR_DESC::OutputTensor']/*" />
+    public TensorDescription OutputTensor { get; set; }
+
+    /// <include file="Documentation.xml" path="/comments/comment[@id='DML_ACTIVATION_SWISH_OPERATOR_DESC::SigmoidInputScale']/*" />
+    public float SigmoidInputScale { get; set; }
+
+    /// <inheritdoc></inheritdoc>/>
+    public override string ToString() => $"ActivationSwish: SigmoidInputScale={SigmoidInputScale}";
+
+    #region Marshal
+    [StructLayout(LayoutKind.Sequential, Pack = 0)]
+    internal struct __Native
+    {
+        public IntPtr InputTensor;
+        public IntPtr OutputTensor;
+        public float SigmoidInputScale;
+    }
+
+    unsafe IntPtr IOperatorDescriptionMarshal.__MarshalAlloc()
+    {
+        __Native* @ref = UnsafeUtilities.Alloc<__Native>();
+
+        @ref->InputTensor = InputTensor.__MarshalAlloc();
+        @ref->OutputTensor = OutputTensor.__MarshalAlloc();
+        @ref->SigmoidInputScale = SigmoidInputScale;
+
+        return new(@ref);
+    }
+
+    unsafe void IOperatorDescriptionMarshal.__MarshalFree(ref IntPtr pDesc)
+    {
+        var @ref = (__Native*)pDesc;
+
+        InputTensor.__MarshalFree(ref @ref->InputTensor);
+        OutputTensor.__MarshalFree(ref @ref->OutputTensor);
+
+        UnsafeUtilities.Free(@ref);
+    }
+    #endregion
+
+    public static implicit operator OperatorDescription(ActivationSwishOperatorDescription description)
+    {
+        return new(description);
+    }
+}

--- a/src/Vortice.DirectML/Documentation.xml
+++ b/src/Vortice.DirectML/Documentation.xml
@@ -4527,6 +4527,9 @@ for (UINT i = 0; i &lt; DimensionCount; ++i) {
   <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_DEQUANTIZE">
     <summary>Indicates the operator described by the <a href="https://learn.microsoft.com/windows/ai/directml/api/ns-directml-dml_dequantize_operator_desc">DML_DEQUANTIZE_OPERATOR_DESC</a> structure.</summary>
   </comment>
+  <comment id="DML_OPERATOR_TYPE::DML_OPERATOR_ACTIVATION_SWISH">
+    <summary>Indicates the operator described by the <a href="https://learn.microsoft.com/windows/ai/directml/api/ns-directml-dml_activation_swish_operator_desc">DML_ACTIVATION_SWISH_OPERATOR_DESC</a> structure.</summary>
+  </comment>
   <comment id="DML_ACTIVATION_GELU_OPERATOR_DESC">
     <summary>
       <para>Performs the gaussian error linear unit (GELU) activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>. <c>f(x) = 0.5 * x * (1.0 + erf(x / sqrt(2)))</c>. This is the exact form, not the tanh approximation. This operator was introduced in DML_FEATURE_LEVEL_5_1.</para>
@@ -4631,5 +4634,20 @@ for (UINT i = 0; i &lt; DimensionCount; ++i) {
   </comment>
   <comment id="DML_DEQUANTIZE_OPERATOR_DESC::OutputTensor">
     <summary>The output tensor to write the results to, with the same sizes as <i>InputTensor</i>.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SWISH_OPERATOR_DESC">
+    <summary>
+      <para>Performs the swish activation function on every element in <i>InputTensor</i>, placing the result into the corresponding element of <i>OutputTensor</i>. <c>f(x) = x * sigmoid(SigmoidInputScale * x)</c>. With <i>SigmoidInputScale</i> = 1 this is the SiLU activation. This operator was introduced in DML_FEATURE_LEVEL_6_2.</para>
+      <para>Microsoft Docs: <see href="https://learn.microsoft.com/windows/ai/directml/api/ns-directml-dml_activation_swish_operator_desc" /></para>
+    </summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SWISH_OPERATOR_DESC::InputTensor">
+    <summary>The input tensor to read from.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SWISH_OPERATOR_DESC::OutputTensor">
+    <summary>The output tensor to write the results to.</summary>
+  </comment>
+  <comment id="DML_ACTIVATION_SWISH_OPERATOR_DESC::SigmoidInputScale">
+    <summary>The scale applied to the input before it enters the sigmoid. Use 1 for SiLU.</summary>
   </comment>
 </comments>

--- a/src/Vortice.DirectML/Mappings.xml
+++ b/src/Vortice.DirectML/Mappings.xml
@@ -231,6 +231,9 @@
     <!-- DML_TARGET_VERSION >= 0x6100 -->
     <remove field="DML_MULTIHEAD_ATTENTION_OPERATOR_DESC::.*" />
 
+    <!-- DML_TARGET_VERSION >= 0x6200 -->
+    <remove field="DML_ACTIVATION_SWISH_OPERATOR_DESC::.*" />
+
     <!-- DML_TARGET_VERSION >= 0x6300 -->
     <remove field="DML_DEQUANTIZE_OPERATOR_DESC::.*" />
 

--- a/tests/Vortice.DirectML.Tests/OperatorTests.cs
+++ b/tests/Vortice.DirectML.Tests/OperatorTests.cs
@@ -105,6 +105,35 @@ public class OperatorTests
     }
 
     [TestCase]
+    public void ActivationSwishTest()
+    {
+        RequireFeatureLevel(FeatureLevel.Level6_2);
+
+        BufferTensorDescription tensor = CreateTensor(1, 1, 1, 7);
+        float[] input = [-4.0f, -1.0f, -0.5f, 0.0f, 0.5f, 1.0f, 3.0f];
+
+        // f(x) = x * sigmoid(x), which is SiLU.
+        float[] output = Dispatch(new ActivationSwishOperatorDescription
+        {
+            InputTensor = tensor,
+            OutputTensor = tensor,
+            SigmoidInputScale = 1.0f,
+        }, [(tensor, input)], tensor);
+        float[] expected = [-0.07194484f, -0.26894142f, -0.18877033f, 0.0f, 0.31122967f, 0.73105858f, 2.85772238f];
+        Assert.That(output, Is.EqualTo(expected).Within(1e-4f));
+
+        // f(x) = x * sigmoid(2x): the scale reaches the sigmoid, not the outer x.
+        output = Dispatch(new ActivationSwishOperatorDescription
+        {
+            InputTensor = tensor,
+            OutputTensor = tensor,
+            SigmoidInputScale = 2.0f,
+        }, [(tensor, input)], tensor);
+        expected = [-0.0013414f, -0.11920292f, -0.13447071f, 0.0f, 0.36552929f, 0.88079708f, 2.99258213f];
+        Assert.That(output, Is.EqualTo(expected).Within(1e-4f));
+    }
+
+    [TestCase]
     public void ActivationSoftmax1Test()
     {
         RequireFeatureLevel(FeatureLevel.Level5_1);


### PR DESCRIPTION
Adds ActivationSwishOperatorDescription (DML_OPERATOR_ACTIVATION_SWISH, feature level 6.2), with docs and a test. With SigmoidInputScale = 1 this is SiLU, which otherwise takes a Sigmoid and a Multiply.